### PR TITLE
Switch field-notes diff to instruction flow

### DIFF
--- a/docs/field-notes.md
+++ b/docs/field-notes.md
@@ -14,7 +14,7 @@ Disable the feature by omitting the flag. Each level keeps its own notebook so p
 
 ## Historical background
 
-An early Python prototype introduced the two‑pass workflow still used today. The first LLM call returns a `field_notes_diff` alongside minutes and keep/aside decisions. If the diff cannot be applied cleanly a second prompt is issued asking for the full notebook via `field_notes_md`. The current Node implementation mirrors that logic but lives in `FieldNotesWriter` and `orchestrator.js`.
+An early Python prototype used diffs to update the notebook. The revised workflow sends **instructions** for how to edit the notes. A second LLM call then applies those steps and returns the complete file through `field_notes_md`. This logic lives in `FieldNotesWriter` and `orchestrator.js`.
 
 ## Migrating legacy notes
 

--- a/prompts/field_notes_addon.txt
+++ b/prompts/field_notes_addon.txt
@@ -2,11 +2,11 @@ When field-notes mode is ON, extend the response schema:
 
 {
   …(minutes, decision)…,
-  "field_notes_diff": "<unified diff here>"
+  "field_notes_instructions": "<step-by-step edits>"
 }
 
 Rules:
-1. Only change notebook lines you can justify by looking at today’s images.
+1. Write concise instructions for updating the notebook, justified by today’s images.
 2. Use `[filename.jpg]` links to cite evidence; they will autolink.
 3. If uncertain, insert a "(?)" marker rather than inventing details.
 4. Keep ≤ 3 `![]()` inline embeds per update to stay lightweight.

--- a/prompts/field_notes_second_pass.hbs
+++ b/prompts/field_notes_second_pass.hbs
@@ -3,9 +3,10 @@
 Current field notes:
 {{existing}}
 
-Patch:
-{{diff}}
+Update instructions:
+{{instructions}}
 
-The diff above has been staged. Please return a JSON object with
-`field_notes_md` containing the entire updated notebook and nothing else.
+Apply those instructions, referencing today's photos for evidence. If a change
+lacks support, omit it. Return a JSON object with `field_notes_md` containing the
+full updated notebook and nothing else.
 

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -374,6 +374,7 @@ export function parseReply(text, allFiles, opts = {}) {
 
   let fieldNotesDiff;
   let fieldNotesMd;
+  let fieldNotesInstructions;
   // Try JSON first
   try {
     const obj = JSON.parse(text);
@@ -382,6 +383,12 @@ export function parseReply(text, allFiles, opts = {}) {
     }
     if (opts.expectFieldNotesMd && typeof obj.field_notes_md === 'string') {
       fieldNotesMd = obj.field_notes_md;
+    }
+    if (
+      opts.expectFieldNotesInstructions &&
+      typeof obj.field_notes_instructions === 'string'
+    ) {
+      fieldNotesInstructions = obj.field_notes_instructions;
     }
 
     const extract = (node) => {
@@ -471,5 +478,6 @@ export function parseReply(text, allFiles, opts = {}) {
     minutes,
     fieldNotesDiff,
     fieldNotesMd,
+    fieldNotesInstructions,
   };
 }

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -202,21 +202,27 @@ export async function triageDirectory({
             console.log(`${indent}⏱️  Batch ${idx + 1} completed in ${(ms / 1000).toFixed(1)}s`);
 
             let parsed = parseReply(reply, batch, {
-              expectFieldNotesDiff: !!notesWriter,
+              expectFieldNotesInstructions: !!notesWriter,
             });
-            const { keep, aside, notes, minutes, fieldNotesDiff, fieldNotesMd } =
-              parsed;
-            if (notesWriter && (fieldNotesMd || fieldNotesDiff)) {
+            const {
+              keep,
+              aside,
+              notes,
+              minutes,
+              fieldNotesInstructions,
+              fieldNotesMd,
+            } = parsed;
+            if (notesWriter && (fieldNotesMd || fieldNotesInstructions)) {
               if (fieldNotesMd) {
                 await notesWriter.writeFull(fieldNotesMd);
-              } else if (fieldNotesDiff) {
+              } else if (fieldNotesInstructions) {
                 const secondPrompt = await renderTemplate(
                   new URL('../prompts/field_notes_second_pass.hbs', import.meta.url)
                     .pathname,
                   {
                     prompt: basePrompt,
                     existing: notesText,
-                    diff: fieldNotesDiff,
+                    instructions: fieldNotesInstructions,
                   }
                 );
                 const secondId = crypto.randomUUID();

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -113,15 +113,15 @@ describe("parseReply", () => {
     expect(aside).toContain(files[1]);
   });
 
-  it("extracts field notes diff", () => {
+  it("extracts field note instructions", () => {
     const obj = {
       decision: { keep: [], aside: [] },
-      field_notes_diff: "diff",
+      field_notes_instructions: "Add note",
     };
-    const { fieldNotesDiff } = parseReply(JSON.stringify(obj), files, {
-      expectFieldNotesDiff: true,
+    const { fieldNotesInstructions } = parseReply(JSON.stringify(obj), files, {
+      expectFieldNotesInstructions: true,
     });
-    expect(fieldNotesDiff).toBe("diff");
+    expect(fieldNotesInstructions).toBe("Add note");
   });
 
   it("extracts field notes markdown", () => {


### PR DESCRIPTION
## Summary
- switch field notes workflow: LLM now emits `field_notes_instructions`
- update second-pass template to apply instructions
- parse new instruction field and pass to second prompt
- document workflow update
- adjust unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fea1d648c8330a226a1e2e81c9e5e