### PR TITLE
Fix Ollama provider instruction bug

### DIFF
--- a/src/providers/ollama.js
+++ b/src/providers/ollama.js
@@ -36,8 +36,10 @@ export default class OllamaProvider {
         // attach them to the original user message rather than flattening
         // everything into a single block.
         const [system, user] = messages;
+        const injectedText = system.content.trim();
         const textParts = [];
         const imageData = [];
+        if (injectedText) textParts.push(injectedText);
         if (Array.isArray(user.content)) {
           for (const part of user.content) {
             if (part.type === 'text') textParts.push(part.text);


### PR DESCRIPTION
## Summary
- ensure Qwen2.5VL gets the curatorial prompt by prepending the system text to the user message in `OllamaProvider`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a1cb97a948330a13890cafdc14148