### PR TITLE
Handle token parameter per model

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ o4-mini-2025-04-16
 These names match the model ids provided by the OpenAI Node SDK, as seen in its
 [type definitions](node_modules/openai/resources/beta/assistants.d.ts).
 
+Models in the `o` series use the new `max_completion_tokens` parameter instead of
+the deprecated `max_tokens`. The CLI handles this automatically based on the
+model you specify.
+
 ### Estimated costs
 
 The cost depends on the number of tokens generated from your images. Roughly


### PR DESCRIPTION
## Summary
- use `max_tokens` for GPT models and `max_completion_tokens` for o-series reasoning models
- document the new parameter in the README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685da32ca9408330bc12766cb7a45f9d