### PR TITLE
Extend agent timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ from OpenAI as soon as they are available. Progress bars advance to a
 "stream" stage while data arrives. Streaming keeps the HTTPS socket alive and
 reduces the chance of retry loops on slow requests.
 
+### Custom timeout
+
+Long vision batches can occasionally exceed the default 5‑minute HTTP timeout.
+The client now waits up to **20 minutes** by default. Set `PHOTO_SELECT_TIMEOUT_MS`
+to override this value if your environment needs a different window.
+
 ### People metadata (optional)
 
 Set `PHOTO_FILTER_API_BASE` to the base URL of your [photo‑filter](https://github.com/openhouse/photo-filter) service to include face‑tag data in the prompt. For each image the CLI fetches `/api/photos/by-filename/<filename>/persons` and sends a JSON blob like `{ "filename": "DSCF1234.jpg", "people": ["Alice", "Bob"] }` before the image itself. Results are cached per filename for the duration of the run.

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -5,9 +5,10 @@ import path from "node:path";
 import crypto from "node:crypto";
 import { delay } from "./config.js";
 
+const DEFAULT_TIMEOUT = 20 * 60 * 1000;
 const httpsAgent = new KeepAliveAgent.HttpsAgent({
   keepAlive: true,
-  timeout: 5 * 60 * 1000,
+  timeout: Number.parseInt(process.env.PHOTO_SELECT_TIMEOUT_MS, 10) || DEFAULT_TIMEOUT,
 });
 httpsAgent.on("error", (err) => {
   if (["EPIPE", "ECONNRESET"].includes(err.code)) {


### PR DESCRIPTION
## Summary
- increase HTTP keepalive timeout to 20 min and allow override via `PHOTO_SELECT_TIMEOUT_MS`
- document new timeout environment variable in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e7e4dfaa48330b06dce3a8db356f8