### PR TITLE
Fix outdated Ollama comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ Both providers generate a JSON schema for each request so vision models return
 typed responses. The environment variables `PHOTO_SELECT_OLLAMA_FORMAT` and
 `PHOTO_SELECT_OPENAI_FORMAT` can override this behaviour and are parsed as JSON
 when the value begins with `{`. Use an empty string to omit the parameter. The
-legacy `"json"` flag remains available for Ollama but can hang with images.
+legacy `"json"` flag is still available for Ollama but is unreliable with
+images; schema-based structured outputs work with vision models.
 
 ```bash
 export PHOTO_SELECT_OLLAMA_FORMAT='{"type":"object","properties":{...}}'
@@ -174,7 +175,7 @@ export PHOTO_SELECT_OLLAMA_FORMAT=""
 ```
 
 Set `PHOTO_SELECT_OLLAMA_NUM_PREDICT` to control the length of Ollama replies.
-By default it matches the 4096-token limit used for OpenAI.
+By default it roughly matches the 4,096-token output limit of many OpenAI models.
 
 `PHOTO_SELECT_TIMEOUT_MS` also governs how long the CLI waits for a response
 from either provider. The default is 20 minutes. Pass `--verbose` or set

--- a/src/providers/ollama.js
+++ b/src/providers/ollama.js
@@ -6,11 +6,12 @@ import { parseFormatEnv } from '../formatOverride.js';
 
 const BASE_URL = process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
 const client = new Ollama({ host: BASE_URL });
-// Check for an environment override. When undefined we generate a schema
+// Check for an environment override. When undefined we generate a JSON schema
 // dynamically for each request. Set the variable to "" to omit the parameter
 // entirely.
 const OLLAMA_FORMAT_OVERRIDE = parseFormatEnv('PHOTO_SELECT_OLLAMA_FORMAT');
-// default to a long response similar to OpenAI's 4096 token cap
+// Default to a long response (~4k tokens) matching the output limit of many
+// OpenAI models.
 const OLLAMA_NUM_PREDICT = Number.parseInt(
   process.env.PHOTO_SELECT_OLLAMA_NUM_PREDICT,
   10
@@ -63,7 +64,9 @@ export default class OllamaProvider {
         };
 
         // Build the request format. If an environment override is not provided
-        // generate a schema that matches the expected reply shape.
+        // generate a structured-output schema matching the expected reply
+        // shape. Legacy "json" mode remains available but is unreliable with
+        // images.
         let format = OLLAMA_FORMAT_OVERRIDE;
         if (format === undefined) {
           format = buildReplySchema({


### PR DESCRIPTION
## Summary
- document JSON schema output in the Ollama provider
- note that the legacy `json` mode is unreliable with images
- clarify token limit comment in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bc68d248083309a23dfab11734878