### PR TITLE
Fix prompts for OpenAI JSON format requirement

### DIFF
--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -6,6 +6,12 @@ import { delay } from "./config.js";
 
 const openai = new OpenAI();
 
+function ensureJsonMention(text) {
+  return /\bjson\b/i.test(text)
+    ? text
+    : `${text}\nRespond in json format.`;
+}
+
 const CACHE_DIR = path.resolve('.cache');
 
 async function getCachedReply(key) {
@@ -126,6 +132,8 @@ export async function chatCompletion({
     const names = curators.join(', ');
     finalPrompt = prompt.replace(/\{\{curators\}\}/g, names);
   }
+
+  finalPrompt = ensureJsonMention(finalPrompt);
 
   const key = await cacheKey({ prompt: finalPrompt, images, model });
   if (cache) {


### PR DESCRIPTION
## Summary
- ensure the user prompt always contains the word `json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b1967a94083308d0b2604ddb0e6b0