### PR TITLE
log missing photo-filter errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ to override this value if your environment needs a different window.
 
 ### People metadata (optional)
 
-Set `PHOTO_FILTER_API_BASE` to the base URL of your [photo‑filter](https://github.com/openhouse/photo-filter) service to include face‑tag data in the prompt. For each image the CLI fetches `/api/photos/by-filename/<filename>/persons` and sends a JSON blob like `{ "filename": "DSCF1234.jpg", "people": ["Alice", "Bob"] }` before the image itself. Results are cached per filename for the duration of the run.
+Set `PHOTO_FILTER_API_BASE` to the base URL of your [photo‑filter](https://github.com/openhouse/photo-filter) service to include face‑tag data in the prompt. The CLI assumes the service is available at `http://localhost:3000` when the variable is unset and logs a warning if requests fail. For each image it fetches `/api/photos/by-filename/<filename>/persons` and sends a JSON blob like `{ "filename": "DSCF1234.jpg", "people": ["Alice", "Bob"] }` before the image itself. Results are cached per filename for the duration of the run.
 
 Example:
 

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -19,8 +19,8 @@ httpsAgent.on("error", (err) => {
 });
 
 const openai = new OpenAI({ httpAgent: httpsAgent });
-const PEOPLE_API_BASE = process.env.PHOTO_FILTER_API_BASE ||
-  "http://localhost:3000";
+const PEOPLE_API_BASE =
+  process.env.PHOTO_FILTER_API_BASE || "http://localhost:3000";
 const peopleCache = new Map();
 
 async function readFileSafe(file, attempt = 0, maxAttempts = 3) {
@@ -51,7 +51,9 @@ async function getPeople(filename) {
     const names = Array.isArray(json.data) ? json.data : [];
     peopleCache.set(filename, names);
     return names;
-  } catch {
+  } catch (err) {
+    const msg = err?.message || err?.code || 'unknown error';
+    console.warn(`\u26A0\uFE0F  metadata fetch failed for ${filename}: ${msg}`);
     peopleCache.set(filename, []);
     return [];
   }


### PR DESCRIPTION
## Summary
- default PHOTO_FILTER_API_BASE already set to localhost
- log a warning when face-tag metadata fetch fails
- note default assumption in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687482147e608330bf0d7347e8598799