### PR TITLE
Fix responses API parameter

### DIFF
--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -139,7 +139,7 @@ export async function chatCompletion({
         const rsp = await openai.responses.create({
           model,
           ...params,
-          response_format: { type: "json_object" },
+          text: { format: { type: "json_object" } },
         });
         const text = rsp.output_text;
         if (cache) await setCachedReply(key, text);


### PR DESCRIPTION
## Summary
- fix the fallback call to the /v1/responses API when chat completion returns a 404

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a2b95acd08330aaf80060719afc5f