### PR TITLE
Add alt-text requirement to field notes

### DIFF
--- a/docs/field-notes.md
+++ b/docs/field-notes.md
@@ -9,6 +9,7 @@ The `--field-notes` flag enables a lightweight notebook that evolves alongside e
 3. If the model returns a unified diff, it is applied to the notebook and the update timestamp is refreshed. A second pass may be triggered if the patch does not apply cleanly.
 4. Bare filenames such as `DSCF0001.jpg` automatically link to images in the same directory.
 5. When more than three inline images (`![]()`) appear in a single entry a warning is appended so the notes remain compact.
+6. Include a brief description when linking or embedding images, e.g. `[cube overview](DSCF0001.jpg)` or `![cube overview](DSCF0001.jpg)`.
 
 Disable the feature by omitting the flag. Each level keeps its own notebook so progress can be reviewed later.
 

--- a/prompts/default_prompt.hbs
+++ b/prompts/default_prompt.hbs
@@ -42,16 +42,17 @@ When you respond, think step‑by‑step silently and then output **only** a val
 {{#if hasFieldNotes}}
 - "field_notes_md" : the **full, updated contents** of *field‑notes.md* after applying the agreed changes. Provide the entire file for direct replacement—no diffs.
 
-Editorial guidelines for curators in this second pass  
-1. Treat *field‑notes.md* as the canonical, evolving record—every new or altered line must be justified by at least one image from today’s batch; cite it with `[filename.jpg]`.  
-2. You may embed up to **3** thumbnail images using `![](filename.jpg)` when it materially clarifies a point.  
-3. Preserve the existing notebook structure; append where necessary and avoid rearranging previously validated content.  
-4. If a detail is ambiguous, mark it with "(?)" rather than guessing.  
-5. Keep prose concise, factual, and free of speculation—bullet points preferred.  
-6. Before adding new facts, scan earlier sections to prevent duplication; update in place instead of repeating information.  
-7. Verify spelling of part numbers, brands, and measurements against the photo prior to inclusion.  
-8. Ensure every `[filename.jpg]` reference actually exists in today’s batch.  
-9. Return pure JSON—no Markdown fences, no extra keys, no explanatory commentary.  
+Editorial guidelines for curators in this second pass
+1. Treat *field‑notes.md* as the canonical, evolving record—every new or altered line must be justified by at least one image from today’s batch; cite it with `[filename.jpg]`.
+2. You may embed up to **3** thumbnail images using `![](filename.jpg)` when it materially clarifies a point.
+3. Provide a short description whenever linking or embedding an image, e.g. `[cube overview](DSCF0001.jpg)` or `![cube overview](DSCF0001.jpg)`.
+4. Preserve the existing notebook structure; append where necessary and avoid rearranging previously validated content.
+5. If a detail is ambiguous, mark it with "(?)" rather than guessing.
+6. Keep prose concise, factual, and free of speculation—bullet points preferred.
+7. Before adding new facts, scan earlier sections to prevent duplication; update in place instead of repeating information.
+8. Verify spelling of part numbers, brands, and measurements against the photo prior to inclusion.
+9. Ensure every `[filename.jpg]` reference actually exists in today’s batch.
+10. Return pure JSON—no Markdown fences, no extra keys, no explanatory commentary.
 {{/if}}
 
 {{/unless}}


### PR DESCRIPTION
## Summary
- document how to include descriptions with images
- update second pass editorial guidance to require alt text when linking or embedding images

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880187ecaf08330bd71d426d0b8601a