### PR TITLE
Add curator collaboration flag with meeting minutes output

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ through to the script unchanged.
 | `--prompt` | `prompts/default_prompt.txt` | Path to a custom prompt file                    |
 | `--model`  | `gpt-4o`                | Any chat‑completion model id you have access to. Can also be set via `$PHOTO_SELECT_MODEL`. |
 | `--api-key` | *(unset)*                  | OpenAI API key. Overrides `$OPENAI_API_KEY`. |
+| `--curators` | *(unset)* | Comma-separated list of curator names used in the group transcript |
 | `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |
 
 ## Supported OpenAI models
@@ -160,9 +161,9 @@ API, so no extra flags are needed.
 
 1. Pick up to 10 random images (all common photo extensions).
 2. Send them to ChatGPT with the prompt (filenames included).
-3. ChatGPT replies with a JSON object indicating which files to keep or set aside and why.
-4. Parse that JSON to determine the destination folders and capture Ingeborg's notes.
-5. Move each file to the corresponding sub‑folder and write a text file containing the notes next to it.
+3. ChatGPT replies with meeting minutes summarising a short discussion among the curators, followed by a JSON object indicating which files to keep or set aside and why.
+4. Parse that JSON to determine the destination folders and capture any notes about each image.
+5. Move each file to the corresponding sub‑folder and write a text file containing the notes next to it. Meeting minutes are saved as `minutes-<timestamp>.txt` in the directory.
 6. Re‑run the algorithm on the newly created `_keep` folder (unless `--no-recurse`).
 7. Stop when a directory has zero unclassified images.
 

--- a/prompts/default_prompt.txt
+++ b/prompts/default_prompt.txt
@@ -1,24 +1,26 @@
-Please Role play as Ingeborg Gerdes:
-- indicate who is speaking
-- say what you think
+You are moderating a collaborative curatorial session.
+The following curators are present: {{curators}}. Jamie is the facilitator.
 
-I am going to make some fine art photo prints for an upcoming show.
+Begin with a diarised conversation in which the curators discuss the images and gently work toward consensus.
+Reflect the thoughtful, iterative process described in the briefing: curators share insights, consider relationships among works, and refine the selection together.
 
-Would you help me make selections? 
-
-I'm going to share photos with you 10 at a time. Please decide which ones we should keep in consideration and which ones we should set aside. Use the **exact** filenames provided.
-
-Respond *only* with a JSON object of the form:
+After capturing these remarks as meeting minutes, output a JSON object summarising the final decision:
 
 {
-  "keep": {
-    "filename1.jpg": "why you want to keep it",
+  "minutes": [
+    { "speaker": "Name", "text": "what was said" },
     ...
-  },
-  "aside": {
-    "filename2.jpg": "why you set it aside",
-    ...
+  ],
+  "decision": {
+    "keep": {
+      "filename1.jpg": "why it stays",
+      ...
+    },
+    "aside": {
+      "filename2.jpg": "why it is set aside",
+      ...
+    }
   }
 }
 
-Every filename must appear exactly once as a key in either "keep" or "aside". Include a concise observation about each image. No other text.
+Every filename must appear exactly once under either "keep" or "aside". No other text after the JSON.

--- a/src/index.js
+++ b/src/index.js
@@ -19,10 +19,16 @@ program
     "OpenAI API key",
     process.env.OPENAI_API_KEY
   )
+  .option(
+    "-c, --curators <names>",
+    "Comma-separated list of curator names",
+    (value) => value.split(',').map((n) => n.trim()).filter(Boolean),
+    []
+  )
   .option("--no-recurse", "Process a single directory only")
   .parse(process.argv);
 
-const { dir, prompt: promptPath, model, recurse, apiKey } = program.opts();
+const { dir, prompt: promptPath, model, recurse, apiKey, curators } = program.opts();
 
 if (apiKey) {
   process.env.OPENAI_API_KEY = apiKey;
@@ -32,7 +38,13 @@ if (apiKey) {
   try {
     const absDir = path.resolve(dir);
     const { triageDirectory } = await import("./orchestrator.js");
-    await triageDirectory({ dir: absDir, promptPath, model, recurse });
+    await triageDirectory({
+      dir: absDir,
+      promptPath,
+      model,
+      recurse,
+      curators,
+    });
     console.log("🎉  Finished triaging.");
   } catch (err) {
     console.error("❌  Error:", err);

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -70,4 +70,15 @@ describe("parseReply", () => {
     expect(keep).toContain(files[0]);
     expect(aside).not.toContain(files[0]);
   });
+
+  it("parses minutes and nested decision", () => {
+    const reply = JSON.stringify({
+      minutes: [{ speaker: "Curator", text: "looks good" }],
+      decision: { keep: ["DSCF1234.jpg"], aside: ["DSCF5678.jpg"] },
+    });
+    const { keep, aside, minutes } = parseReply(reply, files);
+    expect(minutes[0]).toMatch(/Curator/);
+    expect(keep).toContain(files[0]);
+    expect(aside).toContain(files[1]);
+  });
 });


### PR DESCRIPTION
## Summary
- allow comma-separated curator names via `--curators`
- update default prompt with placeholder for curators and instructions to produce meeting minutes
- inject curator names into prompts and cache key
- save meeting minutes to `minutes-<timestamp>.txt`
- extend `parseReply` to handle transcripts and nested decision objects
- add tests for minutes parsing
- document new flag and workflow in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685af90700b88330855f8ef9f2f36f92