### PR TITLE
Fix show-prompt flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ through to the script unchanged.
 | `--api-key` | *(unset)*                  | OpenAI API key. Overrides `$OPENAI_API_KEY`. |
 | `--curators` | *(unset)* | Comma-separated list of curator names used in the group transcript |
 | `--context` | *(unset)* | Text file with exhibition context for the curators |
-| `--show-prompt` | `false` | Print the assembled prompt and exit |
+| `--show-prompt` | `false` | Print the rendered prompt text before each API call |
 | `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |
 | `--field-notes` | `false` | Enable living field-notes.md generation with curator diff workflow |
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ import "dotenv/config";
 import { Command } from "commander";
 import path from "node:path";
 import { DEFAULT_PROMPT_PATH } from "./config.js";
-import { buildPrompt } from "./prompt.js";
 
 const program = new Command();
 program
@@ -33,13 +32,12 @@ program
     "-x, --context <file>",
     "Text file with exhibition context for the curators"
   )
-  .option("--show-prompt", "Print the final prompt and exit")
+  .option("--show-prompt", "Print the rendered prompt before each API call")
   .option("--no-recurse", "Process a single directory only")
   .option("--field-notes", "Enable field notes workflow")
-  .option("--show-prompt", "Print the rendered prompt before each API call")
   .parse(process.argv);
 
-const { dir, prompt: promptPath, model, recurse, apiKey, curators, context: contextPath, showPrompt } = program.opts();
+const { dir, prompt: promptPath, model, recurse, apiKey, curators, context: contextPath, fieldNotes, showPrompt } = program.opts();
 
 if (apiKey) {
   process.env.OPENAI_API_KEY = apiKey;
@@ -55,17 +53,15 @@ if (apiKey) {
     }
     const absDir = path.resolve(dir);
     const { triageDirectory } = await import("./orchestrator.js");
-    const prompt = await buildPrompt(promptPath, { curators, contextPath });
-    if (showPrompt) {
-      console.log(prompt);
-      return;
-    }
     await triageDirectory({
       dir: absDir,
-      prompt,
+      promptPath,
       model,
       recurse,
       curators,
+      contextPath,
+      fieldNotes,
+      showPrompt,
     });
     console.log("🎉  Finished triaging.");
   } catch (err) {

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -60,9 +60,6 @@ export async function triageDirectory({
     }
   }
 
-  if (showPrompt) {
-    console.log(`${indent}📑  Prompt:\n${prompt}`);
-  }
 
   console.log(`${indent}📁  Scanning ${dir}`);
 
@@ -100,6 +97,9 @@ export async function triageDirectory({
     console.log(`${indent}⏳  Sending batch to ChatGPT…`);
     const ts = Date.now();
     await writeFile(path.join(promptsDir, `${ts}.prompt.txt`), prompt, 'utf8');
+    if (showPrompt) {
+      console.log(`${indent}📑  Prompt:\n${prompt}`);
+    }
     const reply = await chatCompletion({
       prompt,
       images: batch,
@@ -200,6 +200,7 @@ export async function triageDirectory({
         curators,
         contextPath,
         fieldNotes,
+        showPrompt,
         depth: depth + 1,
       });
     } else {


### PR DESCRIPTION
## Summary
- update --show-prompt flag to print prompts before each API call
- forward CLI options correctly to the orchestrator
- show prompts during recursion and before each batch
- document the new flag behaviour

## Testing
- `npx vitest run` *(fails: Need to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_686942365fbc8330b23b48bd4cd4ece6