### PR TITLE
Add CLI api-key flag and document helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ moves the files accordingly, and then recurses until a directory is fully triage
 ## Requirements
 
 - Node 20+
-- An OpenAI API key (`OPENAI_API_KEY`)
+- An OpenAI API key (via `OPENAI_API_KEY` or the `--api-key` flag)
   ```bash
   export OPENAI_API_KEY="sk‑..."
   ```
@@ -24,7 +24,7 @@ npm install
 Invoke the CLI from the project directory using `npx`:
 
 ```bash
-npx photo-select [--dir /path/to/images] [--prompt /path/to/prompt.txt] [--model gpt-4.5]
+npx photo-select [--dir /path/to/images] [--prompt /path/to/prompt.txt] [--model gpt-4.5] [--api-key sk-...]
 ```
 
 You can also install globally with `npm install -g` to run `photo-select` anywhere.
@@ -32,12 +32,33 @@ You can also install globally with `npm install -g` to run `photo-select` anywhe
 ## Usage
 
 ```bash
-npx photo-select [--dir /path/to/images] [--prompt /path/to/prompt.txt] [--model gpt-4.5]
+# run from the project directory
+npx photo-select [--dir /path/to/images] [--prompt /path/to/prompt.txt] [--model gpt-4.5] [--api-key sk-...]
 # or, if installed globally:
-photo-select [--dir /path/to/images] [--prompt /path/to/prompt.txt] [--model gpt-4.5]
+photo-select [--dir /path/to/images] [--prompt /path/to/prompt.txt] [--model gpt-4.5] [--api-key sk-...]
 ```
 
 Run `photo-select --help` to see all options.
+
+### photo-select-here.sh
+
+If you keep the repository cloned on your system, the `photo-select-here.sh`
+script lets you run the CLI on whatever directory you're currently in without
+typing `--dir` each time. Call it with the path to the script:
+
+```bash
+/path/to/photo-select/photo-select-here.sh [photo-select flags]
+```
+
+The script automatically:
+
+1. Loads `nvm` and uses the Node version defined in `.nvmrc` if available.
+2. Runs `npx photo-select` inside the repo.
+3. Sets `--dir` to your current working directory unless you specify it
+   explicitly.
+
+All CLI flags—including `--api-key`, `--model`, and `--no-recurse`—can be passed
+through to the script unchanged.
 
 ### Flags
 
@@ -46,6 +67,7 @@ Run `photo-select --help` to see all options.
 | `--dir`    | current directory            | Source directory containing images              |
 | `--prompt` | `prompts/default_prompt.txt` | Path to a custom prompt file                    |
 | `--model`  | `gpt-4o`                | Any chat‑completion model id you have access to. Can also be set via `$PHOTO_SELECT_MODEL`. |
+| `--api-key` | *(unset)*                  | OpenAI API key. Overrides `$OPENAI_API_KEY`. |
 | `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |
 
 ## Supported OpenAI models

--- a/src/index.js
+++ b/src/index.js
@@ -14,10 +14,19 @@ program
     "OpenAI model id",
     process.env.PHOTO_SELECT_MODEL || "gpt-4o"
   )
+  .option(
+    "-k, --api-key <key>",
+    "OpenAI API key",
+    process.env.OPENAI_API_KEY
+  )
   .option("--no-recurse", "Process a single directory only")
   .parse(process.argv);
 
-const { dir, prompt: promptPath, model, recurse } = program.opts();
+const { dir, prompt: promptPath, model, recurse, apiKey } = program.opts();
+
+if (apiKey) {
+  process.env.OPENAI_API_KEY = apiKey;
+}
 
 (async () => {
   try {


### PR DESCRIPTION
## Summary
- allow passing `--api-key` to the CLI
- document API key flag usage
- explain how to use `photo-select-here.sh`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68576a7f653c83308325206e61a16bc7