### PR TITLE
Align Ollama output length with OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ leave it empty to disable.
 export PHOTO_SELECT_OLLAMA_FORMAT=""  # omit format entirely
 ```
 
+Set `PHOTO_SELECT_OLLAMA_NUM_PREDICT` to control the length of Ollama replies.
+By default it matches the 4096-token limit used for OpenAI.
+
 ### People metadata (optional)
 
 Set `PHOTO_FILTER_API_BASE` to the base URL of your [photo‑filter](https://github.com/openhouse/photo-filter) service to include face‑tag data in the prompt. The CLI assumes the service is available at `http://localhost:3000` when the variable is unset and logs a warning if requests fail. For each image it fetches `/api/photos/by-filename/<filename>/persons` and sends a JSON blob like `{ "filename": "DSCF1234.jpg", "people": ["Alice", "Bob"] }` before the image itself. Results are cached per filename for the duration of the run.


### PR DESCRIPTION
## Summary
- include `MAX_RESPONSE_TOKENS` when calling Ollama
- send `num_predict` to request a longer reply
- document `PHOTO_SELECT_OLLAMA_NUM_PREDICT` environment variable

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68891f96a55c833097b1cade67538ea4