### PR TITLE
Fix duplicate file handling

### DIFF
--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -169,11 +169,7 @@ export function parseReply(text, allFiles) {
 
       handle("keep", keep);
       handle("aside", aside);
-
-      for (const f of allFiles) {
-        if (!keep.has(f) && !aside.has(f)) aside.add(f);
-      }
-      return { keep: [...keep], aside: [...aside], notes };
+      // continue to normalization below
     }
   } catch {
     // fall through to plain text handling
@@ -203,6 +199,11 @@ export function parseReply(text, allFiles) {
 
   for (const f of allFiles) {
     if (!keep.has(f) && !aside.has(f)) aside.add(f);
+  }
+
+  // Prefer keeping when a file appears in both groups
+  for (const f of keep) {
+    aside.delete(f);
   }
 
   return { keep: [...keep], aside: [...aside], notes };

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -63,4 +63,11 @@ describe("parseReply", () => {
     expect(keep).toContain(files[0]);
     expect(aside).toContain(files[1]);
   });
+
+  it("deduplicates files listed in both groups", () => {
+    const reply = JSON.stringify({ keep: ["DSCF1234.jpg"], aside: ["DSCF1234.jpg"] });
+    const { keep, aside } = parseReply(reply, files);
+    expect(keep).toContain(files[0]);
+    expect(aside).not.toContain(files[0]);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure files aren't moved twice if in keep and aside
- add regression test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859c1cb28348330829dfaf5583621db