### PR TITLE
Add o3-pro support via responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ The CLI calls the Chat Completions API and automatically switches to `/v1/respon
   `gpt-4o-mini-audio-preview`, `gpt-4o-realtime-preview`,
   `gpt-4o-mini-realtime-preview`, `gpt-4o-search-preview`, and
   `gpt-4o-mini-search-preview`
-* **o‑series reasoning models** – `o4-mini`, `o3`, `o3-pro`, `o3-mini`, `o1`,
-  `o1-pro`, and the deprecated `o1-mini`
+* **o‑series reasoning models** – `o4-mini`, `o3`, `o3-pro` *(responses API)*,
+  `o3-mini`, `o1`, `o1-pro`, and the deprecated `o1-mini`
 * **Other vision models** – `gpt-4-turbo`, `gpt-4.5-preview` *(deprecated)*. The
   `gpt-4-vision-preview` model has been removed.
 
@@ -240,8 +240,8 @@ cp /path/to/source/*.jpg trial-gpt-4.5-preview/
 If you see repeated `OpenAI error (404)` messages, your API key may not have
 access to that model or the id is misspelled. Check `openai models:list` to
 confirm which ids are enabled for your account. Models that require the
-`/v1/responses` endpoint—such as `o1-pro`—are automatically routed through that
-API, so no extra flags are needed.
+`/v1/responses` endpoint—such as `o1-pro` or `o3-pro`—are automatically routed
+through that API, so no extra flags are needed.
 
 
 ## Recursion logic

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -198,10 +198,11 @@ export async function chatCompletion({
       if (cache) await setCachedReply(key, text);
       return text;
     } catch (err) {
-        if (
-          (err instanceof NotFoundError || err.status === 404) &&
-          /v1\/responses/.test(err.message || "")
-        ) {
+      const msg = String(err?.error?.message || err?.message || "");
+      if (
+        (err instanceof NotFoundError || err.status === 404) &&
+        (/v1\/responses/.test(msg) || /v1\/completions/.test(msg) || /not a chat model/i.test(msg))
+      ) {
         const params = await buildInput(finalPrompt, images, curators);
         const rsp = await openai.responses.create({
           model,


### PR DESCRIPTION
## Summary
- handle `o3-pro` by falling back to the Responses API when the chat endpoint rejects the request
- mark `o3-pro` as a responses API model in docs
- test fallback logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686063e97750833081163d815954b3e0