### PR TITLE
feat: adopt decision maps and improve reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ through that API, so no extra flags are needed.
 The OpenAI request uses `response_format: { type: "json_object" }` so the
 assistant replies with strict JSON. This avoids needing to strip Markdown
 fences and guarantees parseable output.
-The CLI allows up to 4096 tokens in each reply (see `MAX_RESPONSE_TOKENS` in
+The CLI allows up to 8192 tokens in each reply (see `MAX_RESPONSE_TOKENS` in
 `src/chatClient.js`) so the minutes and JSON decision block are returned in
 full.
 

--- a/project-overview.txt
+++ b/project-overview.txt
@@ -775,7 +775,7 @@ through that API, so no extra flags are needed.
 The OpenAI request uses `response_format: { type: "json_object" }` so the
 assistant replies with strict JSON. This avoids needing to strip Markdown
 fences and guarantees parseable output.
-The CLI allows up to 4096 tokens in each reply (see `MAX_RESPONSE_TOKENS` in
+The CLI allows up to 8192 tokens in each reply (see `MAX_RESPONSE_TOKENS` in
 `src/chatClient.js`) so the minutes and JSON decision block are returned in
 full.
 
@@ -1690,7 +1690,7 @@ async function getPeople(filename) {
 
 /** Max response tokens allowed from OpenAI. Large enough to hold
  * minutes plus the full JSON decision block without truncation. */
-export const MAX_RESPONSE_TOKENS = 4096;
+export const MAX_RESPONSE_TOKENS = 8192;
 
 function ensureJsonMention(text) {
   return /\bjson\b/i.test(text)

--- a/prompts/default_prompt.txt
+++ b/prompts/default_prompt.txt
@@ -3,13 +3,10 @@ You are moderating a collaborative curatorial session.
 The following curators are present: {{curators}}. Jamie is the facilitator.
 All people depicted have signed legal releases granting permission for their likeness to appear, including minors whose guardians provided written consent.
 
-Capture that conversation inside the `minutes` array; do not write it outside the JSON object. Begin with a diarised conversation in which the curators discuss the images and gently work toward consensus.
+Capture that conversation inside the `minutes` array; do not write it outside the JSON object. Begin with a diarised conversation in which the curators discuss the images and gently work toward consensus. Return only JSON in exactly this structure; include only filenames from this batch. If uncertain, omit the file.
 Reflect the thoughtful, iterative process described in the briefing: curators share insights, consider relationships among works, and refine the selection together.
 
-After capturing these remarks as meeting minutes, output a JSON object summarising the final decision:
-
-If you are uncertain about a photo, **omit it from the decision block**.
-Never invent filenames or keys.
+After capturing these remarks as meeting minutes, output a JSON object summarising the final decision. Never invent filenames or keys.
 
 {
   "minutes": [

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ program
   .option(
     "--reasoning-effort <level>",
     "Reasoning effort (minimal|low|medium|high)",
-    process.env.PHOTO_SELECT_REASONING_EFFORT || "high"
+    process.env.PHOTO_SELECT_REASONING_EFFORT
   )
   .option("--no-recurse", "Process a single directory only")
   .option("-P, --parallel <n>", "Number of concurrent API calls", (v) => Math.max(1, parseInt(v, 10)), 1)
@@ -92,6 +92,11 @@ if (!finalModel) {
   finalModel = provider === 'ollama' ? 'qwen2.5vl:32b' : 'gpt-4o';
 }
 
+let finalReasoningEffort = reasoningEffort;
+if (!finalReasoningEffort) {
+  finalReasoningEffort = /^gpt-5/.test(finalModel) ? 'low' : 'minimal';
+}
+
 (async () => {
   try {
     if (provider === 'openai' && !process.env.OPENAI_API_KEY) {
@@ -115,7 +120,7 @@ if (!finalModel) {
       parallel,
       workers,
       verbosity,
-      reasoningEffort,
+      reasoningEffort: finalReasoningEffort,
     });
     console.log("🎉  Finished triaging.");
   } catch (err) {

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -172,6 +172,7 @@ export async function triageDirectory({
             await batchStore.run({ batch: idx }, async () => {
               try {
                 const start = Date.now();
+                process.env.PHOTO_SELECT_DEBUG_DIR = dir;
                 const reply = await provider.chat({
                   prompt,
                   images: batch,
@@ -293,6 +294,7 @@ export async function triageDirectory({
             await batchStore.run({ batch: idx + 1 }, async () => {
               try {
                 const start = Date.now();
+            process.env.PHOTO_SELECT_DEBUG_DIR = dir;
             const reply = await provider.chat({
               prompt,
               images: batch,


### PR DESCRIPTION
## Summary
- switch GPT-5 schema to decision maps keyed by filename
- raise token limit, set lower default reasoning effort, and retry on empty output
- write debug artifacts per batch and clean curator names in schema
- drop "minutes concise" prompt note and send failed replies to per-batch `.debug`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a2e6aceec833094da7e06bed40652