### PR TITLE
fix: include format name for responses API

### DIFF
--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -347,7 +347,11 @@ export async function chatCompletion({
           input,
           text: {
             verbosity,
-            format: { type: 'json_schema', json_schema: schema },
+            format: {
+              type: 'json_schema',
+              name: schema.name,
+              schema: schema.schema,
+            },
           },
           reasoning: { effort: reasoningEffort },
           max_output_tokens: MAX_RESPONSE_TOKENS,
@@ -441,7 +445,11 @@ export async function chatCompletion({
           instructions,
           input,
           text: {
-            format: { type: 'json_schema', json_schema: schema },
+            format: {
+              type: 'json_schema',
+              name: schema.name,
+              schema: schema.schema,
+            },
             verbosity,
           },
           reasoning: { effort: reasoningEffort },

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -294,8 +294,9 @@ describe("chatCompletion", () => {
     expect(args.text.verbosity).toBe("low");
     expect(args.reasoning.effort).toBe("minimal");
     expect(args.text.format.type).toBe("json_schema");
+    expect(args.text.format.name).toBe("photo_select_decision");
     expect(
-      args.text.format.json_schema.schema.properties.minutes.items.properties.speaker.enum
+      args.text.format.schema.properties.minutes.items.properties.speaker.enum
     ).toContain("Jamie");
     expect(result).toBe("ok");
   });


### PR DESCRIPTION
## Summary
- include required `name` and `schema` fields when requesting structured JSON via the Responses API
- update unit test expectations accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68993abe27888330be6bfe38f30afc76