### PR TITLE
Improve field notes handling

### DIFF
--- a/docs/field-notes.md
+++ b/docs/field-notes.md
@@ -11,3 +11,11 @@ The `--field-notes` flag enables a lightweight notebook that evolves alongside e
 5. When more than three inline images (`![]()`) appear in a single entry a warning is appended so the notes remain compact.
 
 Disable the feature by omitting the flag. Each level keeps its own notebook so progress can be reviewed later.
+
+## Historical background
+
+An early Python prototype introduced the two‑pass workflow still used today. The first LLM call returns a `field_notes_diff` alongside minutes and keep/aside decisions. If the diff cannot be applied cleanly a second prompt is issued asking for the full notebook via `field_notes_md`. The current Node implementation mirrors that logic but lives in `FieldNotesWriter` and `orchestrator.js`.
+
+## Migrating legacy notes
+
+Notebooks created by the Python prototype lack headers and automatic links. Run `node scripts/migrate-notes.js <file>` to convert them to the current format. The script rewrites each file using `FieldNotesWriter`, preserving original text while adding timestamps and autolinks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "agentkeepalive": "^4.2.1",
         "cli-progress": "^3.12.0",
         "commander": "^12.0.0",
+        "diff": "^8.0.2",
         "dotenv": "^16.5.0",
         "handlebars": "^4.7.8",
         "openai": "^4.0.0",
@@ -1517,6 +1518,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
+      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {

--- a/package.json
+++ b/package.json
@@ -16,13 +16,14 @@
   "author": "Jamie Burkart",
   "license": "MIT",
   "dependencies": {
+    "agentkeepalive": "^4.2.1",
     "cli-progress": "^3.12.0",
     "commander": "^12.0.0",
+    "diff": "^8.0.2",
     "dotenv": "^16.5.0",
-    "agentkeepalive": "^4.2.1",
+    "handlebars": "^4.7.8",
     "openai": "^4.0.0",
-    "sharp": "^0.34.2",
-    "handlebars": "^4.7.8"
+    "sharp": "^0.34.2"
   },
   "devDependencies": {
     "vitest": "^1.5.0"

--- a/scripts/migrate-notes.js
+++ b/scripts/migrate-notes.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import FieldNotesWriter from '../src/fieldNotesWriter.js';
+
+async function run() {
+  const files = process.argv.slice(2);
+  if (!files.length) {
+    console.error('Usage: migrate-notes.js <file> [...]');
+    process.exit(1);
+  }
+  for (const file of files) {
+    const abs = path.resolve(file);
+    const writer = new FieldNotesWriter(abs);
+    const text = await fs.readFile(abs, 'utf8');
+    await writer.writeFull(text);
+    console.log(`Migrated ${file}`);
+  }
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- document historical two-pass workflow and migration script
- add fallback patching logic to `FieldNotesWriter`
- provide migration utility for old notebooks
- test patch fallback and failure scenarios
- update dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f9750a5208330ad6965ba550ee883