### PR TITLE
Add default current directory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install
 Invoke the CLI from the project directory using `npx`:
 
 ```bash
-npx photo-select --dir /path/to/images [--prompt /path/to/prompt.txt] [--model gpt-4.5]
+npx photo-select [--dir /path/to/images] [--prompt /path/to/prompt.txt] [--model gpt-4.5]
 ```
 
 You can also install globally with `npm install -g` to run `photo-select` anywhere.
@@ -32,9 +32,9 @@ You can also install globally with `npm install -g` to run `photo-select` anywhe
 ## Usage
 
 ```bash
-npx photo-select --dir /path/to/images [--prompt /path/to/prompt.txt] [--model gpt-4.5]
+npx photo-select [--dir /path/to/images] [--prompt /path/to/prompt.txt] [--model gpt-4.5]
 # or, if installed globally:
-photo-select --dir /path/to/images [--prompt /path/to/prompt.txt] [--model gpt-4.5]
+photo-select [--dir /path/to/images] [--prompt /path/to/prompt.txt] [--model gpt-4.5]
 ```
 
 Run `photo-select --help` to see all options.
@@ -43,7 +43,7 @@ Run `photo-select --help` to see all options.
 
 | flag       | default                      | description                                     |
 | ---------- | ---------------------------- | ----------------------------------------------- |
-| `--dir`    | **required**                 | Source directory containing images              |
+| `--dir`    | current directory            | Source directory containing images              |
 | `--prompt` | `prompts/default_prompt.txt` | Path to a custom prompt file                    |
 | `--model`  | `gpt-4o-mini`                | Any chat‑completion model id you have access to. Can also be set via `$PHOTO_SELECT_MODEL`. |
 | `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const program = new Command();
 program
   .name("photo-select")
   .description("Randomly triage photos with ChatGPT")
-  .requiredOption("-d, --dir <path>", "Source directory of images")
+  .option("-d, --dir <path>", "Source directory of images", process.cwd())
   .option("-p, --prompt <file>", "Custom prompt file", DEFAULT_PROMPT_PATH)
   .option(
     "-m, --model <id>",


### PR DESCRIPTION
## Summary
- default `--dir` to the current directory
- update README examples and flags table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685767630860833083ae10472ee8b3c2