### PR TITLE
Fix recursion termination when all images kept

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -53,14 +53,21 @@ export async function triageDirectory({
     );
   }
 
-  // Step 5 – recurse into keepDir if enabled
+  // Step 5 – recurse into keepDir only if both groups exist
   if (recurse) {
-    await triageDirectory({
-      dir: path.join(dir, "_keep"),
-      promptPath,
-      model,
-      recurse,
-      depth: depth + 1,
-    });
+    const keepDir = path.join(dir, "_keep");
+    const asideDir = path.join(dir, "_aside");
+    const keepCount = (await listImages(keepDir).catch(() => [])).length;
+    const asideCount = (await listImages(asideDir).catch(() => [])).length;
+
+    if (keepCount > 0 && asideCount > 0) {
+      await triageDirectory({
+        dir: keepDir,
+        promptPath,
+        model,
+        recurse,
+        depth: depth + 1,
+      });
+    }
   }
 }


### PR DESCRIPTION
## Summary
- stop recursion when images are all kept or all set aside

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859ffa00df88330a3f3320e1904d06b