### PR TITLE
Add optional verbose payload logging for Ollama

### DIFF
--- a/src/providers/ollama.js
+++ b/src/providers/ollama.js
@@ -26,7 +26,15 @@ const OLLAMA_NUM_PREDICT = Number.parseInt(
 ) || MAX_RESPONSE_TOKENS;
 
 export default class OllamaProvider {
-  async chat({ prompt, images, model, curators = [], maxRetries = 3, onProgress = () => {} }) {
+  async chat({
+    prompt,
+    images,
+    model,
+    curators = [],
+    maxRetries = 3,
+    onProgress = () => {},
+    savePayload,
+  } = {}) {
     let attempt = 0;
     while (true) {
       try {
@@ -70,6 +78,12 @@ export default class OllamaProvider {
         if (OLLAMA_FORMAT && imageData.length === 0) {
           params.format = OLLAMA_FORMAT;
         }
+
+        // ─── save full payload for debugging ────────────────────────────
+        if (typeof savePayload === 'function') {
+          await savePayload(JSON.parse(JSON.stringify(params)));
+        }
+        // ───────────────────────────────────────────────────────────────
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
         const res = await fetch(`${BASE_URL}/api/chat`, {

--- a/tests/ollamaProvider.test.js
+++ b/tests/ollamaProvider.test.js
@@ -35,4 +35,23 @@ describe('OllamaProvider', () => {
     expect(body.messages[1].images).toEqual(['abc']);
     expect(body.images).toBeUndefined();
   });
+
+  it('saves the request payload when provided', async () => {
+    const provider = new OllamaProvider();
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ message: { content: 'ok' } }),
+    }));
+    const saver = vi.fn();
+    await provider.chat({
+      prompt: 'p',
+      images: ['img.jpg'],
+      model: 'm',
+      savePayload: saver,
+    });
+    expect(saver).toHaveBeenCalled();
+    const payload = saver.mock.calls[0][0];
+    expect(payload).toHaveProperty('model', 'm');
+    expect(payload).toHaveProperty('messages');
+  });
 });


### PR DESCRIPTION
## Summary
- log request payloads for debugging when verbose mode is used
- support `savePayload` callback in `OllamaProvider`
- test payload callback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a4609b0008330a35cdab7e5c38631