### PR TITLE
Handle structured responses and add debug logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules
 /.env
 .DS_Store
+.debug

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -196,6 +196,14 @@ export async function triageDirectory({
                   batch,
                   { model, verbosity, reasoningEffort }
                 );
+                if (process.env.PHOTO_SELECT_DEBUG) {
+                  log(
+                    `${indent}\uD83D\uDC1B  Counts: keep=${keep.length}, aside=${aside.length}, unclassified=${unclassified.length}, notes=${notes.size}`
+                  );
+                  for (const [f, note] of notes) {
+                    log(`${indent}\uD83D\uDCDD  ${path.basename(f)} → ${note}`);
+                  }
+                }
                 if (minutes.length) {
                   const uuid = crypto.randomUUID();
                   const minutesFile = path.join(dir, `minutes-${uuid}.txt`);
@@ -304,11 +312,19 @@ export async function triageDirectory({
                 log(`${indent}🤖  ChatGPT reply:\n${reply}`);
                 log(`${indent}⏱️  Batch ${idx + 1} completed in ${(ms / 1000).toFixed(1)}s`);
 
-                const { keep, aside, notes, minutes } = parseReply(
+                const { keep, aside, unclassified = [], notes, minutes } = parseReply(
                   reply,
                   batch,
                   { model, verbosity, reasoningEffort }
                 );
+                if (process.env.PHOTO_SELECT_DEBUG) {
+                  log(
+                    `${indent}\uD83D\uDC1B  Counts: keep=${keep.length}, aside=${aside.length}, unclassified=${unclassified.length}, notes=${notes.size}`
+                  );
+                  for (const [f, note] of notes) {
+                    log(`${indent}\uD83D\uDCDD  ${path.basename(f)} \u2192 ${note}`);
+                  }
+                }
                 if (minutes.length) {
                   const uuid = crypto.randomUUID();
                   const minutesFile = path.join(dir, `minutes-${uuid}.txt`);


### PR DESCRIPTION
## Summary
- extract JSON payloads from Responses API when `output_text` is empty
- write diagnostics and raw payloads to `.debug` for troubleshooting
- enable optional debug counts and per-file notes in orchestrator
- add regression test for `output_json` handling and ignore `.debug`
- return parsed JSON from structured-response extractor and cap debug dumps at 5 MB
- document decision schema fields and update tests accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68995bb4353c8330863d39d2d19fc35e