### PR TITLE
feat: add worker-based batching option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,15 +104,16 @@ through to the script unchanged.
 | `--context` | *(unset)* | Text file with exhibition context for the curators |
 | `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |
 | `--parallel` | `1` | Number of batches to process simultaneously |
+| `--workers` | *(unset)* | Max number of worker processes; each starts a new batch as soon as it finishes |
 
 ### Increasing memory
 
-The Node.js heap defaults to about 4 GB. Large runs with `--parallel` greater than 1
+The Node.js heap defaults to about 4 GB. Large runs with `--parallel` or `--workers` greater than 1
 may exhaust that limit. Set `PHOTO_SELECT_MAX_OLD_SPACE_MB` to allocate more memory:
 
 ```bash
 PHOTO_SELECT_MAX_OLD_SPACE_MB=8192 \
-  /path/to/photo-select/photo-select-here.sh --parallel 10 --api-key sk-...
+  /path/to/photo-select/photo-select-here.sh --workers 10 --api-key sk-...
 ```
 
 The value is passed directly to `--max-old-space-size`, so adjust it to match your
@@ -123,7 +124,10 @@ available RAM.
 Running multiple batches at once hides API latency but can exhaust system resources. See
 [`docs/parallel-playbook.md`](docs/parallel-playbook.md) for a practical guide on
 tuning this flag. In short, start around twice your physical core count and adjust
-until network waits dominate without hitting OpenAI rate limits.
+until network waits dominate without hitting OpenAI rate limits. Alternatively, use
+`--workers` to keep a steady stream of batches without waiting for entire groups to
+finish. Files omitted from a batch are requeued and picked up by the next available
+worker so each level fully resolves before recursion continues.
 
 ### Streaming responses
 

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,11 @@ program
   )
   .option("--no-recurse", "Process a single directory only")
   .option("-P, --parallel <n>", "Number of concurrent API calls", (v) => Math.max(1, parseInt(v, 10)), 1)
+  .option(
+    "--workers <n>",
+    "Number of worker processes (each runs batches sequentially)",
+    (v) => Math.max(1, parseInt(v, 10))
+  )
   .parse(process.argv);
 
 const {
@@ -58,6 +63,7 @@ const {
   curators,
   context: contextPath,
   parallel,
+  workers,
   ollamaBaseUrl,
 } = program.opts();
 
@@ -95,6 +101,7 @@ if (!finalModel) {
       curators,
       contextPath,
       parallel,
+      workers,
     });
     console.log("🎉  Finished triaging.");
   } catch (err) {

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -30,6 +30,7 @@ function formatDuration(ms) {
  * @param {string[]} [options.curators=[]]   Names inserted into the prompt
  * @param {string} [options.contextPath]     Optional additional context file
  * @param {number} [options.parallel=1]      Number of API requests to run simultaneously
+ * @param {number} [options.workers]         Number of worker processes for dynamic batches
  * @param {number} [options.depth=0]         Internal recursion depth (for logging)
 */
 export async function triageDirectory({
@@ -41,6 +42,7 @@ export async function triageDirectory({
   curators = [],
   contextPath,
   parallel = 1,
+  workers,
   depth = 0,
 }) {
   if (!provider) {
@@ -128,90 +130,175 @@ export async function triageDirectory({
 
     console.log(`${indent}📊  ${images.length} unclassified image(s) found`);
 
-    // Step 1 – select up to parallel × 10 images
-    const total = Math.min(images.length, parallel * 10);
-    const selection = pickRandom(images, total);
-    console.log(`${indent}🔍  Selected ${selection.length} image(s)`);
+    if (workers && workers > 0) {
+      const queue = pickRandom(images, images.length);
+      console.log(
+        `${indent}⏳  Processing ${queue.length} image(s) with ${workers} worker(s)…`
+      );
 
-    const batches = [];
-    for (let i = 0; i < selection.length; i += 10) {
-      batches.push(selection.slice(i, i + 10));
-    }
+      const multibar = new MultiBar(
+        {
+          clearOnComplete: false,
+          hideCursor: true,
+          format: `${indent}{prefix} |{bar}| {stage}`,
+        },
+        Presets.shades_classic
+      );
+      const stageMap = { encoding: 1, request: 2, waiting: 3, done: 4 };
+      const getBar = (idx) =>
+        multibar.create(4, 0, { prefix: `Batch ${idx}`, stage: "queued" });
 
-    console.log(`${indent}⏳  Sending ${batches.length} batch(es) to ChatGPT…`);
+      let batchIdx = 0;
+      const nextBatch = () => (queue.length ? queue.splice(0, 10) : null);
 
-    const multibar = new MultiBar(
-      {
-        clearOnComplete: false,
-        hideCursor: true,
-        format: `${indent}{prefix} |{bar}| {stage}`,
-      },
-      Presets.shades_classic
-    );
-    const stageMap = { encoding: 1, request: 2, waiting: 3, done: 4 };
-    const bars = batches.map((_, i) =>
-      multibar.create(4, 0, { prefix: `Batch ${i + 1}`, stage: "queued" })
-    );
+      async function workerFn() {
+        while (true) {
+          const batch = nextBatch();
+          if (!batch) break;
+          const idx = ++batchIdx;
+          const bar = getBar(idx);
+          await batchStore.run({ batch: idx }, async () => {
+            try {
+              const start = Date.now();
+              const reply = await provider.chat({
+                prompt,
+                images: batch,
+                model,
+                curators,
+                onProgress: (stage) => {
+                  bar.update(stageMap[stage] || 0, { stage });
+                },
+                stream: true,
+              });
+              const ms = Date.now() - start;
+              bar.update(4, { stage: "done" });
+              bar.stop();
+              console.log(`${indent}🤖  ChatGPT reply:\n${reply}`);
+              console.log(`${indent}⏱️  Batch ${idx} completed in ${(ms / 1000).toFixed(1)}s`);
 
-    let nextIndex = 0;
-    async function worker() {
-      while (true) {
-        const idx = nextIndex++;
-        if (idx >= batches.length) break;
-        const batch = batches[idx];
-        const bar = bars[idx];
-        await batchStore.run({ batch: idx + 1 }, async () => {
-          try {
-            const start = Date.now();
-            const reply = await provider.chat({
-              prompt,
-              images: batch,
-              model,
-              curators,
-              onProgress: (stage) => {
-                bar.update(stageMap[stage] || 0, { stage });
-              },
-              stream: true,
-            });
-            const ms = Date.now() - start;
-            bar.update(4, { stage: "done" });
-            bar.stop();
-            console.log(`${indent}🤖  ChatGPT reply:\n${reply}`);
-            console.log(`${indent}⏱️  Batch ${idx + 1} completed in ${(ms / 1000).toFixed(1)}s`);
+              const { keep, aside, unclassified, notes, minutes } = parseReply(
+                reply,
+                batch
+              );
+              if (minutes.length) {
+                const uuid = crypto.randomUUID();
+                const minutesFile = path.join(dir, `minutes-${uuid}.txt`);
+                await writeFile(minutesFile, minutes.join('\n'), 'utf8');
+                console.log(`${indent}📝  Saved meeting minutes to ${minutesFile}`);
+              }
 
-            const { keep, aside, notes, minutes } = parseReply(reply, batch);
-            if (minutes.length) {
-              const uuid = crypto.randomUUID();
-              const minutesFile = path.join(dir, `minutes-${uuid}.txt`);
-              await writeFile(minutesFile, minutes.join('\n'), 'utf8');
-              console.log(`${indent}📝  Saved meeting minutes to ${minutesFile}`);
+              const keepDir = path.join(dir, "_keep");
+              const asideDir = path.join(dir, "_aside");
+              await Promise.all([
+                moveFiles(keep, keepDir, notes),
+                moveFiles(aside, asideDir, notes),
+              ]);
+
+              if (unclassified.length) {
+                queue.push(...unclassified);
+              }
+
+              console.log(
+                `📂  Moved: ${keep.length} keep → ${keepDir}, ${aside.length} aside → ${asideDir}`
+              );
+            } catch (err) {
+              bar.update(4, { stage: "error" });
+              bar.stop();
+              console.warn(`${indent}⚠️  Batch ${idx} failed: ${err.message}`);
             }
-
-            const keepDir = path.join(dir, "_keep");
-            const asideDir = path.join(dir, "_aside");
-            await Promise.all([
-              moveFiles(keep, keepDir, notes),
-              moveFiles(aside, asideDir, notes),
-            ]);
-
-            console.log(
-              `📂  Moved: ${keep.length} keep → ${keepDir}, ${aside.length} aside → ${asideDir}`
-            );
-          } catch (err) {
-            bar.update(4, { stage: "error" });
-            bar.stop();
-            console.warn(`${indent}⚠️  Batch ${idx + 1} failed: ${err.message}`);
-          }
-        });
+          });
+        }
       }
-    }
 
-    const workers = Array.from(
-      { length: Math.min(parallel, batches.length) },
-      () => worker()
-    );
-    await Promise.all(workers);
-    multibar.stop();
+      const pool = Array.from(
+        { length: Math.min(workers, Math.max(queue.length, 1)) },
+        () => workerFn()
+      );
+      await Promise.all(pool);
+      multibar.stop();
+    } else {
+      const total = Math.min(images.length, parallel * 10);
+      const selection = pickRandom(images, total);
+      console.log(`${indent}🔍  Selected ${selection.length} image(s)`);
+      const batches = [];
+      for (let i = 0; i < selection.length; i += 10) {
+        batches.push(selection.slice(i, i + 10));
+      }
+      console.log(`${indent}⏳  Sending ${batches.length} batch(es) to ChatGPT…`);
+
+      const multibar = new MultiBar(
+        {
+          clearOnComplete: false,
+          hideCursor: true,
+          format: `${indent}{prefix} |{bar}| {stage}`,
+        },
+        Presets.shades_classic
+      );
+      const stageMap = { encoding: 1, request: 2, waiting: 3, done: 4 };
+      const bars = batches.map((_, i) =>
+        multibar.create(4, 0, { prefix: `Batch ${i + 1}`, stage: "queued" })
+      );
+
+      let nextIndex = 0;
+      async function workerFn() {
+        while (true) {
+          const idx = nextIndex++;
+          if (idx >= batches.length) break;
+          const batch = batches[idx];
+          const bar = bars[idx];
+          await batchStore.run({ batch: idx + 1 }, async () => {
+            try {
+              const start = Date.now();
+              const reply = await provider.chat({
+                prompt,
+                images: batch,
+                model,
+                curators,
+                onProgress: (stage) => {
+                  bar.update(stageMap[stage] || 0, { stage });
+                },
+                stream: true,
+              });
+              const ms = Date.now() - start;
+              bar.update(4, { stage: "done" });
+              bar.stop();
+              console.log(`${indent}🤖  ChatGPT reply:\n${reply}`);
+              console.log(`${indent}⏱️  Batch ${idx + 1} completed in ${(ms / 1000).toFixed(1)}s`);
+
+              const { keep, aside, notes, minutes } = parseReply(reply, batch);
+              if (minutes.length) {
+                const uuid = crypto.randomUUID();
+                const minutesFile = path.join(dir, `minutes-${uuid}.txt`);
+                await writeFile(minutesFile, minutes.join('\n'), 'utf8');
+                console.log(`${indent}📝  Saved meeting minutes to ${minutesFile}`);
+              }
+
+              const keepDir = path.join(dir, "_keep");
+              const asideDir = path.join(dir, "_aside");
+              await Promise.all([
+                moveFiles(keep, keepDir, notes),
+                moveFiles(aside, asideDir, notes),
+              ]);
+
+              console.log(
+                `📂  Moved: ${keep.length} keep → ${keepDir}, ${aside.length} aside → ${asideDir}`
+              );
+            } catch (err) {
+              bar.update(4, { stage: "error" });
+              bar.stop();
+              console.warn(`${indent}⚠️  Batch ${idx + 1} failed: ${err.message}`);
+            }
+          });
+        }
+      }
+
+      const pool = Array.from(
+        { length: Math.min(parallel, batches.length) },
+        () => workerFn()
+      );
+      await Promise.all(pool);
+      multibar.stop();
+    }
     const remaining = (await listImages(dir)).length;
     const processed = totalImages - remaining;
     if (processed) {
@@ -242,6 +329,7 @@ export async function triageDirectory({
         curators,
         contextPath,
         parallel,
+        workers,
         depth: depth + 1,
       });
     } else {

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -107,6 +107,50 @@ describe("triageDirectory", () => {
     await expect(fs.stat(asidePath)).resolves.toBeTruthy();
   });
 
+  it("processes batches with workers", async () => {
+    chatCompletion
+      .mockResolvedValueOnce(JSON.stringify({ keep: ["1.jpg"], aside: [] }))
+      .mockResolvedValueOnce(JSON.stringify({ keep: [], aside: ["2.jpg"] }));
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: false,
+      workers: 2,
+    });
+    expect(chatCompletion).toHaveBeenCalledTimes(2);
+    const keepPath = path.join(tmpDir, "_keep", "1.jpg");
+    const asidePath = path.join(tmpDir, "_aside", "2.jpg");
+    await expect(fs.stat(keepPath)).resolves.toBeTruthy();
+    await expect(fs.stat(asidePath)).resolves.toBeTruthy();
+  });
+
+  it("requeues unclassified images with workers", async () => {
+    await fs.writeFile(path.join(tmpDir, "3.jpg"), "c");
+    chatCompletion
+      .mockResolvedValueOnce(JSON.stringify({ keep: ["1.jpg"], aside: [] }))
+      .mockResolvedValueOnce(
+        JSON.stringify({ keep: [], aside: ["2.jpg", "3.jpg"] })
+      );
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: false,
+      workers: 2,
+    });
+    expect(chatCompletion).toHaveBeenCalledTimes(2);
+    await expect(
+      fs.stat(path.join(tmpDir, "_keep", "1.jpg"))
+    ).resolves.toBeTruthy();
+    await expect(
+      fs.stat(path.join(tmpDir, "_aside", "2.jpg"))
+    ).resolves.toBeTruthy();
+    await expect(
+      fs.stat(path.join(tmpDir, "_aside", "3.jpg"))
+    ).resolves.toBeTruthy();
+  });
+
   it("retries after chat errors", async () => {
     chatCompletion
       .mockRejectedValueOnce(new Error("timeout"))


### PR DESCRIPTION
## Summary
- add `--workers` CLI flag for dynamic batching
- support worker pool in triage orchestrator
- document worker flag and add tests
- requeue unclassified images so workers finish each level

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fa4d42bd883308ffcaa3a65bb53f8