### PR TITLE
Add resume flag for ongoing triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ npx photo-select [--dir /path/to/images] [--prompt /path/to/prompt.txt] [--model
 photo-select [--dir /path/to/images] [--prompt /path/to/prompt.txt] [--model gpt-4o] [--api-key sk-...] [--context /path/to/context.txt]
 ```
 
-Run `photo-select --help` to see all options.
+Run `photo-select --help` to see all options. When rerun in a partially triaged
+directory, the CLI automatically resumes from the deepest `_keep` folder that
+still contains unclassified images.
 
 ### photo-select-here.sh
 

--- a/src/index.js
+++ b/src/index.js
@@ -50,14 +50,24 @@ if (apiKey) {
       process.exit(1);
     }
     const absDir = path.resolve(dir);
-    const { triageDirectory } = await import("./orchestrator.js");
+    const { triageDirectory, findResumePoint } = await import("./orchestrator.js");
+    const found = await findResumePoint(absDir);
+    let startDir = absDir;
+    let depth = 0;
+    if (found) {
+      ({ dir: startDir, depth } = found);
+      if (startDir !== absDir) {
+        console.log(`\uD83D\uDD01  Resuming in ${startDir}`);
+      }
+    }
     await triageDirectory({
-      dir: absDir,
+      dir: startDir,
       promptPath,
       model,
       recurse,
       curators,
       contextPath,
+      depth,
     });
     console.log("🎉  Finished triaging.");
   } catch (err) {


### PR DESCRIPTION
## Summary
- enable resuming an interrupted triage session
- add `findResumePoint` helper for locating the deepest `_keep` folder
- update CLI with auto-resume behavior
- test resume logic

## Testing
- `npm install`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6861f1a62cfc833084acb63fbcfae45f