### PR TITLE
Require reasons in photo decision schema

### DIFF
--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -84,7 +84,7 @@ export const MAX_RESPONSE_TOKENS = 4096;
 export function buildGPT5Schema({ files = [], speakers = [] }) {
   const decisionItem = {
     type: 'object',
-    required: ['file'],
+    required: ['file', 'reason'],
     additionalProperties: false,
     properties: {
       file: { type: 'string', enum: files },
@@ -140,7 +140,7 @@ function ensureJsonMention(text) {
 }
 
 const CACHE_DIR = path.resolve('.cache');
-const CACHE_KEY_PREFIX = 'v3';
+const CACHE_KEY_PREFIX = 'v4';
 
 async function getCachedReply(key) {
   try {
@@ -351,6 +351,7 @@ export async function chatCompletion({
               type: 'json_schema',
               name: schema.name,
               schema: schema.schema,
+              strict: true,
             },
           },
           reasoning: { effort: reasoningEffort },
@@ -449,6 +450,7 @@ export async function chatCompletion({
               type: 'json_schema',
               name: schema.name,
               schema: schema.schema,
+              strict: true,
             },
             verbosity,
           },

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -295,6 +295,7 @@ describe("chatCompletion", () => {
     expect(args.reasoning.effort).toBe("minimal");
     expect(args.text.format.type).toBe("json_schema");
     expect(args.text.format.name).toBe("photo_select_decision");
+    expect(args.text.format.strict).toBe(true);
     expect(
       args.text.format.schema.properties.minutes.items.properties.speaker.enum
     ).toContain("Jamie");
@@ -400,6 +401,10 @@ describe("buildGPT5Schema", () => {
     expect(
       schema.schema.properties.minutes.items.properties.speaker.enum
     ).toEqual(["Jamie", "Alexandra Munroe"]);
+    expect(schema.schema.properties.keep.items.required).toEqual([
+      "file",
+      "reason",
+    ]);
   });
 
   it("provides batch helper", () => {


### PR DESCRIPTION
## Summary
- ensure `reason` is mandatory for each decision entry in GPT-5 schema
- enable strict JSON schema enforcement and bump cache key prefix
- test coverage for strict mode and required fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68993f2177f88330a8064cb6c94924bd