### PR TITLE
handle fenced JSON in parseReply

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ The tool creates `_keep` and `_aside` sub‑folders inside every directory it to
 6. Re‑run the algorithm on the newly created `_keep` folder (unless `--no-recurse`).
 7. Stop when a directory has zero unclassified images.
 
+### JSON mode
+
+The OpenAI request uses `response_format: { type: "json_object" }` so the
+assistant replies with strict JSON. This avoids needing to strip Markdown
+fences and guarantees parseable output.
+
 ## Caching
 
 Responses from OpenAI are cached under a `.cache` directory using a hash of the

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -95,6 +95,7 @@ export async function chatCompletion({
         model,
         messages,
         max_tokens: 1024,
+        response_format: { type: "json_object" },
       });
       const text = choices[0].message.content;
       if (cache) await setCachedReply(key, text);
@@ -119,6 +120,12 @@ export async function chatCompletion({
  *  • “Set aside: DSCF5678”
  */
 export function parseReply(text, allFiles) {
+  // Strip Markdown code fences like ```json ... ``` if present
+  const fenced = text.trim();
+  if (fenced.startsWith('```')) {
+    const match = fenced.match(/^```\w*\n([\s\S]*?)\n```$/);
+    if (match) text = match[1];
+  }
   const map = new Map();
   for (const f of allFiles) {
     map.set(path.basename(f).toLowerCase(), f);

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -53,4 +53,14 @@ describe("parseReply", () => {
     expect(notes.get(files[1])).toMatch(/out of focus/);
     expect(aside).toContain(files[2]);
   });
+
+  it("handles JSON wrapped in Markdown fences", () => {
+    const fenced =
+      '```json\n' +
+      JSON.stringify({ keep: ["DSCF1234.jpg"], aside: ["DSCF5678.jpg"] }) +
+      '\n```';
+    const { keep, aside } = parseReply(fenced, files);
+    expect(keep).toContain(files[0]);
+    expect(aside).toContain(files[1]);
+  });
 });


### PR DESCRIPTION
## Summary
- parse replies starting with ```json fences
- test for fenced JSON handling
- use `response_format: json_object` so ChatGPT replies with strict JSON
- note JSON mode in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68582abf21b48330a7e46ca6b5113eb5