### PR TITLE
Add exhibition context flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ chmod +x src/index.js    # fix permission error when running with npx
 Invoke the CLI from the project directory using `npx`:
 
 ```bash
-npx photo-select [--dir /path/to/images] [--prompt /path/to/prompt.txt] [--model gpt-4.5] [--api-key sk-...]
+npx photo-select [--dir /path/to/images] [--prompt /path/to/prompt.txt] [--model gpt-4.5] [--api-key sk-...] [--context /path/to/context.txt]
 ```
 
 You can also install globally with `npm install -g` to run `photo-select` anywhere.
@@ -34,9 +34,9 @@ You can also install globally with `npm install -g` to run `photo-select` anywhe
 
 ```bash
 # run from the project directory
-npx photo-select [--dir /path/to/images] [--prompt /path/to/prompt.txt] [--model gpt-4.5] [--api-key sk-...]
+npx photo-select [--dir /path/to/images] [--prompt /path/to/prompt.txt] [--model gpt-4.5] [--api-key sk-...] [--context /path/to/context.txt]
 # or, if installed globally:
-photo-select [--dir /path/to/images] [--prompt /path/to/prompt.txt] [--model gpt-4.5] [--api-key sk-...]
+photo-select [--dir /path/to/images] [--prompt /path/to/prompt.txt] [--model gpt-4.5] [--api-key sk-...] [--context /path/to/context.txt]
 ```
 
 Run `photo-select --help` to see all options.
@@ -70,6 +70,7 @@ through to the script unchanged.
 | `--model`  | `gpt-4o`                | Any chat‑completion model id you have access to. Can also be set via `$PHOTO_SELECT_MODEL`. |
 | `--api-key` | *(unset)*                  | OpenAI API key. Overrides `$OPENAI_API_KEY`. |
 | `--curators` | *(unset)* | Comma-separated list of curator names used in the group transcript |
+| `--context` | *(unset)* | Text file with exhibition context for the curators |
 | `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |
 
 ## Supported OpenAI models
@@ -144,10 +145,10 @@ cp /path/to/source/*.jpg trial-gpt-4o/
 cp /path/to/source/*.jpg trial-gpt-4.5/
 
 # run with GPT‑4o
-/path/to/photo-select/photo-select-here.sh --model gpt-4o --dir trial-gpt-4o --api-key sk-...
+/path/to/photo-select/photo-select-here.sh --model gpt-4o --dir trial-gpt-4o --api-key sk-... --context /path/to/context.txt
 
 # run with GPT‑4.5
-/path/to/photo-select/photo-select-here.sh --model gpt-4.5 --dir trial-gpt-4.5 --api-key sk-...
+/path/to/photo-select/photo-select-here.sh --model gpt-4.5 --dir trial-gpt-4.5 --api-key sk-... --context /path/to/context.txt
 ```
 
 If you see repeated `OpenAI error (404)` messages, your API key may not have

--- a/src/index.js
+++ b/src/index.js
@@ -25,10 +25,14 @@ program
     (value) => value.split(',').map((n) => n.trim()).filter(Boolean),
     []
   )
+  .option(
+    "-x, --context <file>",
+    "Text file with exhibition context for the curators"
+  )
   .option("--no-recurse", "Process a single directory only")
   .parse(process.argv);
 
-const { dir, prompt: promptPath, model, recurse, apiKey, curators } = program.opts();
+const { dir, prompt: promptPath, model, recurse, apiKey, curators, context: contextPath } = program.opts();
 
 if (apiKey) {
   process.env.OPENAI_API_KEY = apiKey;
@@ -44,6 +48,7 @@ if (apiKey) {
       model,
       recurse,
       curators,
+      contextPath,
     });
     console.log("🎉  Finished triaging.");
   } catch (err) {

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -14,10 +14,20 @@ export async function triageDirectory({
   model,
   recurse = true,
   curators = [],
+  contextPath,
   depth = 0,
 }) {
   const indent = "  ".repeat(depth);
   let prompt = await readPrompt(promptPath);
+  if (contextPath) {
+    try {
+      const { readFile } = await import('node:fs/promises');
+      const context = await readFile(contextPath, 'utf8');
+      prompt += `\n\nCurator FYI:\n${context}`;
+    } catch (err) {
+      console.warn(`Could not read context file ${contextPath}: ${err.message}`);
+    }
+  }
   if (curators.length) {
     const names = curators.join(', ');
     prompt = prompt.replace(/\{\{curators\}\}/g, names);


### PR DESCRIPTION
## Summary
- add `--context` flag to allow extra exhibition information
- append context text in orchestrator prompt
- document the new flag and usage examples

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b0973a5b4833082f48dc4dd41c256