### PR TITLE
Expand Ollama timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "dotenv": "^16.5.0",
         "handlebars": "^4.7.8",
         "openai": "^4.0.0",
-        "sharp": "^0.34.2"
+        "sharp": "^0.34.2",
+        "undici": "^6.21.3"
       },
       "bin": {
         "photo-select": "src/index.js"
@@ -2630,6 +2631,15 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "dotenv": "^16.5.0",
     "handlebars": "^4.7.8",
     "openai": "^4.0.0",
-    "sharp": "^0.34.2"
+    "sharp": "^0.34.2",
+    "undici": "^6.21.3"
   },
   "devDependencies": {
     "vitest": "^1.5.0"

--- a/src/providers/ollama.js
+++ b/src/providers/ollama.js
@@ -1,5 +1,6 @@
 import { buildMessages, MAX_RESPONSE_TOKENS } from '../chatClient.js';
 import { delay } from '../config.js';
+import { Agent } from 'undici';
 
 const BASE_URL = process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
 const DEFAULT_TIMEOUT = 20 * 60 * 1000;
@@ -7,6 +8,11 @@ const TIMEOUT_MS =
   Number.parseInt(process.env.OLLAMA_HTTP_TIMEOUT, 10) ||
   Number.parseInt(process.env.PHOTO_SELECT_TIMEOUT_MS, 10) ||
   DEFAULT_TIMEOUT;
+const agent = new Agent({
+  connect: { timeout: TIMEOUT_MS },
+  bodyTimeout: TIMEOUT_MS,
+  headersTimeout: TIMEOUT_MS,
+});
 // Allow callers to override the request format, defaulting to JSON for
 // consistent parsing. Set PHOTO_SELECT_OLLAMA_FORMAT to "" to omit the param.
 const OLLAMA_FORMAT =
@@ -70,6 +76,7 @@ export default class OllamaProvider {
           body: JSON.stringify(params),
           signal: controller.signal,
           timeout: TIMEOUT_MS,
+          dispatcher: agent,
         });
         clearTimeout(timer);
         if (res.status === 503) throw new Error('service unavailable');


### PR DESCRIPTION
## Summary
- install `undici`
- ensure Ollama requests use a custom `Agent` that matches the 20‑minute default timeout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a12074d50833086cad7284913c7b8