### PR TITLE
Fix ollama vision bug

### DIFF
--- a/src/providers/ollama.js
+++ b/src/providers/ollama.js
@@ -38,7 +38,11 @@ export default class OllamaProvider {
         const flatMessages = [system, { role: 'user', content: textParts.join('\n') }];
         onProgress('request');
         const params = { model, messages: flatMessages, images: imageData, stream: false };
-        if (OLLAMA_FORMAT) {
+
+        // Ollama vision models fail if `format:"json"` is combined with images.
+        // Only request JSON mode when no image data is present so text-only
+        // conversations still benefit from structured output.
+        if (OLLAMA_FORMAT && imageData.length === 0) {
           params.format = OLLAMA_FORMAT;
         }
         const res = await fetch(`${BASE_URL}/api/chat`, {


### PR DESCRIPTION
## Summary
- avoid sending `format:"json"` when calling Ollama with images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888ea3c009883309d50815a78921b9b