### PR TITLE
fix response schema for decision items

### DIFF
--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -84,7 +84,11 @@ export const MAX_RESPONSE_TOKENS = 4096;
 export function buildGPT5Schema({ files = [], speakers = [] }) {
   const decisionItem = {
     type: 'object',
-    required: ['file'],
+    // OpenAI's response schema requires every property to be listed in
+    // `required`, even if semantically optional. Making `reason` required
+    // keeps the schema valid; callers can supply an empty string when no
+    // rationale is available.
+    required: ['file', 'reason'],
     additionalProperties: false,
     properties: {
       file: { type: 'string', enum: files },

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -298,6 +298,9 @@ describe("chatCompletion", () => {
     expect(
       args.text.format.schema.properties.minutes.items.properties.speaker.enum
     ).toContain("Jamie");
+    expect(
+      args.text.format.schema.properties.keep.items.required
+    ).toEqual(["file", "reason"]);
     expect(result).toBe("ok");
   });
 


### PR DESCRIPTION
## Summary
- make `reason` required in decision items so OpenAI response format accepts schema
- test expected required fields in schema

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68993e0300088330aec94db48e4e362c