### PR TITLE
Add recursion flag and CLI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ npm install
 ## Usage
 
 ```bash
-photo-select --dir /path/to/images [--prompt /path/to/prompt.txt] [--model gpt-4.5]
+photo-select --dir /path/to/images [--prompt /path/to/prompt.txt] [--model gpt-4.5] [--no-recurse]
 ```
+
+Run `photo-select --help` to see all options.
 
 ### Flags
 
@@ -34,6 +36,7 @@ photo-select --dir /path/to/images [--prompt /path/to/prompt.txt] [--model gpt-4
 | `--dir`    | **required**                 | Source directory containing images              |
 | `--prompt` | `prompts/default_prompt.txt` | Path to a custom prompt file                    |
 | `--model`  | `gpt-4o-mini`                | Any chat‑completion model id you have access to. Can also be set via `$PHOTO_SELECT_MODEL`. |
+| `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |
 
 ## Supported OpenAI models
 
@@ -87,7 +90,7 @@ The tool creates `_keep` and `_aside` sub‑folders inside every directory it to
 2. Send them to ChatGPT with the prompt (filenames included).
 3. Parse the reply for `"keep"` or `"set aside"` decisions.
 4. Move each file to the corresponding sub‑folder.
-5. Re‑run the algorithm on the newly created `_keep` folder.
+5. Re‑run the algorithm on the newly created `_keep` folder (unless `--no-recurse`).
 6. Stop when a directory has zero unclassified images.
 
 ## Caching

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import path from "node:path";
-import { triageDirectory } from "./orchestrator.js";
 import { DEFAULT_PROMPT_PATH } from "./config.js";
 
 const program = new Command();
 program
+  .name("photo-select")
+  .description("Randomly triage photos with ChatGPT")
   .requiredOption("-d, --dir <path>", "Source directory of images")
   .option("-p, --prompt <file>", "Custom prompt file", DEFAULT_PROMPT_PATH)
   .option(
@@ -13,14 +14,16 @@ program
     "OpenAI model id",
     process.env.PHOTO_SELECT_MODEL || "gpt-4o-mini"
   )
+  .option("--no-recurse", "Process a single directory only")
   .parse(process.argv);
 
-const { dir, prompt: promptPath, model } = program.opts();
+const { dir, prompt: promptPath, model, recurse } = program.opts();
 
 (async () => {
   try {
     const absDir = path.resolve(dir);
-    await triageDirectory({ dir: absDir, promptPath, model });
+    const { triageDirectory } = await import("./orchestrator.js");
+    await triageDirectory({ dir: absDir, promptPath, model, recurse });
     console.log("🎉  Finished triaging.");
   } catch (err) {
     console.error("❌  Error:", err);

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -7,7 +7,7 @@ import { chatCompletion, parseReply } from "./chatClient.js";
  * Recursively triage images until the current directory is empty
  * or contains only _keep/_aside folders.
  */
-export async function triageDirectory({ dir, promptPath, model }) {
+export async function triageDirectory({ dir, promptPath, model, recurse = true }) {
   const prompt = await readPrompt(promptPath);
 
   let images = await listImages(dir);
@@ -36,6 +36,8 @@ export async function triageDirectory({ dir, promptPath, model }) {
     `📂  Moved: ${keep.length} keep → ${keepDir}, ${aside.length} aside → ${asideDir}`
   );
 
-  // Step 5 – recurse into keepDir
-  await triageDirectory({ dir: keepDir, promptPath, model });
+  // Step 5 – recurse into keepDir if enabled
+  if (recurse) {
+    await triageDirectory({ dir: keepDir, promptPath, model, recurse });
+  }
 }


### PR DESCRIPTION
## Summary
- add `--no-recurse` flag and document it
- lazily load OpenAI so `--help` works without API key

## Testing
- `npm test`
- `node ./src/index.js --help`

------
https://chatgpt.com/codex/tasks/task_e_68576547b8e883308644a375b4aa30ad