### PR TITLE
Fix fallback for /v1/responses models

### DIFF
--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -131,10 +131,10 @@ export async function chatCompletion({
       if (cache) await setCachedReply(key, text);
       return text;
     } catch (err) {
-      if (
-        err instanceof NotFoundError &&
-        /v1\/responses/.test(err.message || "")
-      ) {
+        if (
+          (err instanceof NotFoundError || err.status === 404) &&
+          /v1\/responses/.test(err.message || "")
+        ) {
         const params = await buildInput(prompt, images);
         const rsp = await openai.responses.create({
           model,


### PR DESCRIPTION
## Summary
- expand `chatCompletion` error handling to detect 404s without relying on `NotFoundError`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a02e7be388330b6ff7f85afabd4bf