### PR TITLE
Fix Ollama images

### DIFF
--- a/src/providers/ollama.js
+++ b/src/providers/ollama.js
@@ -53,10 +53,12 @@ export default class OllamaProvider {
           },
         ];
         onProgress('request');
+        // Attach images to the single user message per Ollama API
+        flatMessages[0].images = imageData;
+
         const params = {
           model,
           messages: flatMessages,
-          images: imageData,
           stream: false,
           num_predict: OLLAMA_NUM_PREDICT,
         };

--- a/tests/ollamaProvider.test.js
+++ b/tests/ollamaProvider.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import OllamaProvider from '../src/providers/ollama.js';
+
+vi.mock('../src/chatClient.js', () => ({
+  buildMessages: vi.fn(async () => ({
+    messages: [
+      { role: 'system', content: 'sys' },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'info' },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/jpeg;base64,abc' },
+          },
+        ],
+      },
+    ],
+  })),
+  MAX_RESPONSE_TOKENS: 128,
+}));
+
+vi.mock('../src/config.js', () => ({ delay: vi.fn() }));
+
+describe('OllamaProvider', () => {
+  it('includes images within the user message', async () => {
+    const provider = new OllamaProvider();
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ message: { content: 'ok' } }),
+    }));
+    await provider.chat({ prompt: 'p', images: ['img.jpg'], model: 'm' });
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.messages[0].images).toEqual(['abc']);
+    expect(body.images).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- send base64 images inside the chat message for Ollama
- test that images are included inline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68893def32208330a73625faa9adddad