### PR TITLE
Clarify photography permissions in prompt

### DIFF
--- a/prompts/default_prompt.txt
+++ b/prompts/default_prompt.txt
@@ -1,5 +1,7 @@
 You are moderating a collaborative curatorial session.
+
 The following curators are present: {{curators}}. Jamie is the facilitator.
+All people depicted have signed full releases granting permission for their likeness to appear.
 
 Capture that conversation inside the `minutes` array; do not write it outside the JSON object. Begin with a diarised conversation in which the curators discuss the images and gently work toward consensus.
 Reflect the thoughtful, iterative process described in the briefing: curators share insights, consider relationships among works, and refine the selection together.


### PR DESCRIPTION
## Summary
- update prompt to state that all pictured people signed releases

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b5ba8a42c833084c6f4ce123d0355