### PR TITLE
Improve debug logging and timeout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ through to the script unchanged.
 | `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |
 | `--parallel` | `1` | Number of batches to process simultaneously |
 | `--field-notes` | `false` | Enable notebook updates via field-notes workflow |
+| `--verbose` | `false` | Print extra logs and save prompts/responses |
 
 When enabled, the tool initializes a git repository in the target directory if one is absent and commits each notebook update using the model's commit message.
 During the second pass the prompt includes the two prior versions of each notebook and the commit log for that level so curators can craft a self-contained update.
@@ -151,7 +152,9 @@ reduces the chance of retry loops on slow requests.
 
 Long vision batches can occasionally exceed the default 5‑minute HTTP timeout.
 The client now waits up to **20 minutes** by default. Set `PHOTO_SELECT_TIMEOUT_MS`
-to override this value if your environment needs a different window.
+or `OLLAMA_HTTP_TIMEOUT` to override this value if your environment
+needs a different window. `OLLAMA_HTTP_TIMEOUT` mirrors the official
+Ollama SDK and is respected when using the bundled provider.
 
 ### JSON-only replies from Ollama
 
@@ -167,7 +170,8 @@ Set `PHOTO_SELECT_OLLAMA_NUM_PREDICT` to control the length of Ollama replies.
 By default it matches the 4096-token limit used for OpenAI.
 
 `PHOTO_SELECT_TIMEOUT_MS` also governs how long the CLI waits for a response
-from either provider. The default is 20 minutes.
+from either provider. The default is 20 minutes. Pass `--verbose` or set
+`PHOTO_SELECT_VERBOSE=1` to print additional debugging output when requests fail.
 
 ### People metadata (optional)
 

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,10 @@ const {
   ollamaBaseUrl,
 } = program.opts();
 
+if (verbose) {
+  process.env.PHOTO_SELECT_VERBOSE = '1';
+}
+
 if (apiKey) {
   process.env.OPENAI_API_KEY = apiKey;
 }

--- a/src/providers/ollama.js
+++ b/src/providers/ollama.js
@@ -4,7 +4,9 @@ import { delay } from '../config.js';
 const BASE_URL = process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
 const DEFAULT_TIMEOUT = 20 * 60 * 1000;
 const TIMEOUT_MS =
-  Number.parseInt(process.env.PHOTO_SELECT_TIMEOUT_MS, 10) || DEFAULT_TIMEOUT;
+  Number.parseInt(process.env.OLLAMA_HTTP_TIMEOUT, 10) ||
+  Number.parseInt(process.env.PHOTO_SELECT_TIMEOUT_MS, 10) ||
+  DEFAULT_TIMEOUT;
 // Allow callers to override the request format, defaulting to JSON for
 // consistent parsing. Set PHOTO_SELECT_OLLAMA_FORMAT to "" to omit the param.
 const OLLAMA_FORMAT =
@@ -82,6 +84,9 @@ export default class OllamaProvider {
         onProgress('done');
         return data.message.content;
       } catch (err) {
+        if (process.env.PHOTO_SELECT_VERBOSE) {
+          console.error('ollama fetch failure:', err);
+        }
         if (attempt >= maxRetries) throw err;
         attempt += 1;
         const wait = 2 ** attempt * 1000;


### PR DESCRIPTION
## Summary
- allow overriding ollama timeout via `OLLAMA_HTTP_TIMEOUT`
- print ollama error details when `--verbose` is used
- expose verbose flag through `PHOTO_SELECT_VERBOSE`
- document new options

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6889b1da99c0833089dc755c73abf251