### PR TITLE
Fix field-notes prompt gating

### DIFF
--- a/prompts/default_prompt.hbs
+++ b/prompts/default_prompt.hbs
@@ -13,7 +13,7 @@ You will review the following image files (use *only* these names when forming d
 Background for today's review:
 {{context}}
 {{/if}}
-{{#if fieldNotes}}
+{{#if hasFieldNotes}}
 Field-notes snapshot prior to this batch:
 {{fieldNotes}}
 {{/if}}
@@ -21,7 +21,7 @@ Field-notes snapshot prior to this batch:
 When you respond, think step-by-step silently and then output **only** a valid JSON object with the following top-level keys:
 - "minutes" : an array of { "speaker": "<Name>", "text": "<what was said>" }. The final "text" must be a forward-looking question.
 - "decision" : an object whose optional keys are exactly "keep" and "aside". Each key maps a filename to a one-sentence rationale. Omit filenames that lack consensus.
-{{#if fieldNotes}}
+{{#if hasFieldNotes}}
 - "field_notes_diff" : a unified diff (like `git diff -U0`) patching *field-notes.md*.
   Contributor guide
   1. Change only lines justified by today’s images.

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -171,6 +171,7 @@ export async function triageDirectory({
               contextPath,
               images: batch,
               fieldNotes: notesText,
+              hasFieldNotes: !!notesWriter,
             });
             let prompt = basePrompt;
             if (addon) prompt += `\n${addon}`;

--- a/src/templates.js
+++ b/src/templates.js
@@ -14,7 +14,7 @@ export async function renderTemplate(filePath = DEFAULT_PROMPT_PATH, data = {}) 
 
 export async function buildPrompt(
   filePath,
-  { curators = [], images = [], contextPath, fieldNotes }
+  { curators = [], images = [], contextPath, fieldNotes, hasFieldNotes = false }
 ) {
   const context = contextPath
     ? await fs.readFile(contextPath, 'utf8').catch(() => '')
@@ -24,6 +24,7 @@ export async function buildPrompt(
     images: images.map((f) => path.basename(f)),
     context,
     fieldNotes,
+    hasFieldNotes,
   });
 }
 


### PR DESCRIPTION
## Summary
- ensure first field-notes batch includes instructions by passing a boolean flag
- gate field notes sections in the default prompt on this flag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fcdd542788330af50546c698e1e37