### PR TITLE
Add field notes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ through to the script unchanged.
 | `--curators` | *(unset)* | Comma-separated list of curator names used in the group transcript |
 | `--context` | *(unset)* | Text file with exhibition context for the curators |
 | `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |
+| `--field-notes` | `false` | Maintain a field-notes.md file at each recursion level |
 
 ### People metadata (optional)
 
@@ -252,10 +253,11 @@ through that API, so no extra flags are needed.
 3. ChatGPT replies with meeting minutes summarising a short discussion among the curators, followed by a JSON object indicating which files to keep or set aside and why.
 4. Parse that JSON to determine which files were explicitly labeled `keep` or `aside` and capture any notes about each image.
 5. Move those files to the corresponding sub‑folders and write a text file containing the notes next to each image. Files omitted from the decision block remain in place for the next batch so the model can review them again. Meeting minutes are saved as `minutes-<timestamp>.txt` in the directory.
-6. Re‑run the algorithm on the newly created `_keep` folder (unless `--no-recurse`).
+6. If `--field-notes` is enabled, apply the `field_notes_diff` output to a `field-notes.md` file and copy it into deeper levels.
+7. Re‑run the algorithm on the newly created `_keep` folder (unless `--no-recurse`).
    If every photo at a level is kept or every photo is set aside, recursion stops early.
-7. On the first pass of each level a `_level-XXX` folder is created next to `_keep` and `_aside` containing a snapshot of the images originally present.
-8. Stop when a directory has zero unclassified images.
+8. On the first pass of each level a `_level-XXX` folder is created next to `_keep` and `_aside` containing a snapshot of the images originally present.
+9. Stop when a directory has zero unclassified images.
 
 ### JSON mode
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "commander": "^12.0.0",
+        "diff": "^8.0.2",
         "dotenv": "^16.5.0",
         "openai": "^4.0.0",
         "sharp": "^0.34.2"
@@ -1493,6 +1494,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
+      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "commander": "^12.0.0",
+    "diff": "^8.0.2",
     "dotenv": "^16.5.0",
     "openai": "^4.0.0",
     "sharp": "^0.34.2"

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -259,6 +259,7 @@ export function parseReply(text, allFiles) {
   const aside = new Set();
   const notes = new Map();
   const minutes = [];
+  let fieldNotesDiff = "";
 
   // Try JSON first
   try {
@@ -266,6 +267,11 @@ export function parseReply(text, allFiles) {
 
     const extract = (node) => {
       if (!node || typeof node !== 'object') return null;
+      if (typeof node.field_notes_diff === 'string' && !fieldNotesDiff) {
+        fieldNotesDiff = node.field_notes_diff;
+      } else if (typeof node.fieldNotesDiff === 'string' && !fieldNotesDiff) {
+        fieldNotesDiff = node.fieldNotesDiff;
+      }
       if (Array.isArray(node.minutes)) minutes.push(...node.minutes.map((m) => `${m.speaker}: ${m.text}`));
 
       if (node.keep && node.aside) return node;
@@ -343,5 +349,5 @@ export function parseReply(text, allFiles) {
   const decided = new Set([...keep, ...aside]);
   const unclassified = allFiles.filter((f) => !decided.has(f));
 
-  return { keep: [...keep], aside: [...aside], unclassified, notes, minutes };
+  return { keep: [...keep], aside: [...aside], unclassified, notes, minutes, fieldNotesDiff };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -33,9 +33,10 @@ program
     "Text file with exhibition context for the curators"
   )
   .option("--no-recurse", "Process a single directory only")
+  .option("--field-notes", "Maintain field-notes.md at each level")
   .parse(process.argv);
 
-const { dir, prompt: promptPath, model, recurse, apiKey, curators, context: contextPath } = program.opts();
+const { dir, prompt: promptPath, model, recurse, apiKey, curators, context: contextPath, fieldNotes } = program.opts();
 
 if (apiKey) {
   process.env.OPENAI_API_KEY = apiKey;
@@ -58,6 +59,7 @@ if (apiKey) {
       recurse,
       curators,
       contextPath,
+      fieldNotes,
     });
     console.log("🎉  Finished triaging.");
   } catch (err) {

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -3,6 +3,7 @@ import { readFile, writeFile, mkdir, stat, copyFile } from "node:fs/promises";
 import { readPrompt } from "./config.js";
 import { listImages, pickRandom, moveFiles } from "./imageSelector.js";
 import { chatCompletion, parseReply } from "./chatClient.js";
+import { applyPatch } from "diff";
 
 /**
  * Recursively triage images until the current directory is empty
@@ -15,6 +16,8 @@ export async function triageDirectory({
   recurse = true,
   curators = [],
   contextPath,
+  fieldNotes = false,
+  notesPath,
   depth = 0,
 }) {
   const indent = "  ".repeat(depth);
@@ -30,6 +33,25 @@ export async function triageDirectory({
   if (curators.length) {
     const names = curators.join(', ');
     prompt = prompt.replace(/\{\{curators\}\}/g, names);
+  }
+
+  let notesFile;
+  if (fieldNotes) {
+    notesFile = notesPath || path.join(dir, 'field-notes.md');
+    try {
+      await stat(notesFile);
+    } catch {
+      await writeFile(notesFile, '', { flag: 'a' });
+    }
+    try {
+      const existing = await readFile(notesFile, 'utf8');
+      if (existing.trim()) {
+        prompt += `\n\nField notes so far:\n${existing}`;
+      }
+      prompt += `\n\nInclude a 'field_notes_diff' field with a unified diff for field-notes.md.`;
+    } catch {
+      // ignore read errors
+    }
   }
 
   console.log(`${indent}📁  Scanning ${dir}`);
@@ -74,11 +96,25 @@ export async function triageDirectory({
     console.log(`${indent}🤖  ChatGPT reply:\n${reply}`);
 
     // Step 3 – parse decisions
-    const { keep, aside, notes, minutes } = parseReply(reply, batch);
+    const { keep, aside, notes, minutes, fieldNotesDiff } = parseReply(reply, batch);
     if (minutes.length) {
       const minutesFile = path.join(dir, `minutes-${Date.now()}.txt`);
       await writeFile(minutesFile, minutes.join('\n'), 'utf8');
       console.log(`${indent}📝  Saved meeting minutes to ${minutesFile}`);
+    }
+    if (fieldNotesDiff && notesFile) {
+      try {
+        const current = await readFile(notesFile, 'utf8');
+        const patched = applyPatch(current, fieldNotesDiff);
+        if (patched === false) {
+          console.warn(`${indent}⚠️  Could not apply field notes diff`);
+        } else {
+          await writeFile(notesFile, patched, 'utf8');
+          console.log(`${indent}📒  Updated field notes`);
+        }
+      } catch (err) {
+        console.warn(`${indent}⚠️  Field notes update failed: ${err.message}`);
+      }
     }
 
     // Step 4 – move files
@@ -112,6 +148,15 @@ export async function triageDirectory({
     }
 
     if (keepCount && asideCount) {
+      let childNotes;
+      if (notesFile) {
+        childNotes = path.join(keepDir, path.basename(notesFile));
+        try {
+          await stat(childNotes);
+        } catch {
+          try { await copyFile(notesFile, childNotes); } catch {}
+        }
+      }
       await triageDirectory({
         dir: keepDir,
         promptPath,
@@ -119,6 +164,8 @@ export async function triageDirectory({
         recurse,
         curators,
         contextPath,
+        fieldNotes,
+        notesPath: childNotes,
         depth: depth + 1,
       });
     } else if (keepCount || asideCount) {

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -112,6 +112,13 @@ describe("parseReply", () => {
     expect(keep).toContain(files[0]);
     expect(aside).toContain(files[1]);
   });
+
+  it("captures field notes diff", () => {
+    const diff = "--- a/field-notes.md\n+++ b/field-notes.md\n@@\n-old\n+new";
+    const reply = JSON.stringify({ keep: [], aside: [], field_notes_diff: diff });
+    const { fieldNotesDiff } = parseReply(reply, files);
+    expect(fieldNotesDiff).toBe(diff);
+  });
 });
 
 /** Verify images are labelled in messages */

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -85,4 +85,21 @@ describe("triageDirectory", () => {
     const nested = path.join(tmpDir, "_keep", "_keep");
     await expect(fs.stat(nested)).rejects.toThrow();
   });
+
+  it("updates field notes when diff provided", async () => {
+    const diff = "--- a/field-notes.md\n+++ b/field-notes.md\n@@\n+new";
+    chatCompletion.mockResolvedValueOnce(
+      JSON.stringify({ keep: [], aside: ["1.jpg", "2.jpg"], field_notes_diff: diff })
+    );
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: false,
+      fieldNotes: true,
+    });
+    const notesPath = path.join(tmpDir, "field-notes.md");
+    const content = await fs.readFile(notesPath, "utf8");
+    expect(content).toMatch(/new/);
+  });
 });


### PR DESCRIPTION
## Summary
- add `--field-notes` option to CLI
- store and update `field-notes.md` when enabled
- parse `field_notes_diff` from model replies
- copy field notes between recursion levels
- document new option and recursion step
- test field notes handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68661e480f348330bf5546efa785c526