### PR TITLE
Add more progress logging and nicer nvm message

### DIFF
--- a/photo-select-here.sh
+++ b/photo-select-here.sh
@@ -16,7 +16,9 @@ fi
 
 # Use Node version from .nvmrc if nvm is available
 if command -v nvm >/dev/null 2>&1; then
-  nvm use "$SCRIPT_DIR" >/dev/null || true
+  if ! nvm use "$SCRIPT_DIR" >/dev/null 2>&1; then
+    echo "nvm: Node $(cat "$SCRIPT_DIR/.nvmrc") not installed; using system node $(node --version)" >&2
+  fi
 fi
 
 cd "$SCRIPT_DIR"


### PR DESCRIPTION
## Summary
- more descriptive progress output while triaging
- warn if the requested Node version isn't installed when running `photo-select-here.sh`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68576c9bb3c88330ad9d788f9b72e31c