### PR TITLE
Add 2-step field notes update

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ through to the script unchanged.
 | `--curators` | *(unset)* | Comma-separated list of curator names used in the group transcript |
 | `--context` | *(unset)* | Text file with exhibition context for the curators |
 | `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |
-| `--field-notes` | `false` | Maintain a field-notes.md file at each recursion level |
+| `--field-notes` | `false` | Maintain a field-notes.md file at each recursion level (each level starts fresh) |
 
 ### People metadata (optional)
 
@@ -255,7 +255,7 @@ through that API, so no extra flags are needed.
 3. ChatGPT replies with meeting minutes summarising a short discussion among the curators, followed by a JSON object indicating which files to keep or set aside and why.
 4. Parse that JSON to determine which files were explicitly labeled `keep` or `aside` and capture any notes about each image.
 5. Move those files to the corresponding sub‑folders and write a text file containing the notes next to each image. Files omitted from the decision block remain in place for the next batch so the model can review them again. Meeting minutes are saved as `minutes-<timestamp>.txt` in the directory.
-6. If `--field-notes` is enabled, apply the `field_notes_diff` output to a `field-notes.md` file and copy it into deeper levels. The diff should use standard unified patch headers—`--- a/field-notes.md`, `+++ b/field-notes.md`, and a numeric hunk header such as `@@ -0,0 +1,4 @@` for a new file—so it can be applied automatically.
+6. If `--field-notes` is enabled, apply the `field_notes_diff` output to a `field-notes.md` file in the current directory. Each recursion level starts with a fresh `field-notes.md` rather than copying the parent. The diff should use standard unified patch headers—`--- a/field-notes.md`, `+++ b/field-notes.md`, and a numeric hunk header such as `@@ -0,0 +1,4 @@` for a new file—so it can be applied automatically.
 7. Re‑run the algorithm on the newly created `_keep` folder (unless `--no-recurse`).
    If every photo at a level is kept or every photo is set aside, recursion stops early.
 8. On the first pass of each level a `_level-XXX` folder is created next to `_keep` and `_aside` containing a snapshot of the images originally present.

--- a/prompts/default_prompt.txt
+++ b/prompts/default_prompt.txt
@@ -31,6 +31,7 @@ Never invent filenames or keys.
 
 Include only those filenames for which you reach a clear decision.
 Return pure JSON and use each label verbatim. No other text after the JSON.
+Provide an `observations` array summarising any new insights the field notes should incorporate. If a detail is unclear or you are uncertain what the photo shows, state that uncertainty—questions are valuable observations too. The diff will be generated in a follow‑up request.
 
-When adding a `field_notes_diff` property, format it as a standard unified diff for `field-notes.md`. Begin the diff with `--- a/field-notes.md` and `+++ b/field-notes.md` header lines followed by a numeric hunk header (e.g. `@@ -0,0 +1,4 @@` when the file is new) so the patch can be applied automatically. Use the unified diff format to transform as many hunks as are needed.
-Do not organise field notes as a list keyed by filenames. Integrate observations from the photos into subject-matter semantic sections and subsections. Refine and refactor the taxonomy over time so the document reads like a cohesive comprehensive highly accurate detail rich comprehensive outline—emerging from the observation of the photos—rather than a checklist of images.
+When producing a `field_notes_diff`, format it as a standard unified diff for `field-notes.md`. Begin the diff with `--- a/field-notes.md` and `+++ b/field-notes.md` header lines followed by a numeric hunk header (e.g. `@@ -0,0 +1,4 @@` when the file is new) so the patch can be applied automatically. Use the unified diff format to transform as many hunks as are needed.
+Do not organise field notes as a list keyed by filenames. Integrate observations from the photos into subject-matter semantic sections and subsections. Refine and refactor the taxonomy over time so the document reads like a cohesive comprehensive highly accurate detail rich outline emerging from the observation of the photos rather than a checklist of images.

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -102,7 +102,7 @@ export async function buildMessages(prompt, images, curators = []) {
   const userText = {
     role: "user",
     content: [
-      { type: "text", text: ensureJsonMention("Here are the images:") },
+      { type: "text", text: ensureJsonMention(images.length ? "Here are the images:" : "Additional context:") },
       ...userImageParts,
     ],
   };
@@ -143,7 +143,7 @@ export async function buildInput(prompt, images, curators = []) {
       {
         role: "user",
         content: [
-          { type: "input_text", text: ensureJsonMention("Here are the images:") },
+          { type: "input_text", text: ensureJsonMention(images.length ? "Here are the images:" : "Additional context:") },
           ...imageParts,
         ],
       },
@@ -260,6 +260,7 @@ export function parseReply(text, allFiles) {
   const notes = new Map();
   const minutes = [];
   let fieldNotesDiff = "";
+  const observations = [];
 
   // Try JSON first
   try {
@@ -272,6 +273,7 @@ export function parseReply(text, allFiles) {
       } else if (typeof node.fieldNotesDiff === 'string' && !fieldNotesDiff) {
         fieldNotesDiff = node.fieldNotesDiff;
       }
+      if (Array.isArray(node.observations)) observations.push(...node.observations.map(String));
       if (Array.isArray(node.minutes)) minutes.push(...node.minutes.map((m) => `${m.speaker}: ${m.text}`));
 
       if (node.keep && node.aside) return node;
@@ -349,5 +351,5 @@ export function parseReply(text, allFiles) {
   const decided = new Set([...keep, ...aside]);
   const unclassified = allFiles.filter((f) => !decided.has(f));
 
-  return { keep: [...keep], aside: [...aside], unclassified, notes, minutes, fieldNotesDiff };
+  return { keep: [...keep], aside: [...aside], unclassified, notes, minutes, fieldNotesDiff, observations };
 }

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -120,4 +120,61 @@ describe("triageDirectory", () => {
     expect(content).toMatch(/foo/);
     expect(content).toMatch(/bar/);
   });
+
+  it("updates field notes via second call when observations provided", async () => {
+    chatCompletion
+      .mockResolvedValueOnce(
+        JSON.stringify({ keep: [], aside: ["1.jpg", "2.jpg"], observations: ["obs1"] })
+      )
+      .mockResolvedValueOnce(
+        JSON.stringify({ field_notes_diff: "--- a/field-notes.md\n+++ b/field-notes.md\n@@\n+obs1" })
+      );
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: false,
+      fieldNotes: true,
+    });
+    expect(chatCompletion).toHaveBeenCalledTimes(2);
+    const notesPath = path.join(tmpDir, "field-notes.md");
+    const content = await fs.readFile(notesPath, "utf8");
+    expect(content).toMatch(/obs1/);
+  });
+
+  it("starts a new field notes file at each recursion level", async () => {
+    chatCompletion
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          keep: ["1.jpg"],
+          aside: ["2.jpg"],
+          field_notes_diff: "--- a/field-notes.md\n+++ b/field-notes.md\n@@\n+parent",
+        })
+      )
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          keep: [],
+          aside: ["1.jpg"],
+          field_notes_diff: "--- a/field-notes.md\n+++ b/field-notes.md\n@@\n+child",
+        })
+      );
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: true,
+      fieldNotes: true,
+    });
+
+    expect(chatCompletion).toHaveBeenCalledTimes(2);
+    const parentPath = path.join(tmpDir, "field-notes.md");
+    const childPath = path.join(tmpDir, "_keep", "field-notes.md");
+    const parentContent = await fs.readFile(parentPath, "utf8");
+    const childContent = await fs.readFile(childPath, "utf8");
+    expect(parentContent).toMatch(/parent/);
+    expect(parentContent).not.toMatch(/child/);
+    expect(childContent).toMatch(/child/);
+    expect(childContent).not.toMatch(/parent/);
+  });
 });


### PR DESCRIPTION
## Summary
- support text-only calls in `chatClient`
- return an `observations` array from `parseReply`
- perform a second OpenAI call when observations need to be integrated into `field-notes.md`
- start fresh `field-notes.md` at each recursion level
- update default prompt with guidance about the `observations` list
- test the new behaviour
- clarify instructions that uncertainties can be noted when deriving observations
- preserve uncertainty when integrating observations into field notes
- document fresh field notes per recursion

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866b8cb4cb8833085936e71ae986af3