### PR TITLE
Refactor for map-based decisions and telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,13 @@ The **Vitest** suite covers random selection, safe moves, and response‑parsing
 
 ---
 
+## Telemetry
+
+If `.ps-stats.json` exists in the working directory, each triage batch appends
+metrics about decision latency and notebook updates. Delete the file to opt out.
+
+---
+
 ## Development tips
 
 - Use `nvm use` in every new shell (or add a shell hook).

--- a/prompts/default_prompt.hbs
+++ b/prompts/default_prompt.hbs
@@ -1,60 +1,38 @@
 You are moderating a collaborative curatorial session.
-The following curators are present: {{curators}}. Jamie is the facilitator.
-Before discussing the images, list the keys you will return (e.g. "minutes, decision{{#if fieldNotes}}, field_notes_diff"{{/if}}) then proceed.
+
+Session participants:
+- Curators: {{curators}}
+- Facilitator: Jamie
+
+You will review the following image files (use *only* these names when forming decisions):
+{{#each images}}
+- {{this}}
+{{/each}}
+
 {{#if context}}
 
-Curator FYI:
+Background for today's review:
 {{context}}
 {{/if}}
 {{#if fieldNotes}}
 
-Field notes so far:
+Field‑notes snapshot prior to this batch:
 {{fieldNotes}}
 {{/if}}
 
-Capture that conversation inside the `minutes` array; do not write it outside the JSON object. Begin with a diarised conversation in which the curators discuss the images and gently work toward consensus.
-Reflect the thoughtful, iterative process described in the briefing: curators share insights, consider relationships among works, and refine the selection together.
+When you respond, think step‑by‑step silently and then output **only** a valid JSON object with the following top‑level keys:
 
-After capturing these remarks as meeting minutes, output a JSON object summarising the final decision:
-
-If you are uncertain about a photo, **omit it from the decision block**.
-Never invent filenames or keys.
-
+- "minutes" : an array of `{ "speaker": "<Name>", "text": "<what was said>" }`. The final `text` must be a forward‑looking question.
+- "decision" : an object whose optional keys are **exactly** "keep" and "aside". Each key maps a filename to a one‑sentence rationale. Omit filenames that lack consensus.
 {{#if fieldNotes}}
-  While doing this work curators maintain living, itterative, running research notebook called field-notes.md.
-  Extract new facts today's images reveal (measurements, equipment IDs, unanswered questions, etc)—as you see fit for a field notes report of the situation the curators collectively witness through the photos.
-  Write a tiny git-style patch—a list of lines to insert or delete in the main notebook (field-notes.md).
-
-  Field-Notes.md Contributor Guide:
-  1. Only change lines in field-notes.md you can justify by looking at today’s images, allowing the remainder of field-notes.md to pass forward unchanged.
-  2. Use `[filename.jpg]` links to cite photographic evidence for each facutal observation noted; they will autolink.
-  3. If uncertain, insert a "(?)" marker rather than inventing details. Discovering a facutal inconsistency, highlighting an ambiguity, or surfacing a question—can itself be a meaningfully discerning contribution.
-  4. Keep ≤ 3 `![]()` inline embeds per update to stay lightweight.
+- "field_notes_diff" : a unified diff (like `git diff -U0`) patching *field‑notes.md*.  
+  Contributor guide  
+  1. Change only lines justified by today’s images.  
+  2. Cite evidence with `[filename.jpg]` links.  
+  3. Mark uncertainties with "(?)".  
+  4. Embed ≤ 3 `![]()` inline images.
 {{/if}}
 
+Never invent filenames, keys, or extra properties. Use only the image list above and the keys "keep"/"aside".
 
-{
-  "minutes": [
-    { "speaker": "Name", "text": "what was said" },
-    ...
-  ],
-  "decision": {
-    "keep": {
-      "filename1.jpg": "why it stays",
-      ...
-    },
-    "aside": {
-      "filename2.jpg": "why it is set aside",
-      ...
-    }
-  }{{#if fieldNotes}},
-  "field_notes_diff": "<unified diff here>"
-  {{/if}}
-}
-
-
-
-Include only those filenames for which you reach a clear decision.
-The final line of `minutes` must be a forward-looking question.
-Return pure JSON and use each label verbatim. No other text after the JSON.
-
+Return pure JSON—no markdown, no commentary, no extra text.

--- a/reply.schema.json
+++ b/reply.schema.json
@@ -27,42 +27,18 @@
           "type": "object",
           "properties": {
             "keep": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "string"
-                  }
-                }
-              ]
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             },
             "aside": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "string"
-                  }
-                }
-              ]
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           },
-          "required": [
-            "keep",
-            "aside"
-          ],
           "additionalProperties": false
         },
         "field_notes_diff": {

--- a/scripts/generate_schema.js
+++ b/scripts/generate_schema.js
@@ -12,8 +12,8 @@ async function main() {
   const keys = new Set(['minutes', 'decision', 'keep', 'aside', ...tokens]);
 
   const decision = z.object({
-    keep: z.union([z.array(z.string()), z.record(z.string(), z.string())]),
-    aside: z.union([z.array(z.string()), z.record(z.string(), z.string())])
+    keep: z.record(z.string(), z.string()).optional(),
+    aside: z.record(z.string(), z.string()).optional(),
   });
   const shape = {
     minutes: z.array(z.object({ speaker: z.string(), text: z.string() })),
@@ -29,8 +29,8 @@ async function main() {
     'export const Reply = z.object({',
     '  minutes: z.array(z.object({ speaker: z.string(), text: z.string() })),',
     '  decision: z.object({',
-    '    keep: z.union([z.array(z.string()), z.record(z.string(), z.string())]),',
-    '    aside: z.union([z.array(z.string()), z.record(z.string(), z.string())])',
+    '    keep: z.record(z.string(), z.string()).optional(),',
+    '    aside: z.record(z.string(), z.string()).optional()',
     '  }),'
   ];
   if (keys.has('field_notes_diff')) tsLines.push("  field_notes_diff: z.string().optional(),");

--- a/src/hash.js
+++ b/src/hash.js
@@ -1,5 +1,7 @@
 import crypto from 'node:crypto';
+import { readFile } from 'node:fs/promises';
 
-export function sha256(text) {
-  return crypto.createHash('sha256').update(text).digest('hex');
+export async function sha256(filePath) {
+  const buf = await readFile(filePath);
+  return crypto.createHash('sha256').update(buf).digest('hex');
 }

--- a/src/replySchema.js
+++ b/src/replySchema.js
@@ -3,8 +3,8 @@ import { z } from 'zod';
 export const Reply = z.object({
   minutes: z.array(z.object({ speaker: z.string(), text: z.string() })),
   decision: z.object({
-    keep: z.union([z.array(z.string()), z.record(z.string(), z.string())]),
-    aside: z.union([z.array(z.string()), z.record(z.string(), z.string())])
+    keep: z.record(z.string(), z.string()).optional(),
+    aside: z.record(z.string(), z.string()).optional()
   }),
   field_notes_diff: z.string().optional(),
   field_notes_md: z.string().optional(),

--- a/src/replySchema.ts
+++ b/src/replySchema.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 export const Reply = z.object({
   minutes: z.array(z.object({ speaker: z.string(), text: z.string() })),
   decision: z.object({
-    keep: z.union([z.array(z.string()), z.record(z.string(), z.string())]),
-    aside: z.union([z.array(z.string()), z.record(z.string(), z.string())])
+    keep: z.record(z.string(), z.string()).optional(),
+    aside: z.record(z.string(), z.string()).optional()
   }),
   field_notes_diff: z.string().optional(),
   field_notes_md: z.string().optional(),

--- a/src/stats.js
+++ b/src/stats.js
@@ -1,0 +1,5 @@
+import { writeFile } from 'node:fs/promises';
+
+export async function writeStats(data) {
+  await writeFile('.ps-stats.json', JSON.stringify(data, null, 2), 'utf8');
+}

--- a/tests/archive.test.js
+++ b/tests/archive.test.js
@@ -11,10 +11,10 @@ vi.mock('../src/chatClient.js', async () => {
   const actual = await vi.importActual('../src/chatClient.js');
   return {
     ...actual,
-    chatCompletion: vi.fn().mockResolvedValue(JSON.stringify({
+    chatCompletion: vi.fn().mockResolvedValue({
       minutes: [{ speaker: 'A', text: 'done?' }],
-      decision: { keep: [], aside: ['a.jpg'] }
-    }))
+      decision: { keep: {}, aside: { 'a.jpg': '' } }
+    })
   };
 });
 

--- a/tests/hash.test.js
+++ b/tests/hash.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { sha256 } from '../src/hash.js';
+
+describe('sha256', () => {
+  it('produces stable hashes for file contents', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'hash-'));
+    const file = path.join(dir, 'a.txt');
+    await fs.writeFile(file, 'hello');
+    const h1 = await sha256(file);
+    const h2 = await sha256(file);
+    expect(h1).toBe(h2);
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+});

--- a/tests/schema.test.js
+++ b/tests/schema.test.js
@@ -3,7 +3,7 @@ import { Reply } from '../src/replySchema.js';
 
 const fixture = {
   minutes: [{ speaker: 'A', text: 'done?' }],
-  decision: { keep: ['a.jpg'], aside: ['b.jpg'] }
+  decision: { keep: { 'a.jpg': 'ok' }, aside: { 'b.jpg': 'bad' } }
 };
 
 describe('reply schema', () => {


### PR DESCRIPTION
## Summary
- update prompt template
- change reply schema to use object maps
- refactor orchestrator for new prompt plumbing
- validate chat replies with retry logic
- compute sha256 for files and export to SQLite
- record session metrics and document telemetry
- update and expand tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869b6d78e24833091b392bb16428a73