### PR TITLE
Fix curator tag injection

### DIFF
--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -70,8 +70,9 @@ export async function curatorsFromTags(files) {
       counts.set(person, (counts.get(person) || 0) + 1);
     }
   }
+  const banned = new Set(["_UNKNOWN_"]);
   return [...counts.entries()]
-    .filter(([, c]) => c > 1)
+    .filter(([n, c]) => c > 1 && !banned.has(n))
     .map(([n]) => n);
 }
 

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -51,10 +51,6 @@ export async function triageDirectory({
       console.warn(`Could not read context file ${contextPath}: ${err.message}`);
     }
   }
-  if (curators.length) {
-    const names = curators.join(', ');
-    prompt = prompt.replace(/\{\{curators\}\}/g, names);
-  }
 
   console.log(`${indent}📁  Scanning ${dir}`);
 

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -183,6 +183,16 @@ describe("curatorsFromTags", () => {
     const names = await curatorsFromTags(imgs);
     expect(names).toContain("Alice");
   });
+
+  it("filters placeholder names", async () => {
+    const imgs = ["/tmp/y1.jpg", "/tmp/y2.jpg"];
+    global.fetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: ["_UNKNOWN_"] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: ["_UNKNOWN_"] }) });
+    const names = await curatorsFromTags(imgs);
+    expect(names).toHaveLength(0);
+    global.fetch.mockReset();
+  });
 });
 
 describe("chatCompletion", () => {


### PR DESCRIPTION
## Summary
- ensure prompt keeps {{curators}} placeholder until chatCompletion
- ignore `_UNKNOWN_` face tags when deriving curators
- add regression test for filtering placeholder names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687551dce69083309363903a51582bcf