### PR TITLE
feat: add worker-based batching option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,15 +104,16 @@ through to the script unchanged.
 | `--context` | *(unset)* | Text file with exhibition context for the curators |
 | `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |
 | `--parallel` | `1` | Number of batches to process simultaneously |
+| `--workers` | *(unset)* | Max number of worker processes; each starts a new batch as soon as it finishes |
 
 ### Increasing memory
 
-The Node.js heap defaults to about 4 GB. Large runs with `--parallel` greater than 1
+The Node.js heap defaults to about 4 GB. Large runs with `--parallel` or `--workers` greater than 1
 may exhaust that limit. Set `PHOTO_SELECT_MAX_OLD_SPACE_MB` to allocate more memory:
 
 ```bash
 PHOTO_SELECT_MAX_OLD_SPACE_MB=8192 \
-  /path/to/photo-select/photo-select-here.sh --parallel 10 --api-key sk-...
+  /path/to/photo-select/photo-select-here.sh --workers 10 --api-key sk-...
 ```
 
 The value is passed directly to `--max-old-space-size`, so adjust it to match your
@@ -123,7 +124,10 @@ available RAM.
 Running multiple batches at once hides API latency but can exhaust system resources. See
 [`docs/parallel-playbook.md`](docs/parallel-playbook.md) for a practical guide on
 tuning this flag. In short, start around twice your physical core count and adjust
-until network waits dominate without hitting OpenAI rate limits.
+until network waits dominate without hitting OpenAI rate limits. Alternatively, use
+`--workers` to keep a steady stream of batches without waiting for entire groups to
+finish. Files omitted from a batch are requeued and picked up by the next available
+worker so each level fully resolves before recursion continues.
 
 ### Streaming responses
 

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,11 @@ program
   )
   .option("--no-recurse", "Process a single directory only")
   .option("-P, --parallel <n>", "Number of concurrent API calls", (v) => Math.max(1, parseInt(v, 10)), 1)
+  .option(
+    "--workers <n>",
+    "Number of worker processes (each runs batches sequentially)",
+    (v) => Math.max(1, parseInt(v, 10))
+  )
   .parse(process.argv);
 
 const {
@@ -58,6 +63,7 @@ const {
   curators,
   context: contextPath,
   parallel,
+  workers,
   ollamaBaseUrl,
 } = program.opts();
 
@@ -95,6 +101,7 @@ if (!finalModel) {
       curators,
       contextPath,
       parallel,
+      workers,
     });
     console.log("🎉  Finished triaging.");
   } catch (err) {

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -107,6 +107,55 @@ describe("triageDirectory", () => {
     await expect(fs.stat(asidePath)).resolves.toBeTruthy();
   });
 
+  it("processes batches with workers", async () => {
+    chatCompletion
+      .mockResolvedValueOnce(JSON.stringify({ keep: ["1.jpg"], aside: [] }))
+      .mockResolvedValueOnce(JSON.stringify({ keep: [], aside: ["2.jpg"] }));
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: false,
+      workers: 2,
+    });
+    const etaLogs = logSpy.mock.calls.filter(([m]) =>
+      m.includes("ETA to finish level")
+    );
+    expect(etaLogs.length).toBeGreaterThanOrEqual(2);
+    expect(chatCompletion).toHaveBeenCalledTimes(2);
+    const keepPath = path.join(tmpDir, "_keep", "1.jpg");
+    const asidePath = path.join(tmpDir, "_aside", "2.jpg");
+    await expect(fs.stat(keepPath)).resolves.toBeTruthy();
+    await expect(fs.stat(asidePath)).resolves.toBeTruthy();
+  });
+
+  it("requeues unclassified images with workers", async () => {
+    await fs.writeFile(path.join(tmpDir, "3.jpg"), "c");
+    chatCompletion
+      .mockResolvedValueOnce(JSON.stringify({ keep: ["1.jpg"], aside: [] }))
+      .mockResolvedValueOnce(
+        JSON.stringify({ keep: [], aside: ["2.jpg", "3.jpg"] })
+      );
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: false,
+      workers: 2,
+    });
+    expect(chatCompletion).toHaveBeenCalledTimes(2);
+    await expect(
+      fs.stat(path.join(tmpDir, "_keep", "1.jpg"))
+    ).resolves.toBeTruthy();
+    await expect(
+      fs.stat(path.join(tmpDir, "_aside", "2.jpg"))
+    ).resolves.toBeTruthy();
+    await expect(
+      fs.stat(path.join(tmpDir, "_aside", "3.jpg"))
+    ).resolves.toBeTruthy();
+  });
+
   it("retries after chat errors", async () => {
     chatCompletion
       .mockRejectedValueOnce(new Error("timeout"))


### PR DESCRIPTION
## Summary
- add `--workers` CLI flag for dynamic batching
- support worker pool in triage orchestrator
- document worker flag and add tests
- requeue unclassified images so workers finish each level
- show per-batch ETA for worker mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fa4d42bd883308ffcaa3a65bb53f8