### PR TITLE
Document memory flag, add env check

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,19 @@ through to the script unchanged.
 | `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |
 | `--parallel` | `1` | Number of batches to process simultaneously |
 
+### Increasing memory
+
+The Node.js heap defaults to about 4 GB. Large runs with `--parallel` greater than 1
+may exhaust that limit. Set `PHOTO_SELECT_MAX_OLD_SPACE_MB` to allocate more memory:
+
+```bash
+PHOTO_SELECT_MAX_OLD_SPACE_MB=8192 \
+  /path/to/photo-select/photo-select-here.sh --parallel 10 --api-key sk-...
+```
+
+The value is passed directly to `--max-old-space-size`, so adjust it to match your
+available RAM.
+
 ### People metadata (optional)
 
 Set `PHOTO_FILTER_API_BASE` to the base URL of your [photo‑filter](https://github.com/openhouse/photo-filter) service to include face‑tag data in the prompt. For each image the CLI fetches `/api/photos/by-filename/<filename>/persons` and sends a JSON blob like `{ "filename": "DSCF1234.jpg", "people": ["Alice", "Bob"] }` before the image itself. Results are cached per filename for the duration of the run.

--- a/photo-select-here.sh
+++ b/photo-select-here.sh
@@ -23,6 +23,11 @@ fi
 
 cd "$SCRIPT_DIR"
 
+# Optional memory tweak for large batches
+if [ -n "${PHOTO_SELECT_MAX_OLD_SPACE_MB:-}" ]; then
+  export NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=${PHOTO_SELECT_MAX_OLD_SPACE_MB}"
+fi
+
 dir_specified=false
 for arg in "$@"; do
   case "$arg" in


### PR DESCRIPTION
## Summary
- allow larger Node heap via PHOTO_SELECT_MAX_OLD_SPACE_MB in photo-select-here.sh
- document new environment variable for large parallel runs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ae5ad9464833087af33f87fba4bbf