### PR TITLE
Add docs for people metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 # Copy to `.env` and paste your real key here.
 OPENAI_API_KEY=sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# Optional: base URL for the photo-filter API providing people tags
+# Defaults to http://localhost:3000 when unset
+# PHOTO_FILTER_API_BASE=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -97,6 +97,19 @@ through to the script unchanged.
 | `--context` | *(unset)* | Text file with exhibition context for the curators |
 | `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |
 
+### People metadata (optional)
+
+Set `PHOTO_FILTER_API_BASE` to the base URL of your [photo‑filter](https://github.com/openhouse/photo-filter) service to include face‑tag data in the prompt. For each image the CLI fetches `/api/photos/by-filename/<filename>/persons` and sends a JSON blob like `{ "filename": "DSCF1234.jpg", "people": ["Alice", "Bob"] }` before the image itself. Results are cached per filename for the duration of the run.
+
+Example:
+
+```bash
+PHOTO_FILTER_API_BASE=http://localhost:3000 \
+/path/to/photo-select/photo-select-here.sh --api-key sk-... --model o3 \
+  --curators "Ingeborg Gerdes, Alexandra Munroe, Mandy Steinback, Kendell Harbin, Erin Zona, Madeline Gallucci, Deborah Treisman" \
+  --context /path/to/info.md
+```
+
 ## Supported OpenAI models
 
 The CLI calls the Chat Completions API and automatically switches to `/v1/responses` if a model only supports that endpoint. Any vision-capable chat model listed on OpenAI's [models](https://platform.openai.com/docs/models) page should work, including:

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -1,12 +1,17 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-let parseReply, buildMessages;
+let parseReply, buildMessages, buildInput;
 beforeAll(async () => {
   process.env.OPENAI_API_KEY = 'test-key';
-  ({ parseReply, buildMessages } = await import('../src/chatClient.js'));
+  global.fetch = vi.fn(async () => ({ ok: true, json: async () => ({ data: [] }) }));
+  ({ parseReply, buildMessages, buildInput } = await import('../src/chatClient.js'));
+});
+
+afterAll(() => {
+  global.fetch = undefined;
 });
 
 const files = [
@@ -96,8 +101,50 @@ describe("buildMessages", () => {
     await fs.writeFile(img1, "a");
     await fs.writeFile(img2, "b");
     const [, user] = await buildMessages("prompt", [img1, img2]);
-    expect(user.content[1]).toEqual({ type: "text", text: "1.jpg" });
-    expect(user.content[3]).toEqual({ type: "text", text: "2.jpg" });
+    expect(JSON.parse(user.content[1].text)).toEqual({ filename: "1.jpg" });
+    expect(JSON.parse(user.content[3].text)).toEqual({ filename: "2.jpg" });
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("includes people names when available", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "ps-msg-"));
+    const img1 = path.join(dir, "a.jpg");
+    await fs.writeFile(img1, "a");
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: ["Alice", "Bob"] }),
+    });
+    const [, user] = await buildMessages("prompt", [img1]);
+    const meta = JSON.parse(user.content[1].text);
+    expect(meta.filename).toBe("a.jpg");
+    expect(meta.people).toEqual(["Alice", "Bob"]);
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+});
+
+describe("buildInput", () => {
+  it("labels each image before the encoded data", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "ps-in-"));
+    const img1 = path.join(dir, "1.jpg");
+    await fs.writeFile(img1, "a");
+    const { input } = await buildInput("prompt", [img1]);
+    const meta = JSON.parse(input[0].content[1].text);
+    expect(meta).toEqual({ filename: "1.jpg" });
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("includes people names when available", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "ps-in-"));
+    const img1 = path.join(dir, "a.jpg");
+    await fs.writeFile(img1, "a");
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: ["Alice", "Bob"] }),
+    });
+    const { input } = await buildInput("prompt", [img1]);
+    const meta = JSON.parse(input[0].content[1].text);
+    expect(meta.filename).toBe("a.jpg");
+    expect(meta.people).toEqual(["Alice", "Bob"]);
     await fs.rm(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary
- document how PHOTO_FILTER_API_BASE works
- include example `photo-select-here.sh` command
- extend `.env.example`
- add buildInput tests for person data

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ff723ca8c8330a05f11bf0a48a986