### PR TITLE
Add field notes history context

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ through to the script unchanged.
 | `--field-notes` | `false` | Enable notebook updates via field-notes workflow |
 
 When enabled, the tool initializes a git repository in the target directory if one is absent and commits each notebook update using the model's commit message.
+During the second pass the prompt includes the two prior versions of each notebook and the commit log for that level so curators can craft a self-contained update.
 
 See [docs/field-notes.md](docs/field-notes.md) for a description of how the
 notebook system works.

--- a/docs/field-notes.md
+++ b/docs/field-notes.md
@@ -11,6 +11,7 @@ The `--field-notes` flag enables a lightweight notebook that evolves alongside e
 5. When more than three inline images (`![]()`) appear in a single entry a warning is appended so the notes remain compact.
 6. Include a brief description when linking or embedding images, e.g. `[cube overview](DSCF0001.jpg)` or `![cube overview](DSCF0001.jpg)`. The curatorial template now requires alt‑text for every reference.
 7. If the target directory lacks a `.git` repository one is initialized automatically. Updates from the second pass are committed with the curator-provided message.
+8. During the second pass the prompt also includes the two previous versions of `field-notes.md` (when available) along with the commit history for the current level.
 
 Disable the feature by omitting the flag. Each level keeps its own notebook so progress can be reviewed later.
 

--- a/project-overview.txt
+++ b/project-overview.txt
@@ -1576,6 +1576,9 @@ LLM receives identical personas, context, and filename whitelist in both passes.
 | `{{images}}`     | runtime file scan | ✓                         |
 | `{{context}}`    | `--context` file  | optional                  |
 | `{{fieldNotes}}` | prior notebook    | when `--field-notes` flag |
+| `{{fieldNotesPrev}}` | previous notebook version | second pass |
+| `{{fieldNotesPrev2}}` | version before that | second pass |
+| `{{commitMessages}}` | git commit messages | second pass |
 
 ---
 

--- a/prompts/default_prompt.hbs
+++ b/prompts/default_prompt.hbs
@@ -17,6 +17,22 @@ Background for today's review:
 Field‑notes snapshot prior to this batch:
 {{fieldNotes}}
 {{/if}}
+{{#if isSecondPass}}
+{{#if fieldNotesPrev}}
+Previous revision:
+{{fieldNotesPrev}}
+{{/if}}
+{{#if fieldNotesPrev2}}
+Earlier revision:
+{{fieldNotesPrev2}}
+{{/if}}
+{{#if commitMessages}}
+Git commit messages for this level:
+{{#each commitMessages}}
+- {{this}}
+{{/each}}
+{{/if}}
+{{/if}}
 
 {{!-- ──────────────── PASS‑SPECIFIC INSTRUCTIONS ──────────────── --}}
 
@@ -54,6 +70,7 @@ Editorial guidelines for curators in this second pass
 8. **Accuracy audit** – Double‑check spelling of part numbers, brands, and measurements against the photo before entry.
 9. **Existence test** – Ensure every `[descriptive text](filename.jpg)` you cite is present in today’s image list.
 10. **Pure JSON output** – Return a JSON object with only the keys "minutes" and "field_notes_md"; no Markdown fences, no extraneous commentary.
+11. **Self-contained record** – Only the updated file will persist. Summarise any needed context from the history here.
 {{/if}}
 
 {{/unless}}

--- a/src/templates.js
+++ b/src/templates.js
@@ -19,6 +19,9 @@ export async function buildPrompt(
     images = [],
     contextPath,
     fieldNotes,
+    fieldNotesPrev,
+    fieldNotesPrev2,
+    commitMessages,
     hasFieldNotes = false,
     isSecondPass = false,
   }
@@ -31,6 +34,9 @@ export async function buildPrompt(
     images: images.map((f) => path.basename(f)),
     context,
     fieldNotes,
+    fieldNotesPrev,
+    fieldNotesPrev2,
+    commitMessages,
     hasFieldNotes,
     isSecondPass,
   });


### PR DESCRIPTION
## Summary
- include previous revisions and commit log in second-pass prompts
- update prompt with bullet about self-contained notes
- document new placeholders and workflow
- pass history through templates

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688082f7104c8330a80608f016c05ba4