### PR TITLE
Add wrapper script for nvm usage

### DIFF
--- a/photo-select-here.sh
+++ b/photo-select-here.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_DIR="$(pwd)"
+
+# Load nvm if available
+if [ -z "${NVM_DIR:-}" ]; then
+  if [ -d "$HOME/.nvm" ]; then
+    export NVM_DIR="$HOME/.nvm"
+  fi
+fi
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  . "$NVM_DIR/nvm.sh"
+fi
+
+# Use Node version from .nvmrc if nvm is available
+if command -v nvm >/dev/null 2>&1; then
+  nvm use "$SCRIPT_DIR" >/dev/null || true
+fi
+
+cd "$SCRIPT_DIR"
+
+npx photo-select "$@" --dir "$TARGET_DIR"


### PR DESCRIPTION
## Summary
- add `photo-select-here.sh` helper script to run the CLI on the current working directory while loading nvm

## Testing
- `npm test`
- `./photo-select-here.sh --help`

------
https://chatgpt.com/codex/tasks/task_e_6857682b5e6c8330bc4375c05456251a