### PR TITLE
Update defaults and CLI wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ Run `photo-select --help` to see all options.
 | ---------- | ---------------------------- | ----------------------------------------------- |
 | `--dir`    | current directory            | Source directory containing images              |
 | `--prompt` | `prompts/default_prompt.txt` | Path to a custom prompt file                    |
-| `--model`  | `gpt-4o-mini`                | Any chat‑completion model id you have access to. Can also be set via `$PHOTO_SELECT_MODEL`. |
+| `--model`  | `gpt-4o`                | Any chat‑completion model id you have access to. Can also be set via `$PHOTO_SELECT_MODEL`. |
 | `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |
 
 ## Supported OpenAI models
 
 The tool uses OpenAI's chat completion models with vision support. Notable options include:
 
-* `gpt-4o` – flagship multimodal model
-* `gpt-4o-mini` – smaller, faster, cheaper version (default)
+* `gpt-4o` – flagship multimodal model (default)
+* `gpt-4o-mini` – smaller, faster, cheaper version
 * `gpt-4-turbo` – high context window model
 * `gpt-4.5` – optional mid‑tier model
 * `gpt-4-vision-preview` – earlier vision model
@@ -72,8 +72,8 @@ Approximate price per run:
 
 | model          | input $/1M | output $/1M | est. cost on 315 photos |
 | -------------- | ---------- | ----------- | ---------------------- |
-| `gpt-4o-mini`  | $0.15      | $0.60       | ~$0.55 |
 | `gpt-4o`       | $2.50      | $10.00      | ~$9 |
+| `gpt-4o-mini`  | $0.15      | $0.60       | ~$0.55 |
 | `gpt-4-turbo`  | $10.00     | $30.00      | ~$33 |
 | `gpt-4.5`      | $75.00     | $150.00     | ~$225 |
 | `gpt-4`        | $30.00     | $60.00      | ~$90 |

--- a/photo-select-here.sh
+++ b/photo-select-here.sh
@@ -21,4 +21,18 @@ fi
 
 cd "$SCRIPT_DIR"
 
-npx photo-select "$@" --dir "$TARGET_DIR"
+dir_specified=false
+for arg in "$@"; do
+  case "$arg" in
+    -d|--dir|--dir=*|-d=*)
+      dir_specified=true
+      break
+      ;;
+  esac
+done
+
+if [ "$dir_specified" = true ]; then
+  npx photo-select "$@"
+else
+  npx photo-select "$@" --dir "$TARGET_DIR"
+fi

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -76,7 +76,7 @@ export async function buildMessages(prompt, images) {
 export async function chatCompletion({
   prompt,
   images,
-  model = "gpt-4o-mini",
+  model = "gpt-4o",
   maxRetries = 3,
   cache = true,
 }) {

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ program
   .option(
     "-m, --model <id>",
     "OpenAI model id",
-    process.env.PHOTO_SELECT_MODEL || "gpt-4o-mini"
+    process.env.PHOTO_SELECT_MODEL || "gpt-4o"
   )
   .option("--no-recurse", "Process a single directory only")
   .parse(process.argv);


### PR DESCRIPTION
## Summary
- default to model `gpt-4o`
- let `photo-select-here.sh` respect all Node CLI flags
- document the new default model

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857698f186c8330a8d62f192a1220c7