### PR TITLE
Improve retry logging for ChatGPT errors

### DIFF
--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -224,6 +224,7 @@ export async function chatCompletion({
       const label = isNetwork ? "network error" : "OpenAI error";
       const codeInfo = err.status ?? code ?? "unknown";
       console.warn(`${label} (${codeInfo}). Retrying in ${wait} ms…`);
+      console.warn("Full error response:", err);
       await delay(wait);
     }
   }


### PR DESCRIPTION
## Summary
- log the full error object when retrying an OpenAI call

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686aaf2c926c8330b5e49f77f89b7a3b