### PR TITLE
Add alt‑text requirement to prompts

### DIFF
--- a/docs/field-notes.md
+++ b/docs/field-notes.md
@@ -9,7 +9,7 @@ The `--field-notes` flag enables a lightweight notebook that evolves alongside e
 3. If the model returns a unified diff, it is applied to the notebook and the update timestamp is refreshed. A second pass may be triggered if the patch does not apply cleanly.
 4. Bare filenames such as `DSCF0001.jpg` automatically link to images in the same directory.
 5. When more than three inline images (`![]()`) appear in a single entry a warning is appended so the notes remain compact.
-6. Include a brief description when linking or embedding images, e.g. `[cube overview](DSCF0001.jpg)` or `![cube overview](DSCF0001.jpg)`.
+6. Include a brief description when linking or embedding images, e.g. `[cube overview](DSCF0001.jpg)` or `![cube overview](DSCF0001.jpg)`. The curatorial template now requires alt‑text for every reference.
 
 Disable the feature by omitting the flag. Each level keeps its own notebook so progress can be reviewed later.
 

--- a/prompts/default_prompt.hbs
+++ b/prompts/default_prompt.hbs
@@ -29,9 +29,9 @@ When you respond, think step‑by‑step silently and then output **only** a val
 
 Rules for **field_notes_instructions**  
 1. Write concise instructions for updating the notebook, justified by today’s images.  
-2. Cite evidence with `[filename.jpg]` links; they will autolink.  
-3. If uncertain, insert a "(?)" marker rather than inventing details.  
-4. Embed ≤ 3 `![]()` inline images.  
+2. Cite evidence with `[descriptive text](filename.jpg)` links; they will autolink.
+3. If uncertain, insert a "(?)" marker rather than inventing details.
+4. Embed ≤ 3 `![descriptive alt-text](filename.jpg)` inline images.
 5. Return pure JSON – no Markdown fences, no commentary, no extra text.  
 {{/if}}
 
@@ -43,15 +43,15 @@ When you respond, think step‑by‑step silently and then output **only** a val
 - "field_notes_md" : the **full, updated contents** of *field‑notes.md* after applying the agreed changes. Provide the entire file for direct replacement—no diffs.
 
 Editorial guidelines for curators in this second pass
-1. **Source‑first mindset** – *field‑notes.md* is the canonical record. Every new or modified line **must** be supported by at least one image from **this** batch; cite it with `[filename.jpg]`.
-2. **Selective thumbnails** – You may embed up to **3** thumbnails using `![](filename.jpg)` **only** when the image materially clarifies a point.
+1. **Source‑first mindset** – *field‑notes.md* is the canonical record. Every new or modified line **must** be supported by at least one image from **this** batch; cite it with `[descriptive text](filename.jpg)`.
+2. **Selective thumbnails** – You may embed up to **3** thumbnails using `![descriptive alt-text](filename.jpg)` **only** when the image materially clarifies a point.
 3. **Descriptive links** – Whenever linking or embedding, add a brief phrase: `[cube overview](DSCF0001.jpg)` or `![cube overview](DSCF0001.jpg)`.
 4. **Structural integrity** – Preserve existing section order; append or update in place rather than rearranging previously validated content. If re‑structuring is warranted, do so sparingly and annotate the move with an image citation.
 5. **Flag uncertainty** – Mark ambiguous details with "(?)" instead of guessing; let the image evidence catch up in a later batch.
 6. **Economy of prose** – Write in concise, factual bullet points; avoid speculation and narrative flourishes.
 7. **De‑duplication check** – Scan earlier sections before adding facts; refine or merge related lines rather than repeating.
 8. **Accuracy audit** – Double‑check spelling of part numbers, brands, and measurements against the photo before entry.
-9. **Existence test** – Ensure every `[filename.jpg]` you cite is present in today’s image list.
+9. **Existence test** – Ensure every `[descriptive text](filename.jpg)` you cite is present in today’s image list.
 10. **Pure JSON output** – Return a JSON object with only the keys "minutes" and "field_notes_md"; no Markdown fences, no extraneous commentary.
 {{/if}}
 


### PR DESCRIPTION
## Summary
- clarify that field-notes links need descriptive text
- mention alt-text requirement in docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68803085bdec83308f84da128456ba1a