### PR TITLE
feat: support revisit decisions for undecided photos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ LLM receives identical personas, context, and filename whitelist in both passes.
 ## 3  Reply Schema Invariants
 
 - **minutes** → `array<{ speaker:string, text:string }>`; last `text` ends with a forward‑looking question.
-- **decision** → object with optional keys **exactly** `"keep"` and `"aside"`; each maps `filename → rationale`.
+ - **decision** → object with optional keys **exactly** `"keep"`, `"aside"`, and `"revisit"`; each maps `filename → rationale`.
 - **field_notes_diff** or **field_notes_md** as per Phase rules.
 - **No additional top‑level keys**.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # photo‑select
 
-A command‑line workflow that **selects 10 random images, asks ChatGPT which to “keep” or “set aside,”
+A command‑line workflow that **selects 10 random images, asks ChatGPT which to “keep,” “revisit,” or “set aside,”
 moves the files accordingly, and then recurses until a directory is fully triaged.**
 
 ---
@@ -309,9 +309,9 @@ through that API, so no extra flags are needed.
 
 1. Pick up to 10 random images (all common photo extensions).
 2. Send them to ChatGPT with the prompt (filenames included).
-3. ChatGPT replies with meeting minutes summarising a short discussion among the curators, followed by a JSON object indicating which files to keep or set aside and why.
-4. Parse that JSON to determine which files were explicitly labeled `keep` or `aside` and capture any notes about each image.
-5. Move those files to the corresponding sub‑folders and write a text file containing the notes next to each image. Files omitted from the decision block remain in place for the next batch so the model can review them again. Meeting minutes are saved as `minutes-<timestamp>.txt` in the directory.
+3. ChatGPT replies with meeting minutes summarising a short discussion among the curators, followed by a JSON object indicating which files to keep, revisit, or set aside and why.
+4. Parse that JSON to determine which files were explicitly labeled `keep` or `aside` and capture any notes about each image. Files labeled `revisit` are noted but left in place.
+5. Move the `keep` and `aside` files to the corresponding sub‑folders and write a text file containing the notes next to each image. Files omitted from the decision block or tagged `revisit` remain in place for the next batch so the model can review them again. Meeting minutes are saved as `minutes-<timestamp>.txt` in the directory.
 6. Re‑run the algorithm on the newly created `_keep` folder (unless `--no-recurse`).
    If every photo at a level is kept or every photo is set aside, recursion stops early.
 7. On the first pass of each level a `_level-XXX` folder is created next to `_keep` and `_aside` containing a snapshot of the images originally present. If any files fail to copy after three retries (common on network drives), their paths are recorded in `failed-archives.txt` inside that folder.

--- a/prompts/default_prompt.txt
+++ b/prompts/default_prompt.txt
@@ -8,7 +8,7 @@ Reflect the thoughtful, iterative process described in the briefing: curators sh
 
 After capturing these remarks as meeting minutes, output a JSON object summarising the final decision:
 
-If you are uncertain about a photo, **omit it from the decision block**.
+If you are uncertain about a photo, you may list it under `revisit` to defer the choice. Photos omitted from the decision block will also be revisited later.
 Never invent filenames or keys.
 
 {
@@ -23,6 +23,10 @@ Never invent filenames or keys.
     },
     "aside": {
       "filename2.jpg": "why it is set aside",
+      ...
+    },
+    "revisit": {
+      "filename3.jpg": "why it should be reconsidered later",
       ...
     }
   }

--- a/prompts/default_prompt_olympia.txt
+++ b/prompts/default_prompt_olympia.txt
@@ -6,7 +6,7 @@ I am going to make some fine art photo prints of my friend Olympia Kazi's 50th b
 
 Would you help me make selections? 
 
-I'm going to share photos with you 10 at a time. Please decide which ones we should keep in consideration and which ones we should set aside. Use the **exact** filenames provided. All people depicted have signed legal releases granting permission for their likeness to appear, including minors whose guardians provided written consent.
+I'm going to share photos with you 10 at a time. Please decide which ones we should keep in consideration, which ones we should revisit later, and which ones we should set aside. Use the **exact** filenames provided. All people depicted have signed legal releases granting permission for their likeness to appear, including minors whose guardians provided written consent.
 
 Respond *only* with a JSON object of the form:
 
@@ -18,10 +18,14 @@ Respond *only* with a JSON object of the form:
   "aside": {
     "filename2.jpg": "[Please share your valued observations and thoughts on this image, here.]",
     ...
+  },
+  "revisit": {
+    "filename3.jpg": "[Please share your valued observations and thoughts on why this image should be reconsidered later.]",
+    ...
   }
 }
 
-Every filename must appear exactly once as a key in either "keep" or "aside". Include your observations on each image. No other text.
+Every filename must appear exactly once as a key in either "keep", "revisit", or "aside". Include your observations on each image. No other text.
 
 ===
 

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -102,6 +102,14 @@ describe("parseReply", () => {
     expect(aside).not.toContain(files[0]);
   });
 
+  it("parses revisit directives", () => {
+    const reply = JSON.stringify({ keep: ["DSCF1234.jpg"], revisit: ["DSCF5678.jpg"] });
+    const { keep, revisit, unclassified } = parseReply(reply, files);
+    expect(keep).toContain(files[0]);
+    expect(revisit).toContain(files[1]);
+    expect(unclassified).toContain(files[2]);
+  });
+
   it("parses minutes and nested decision", () => {
     const reply = JSON.stringify({
       minutes: [{ speaker: "Curator", text: "looks good" }],


### PR DESCRIPTION
## Summary
- allow `revisit` decisions in contract and default prompts so curators can defer uncertain images
- parse and normalize new `revisit` category in chat client, leaving those files unmoved
- document and test `revisit` flow, expanding README and parser tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68901c4d9f188330acb4e78d456d3f0a