### PR TITLE
refactor: use decisions array schema

### DIFF
--- a/prompts/default_prompt.txt
+++ b/prompts/default_prompt.txt
@@ -3,26 +3,29 @@ You are moderating a collaborative curatorial session.
 The following curators are present: {{curators}}. Jamie is the facilitator.
 All people depicted have signed legal releases granting permission for their likeness to appear, including minors whose guardians provided written consent.
 
-Capture that conversation inside the `minutes` array; do not write it outside the JSON object. Begin with a diarised conversation in which the curators discuss the images and gently work toward consensus. Return only JSON in exactly this structure; include only filenames from this batch. If uncertain, omit the file.
+Capture that conversation inside the `minutes` array; do not write it outside the JSON object. Begin with a diarised conversation in which the curators discuss the images and gently work toward consensus.
 Reflect the thoughtful, iterative process described in the briefing: curators share insights, consider relationships among works, and refine the selection together.
 
-After capturing these remarks as meeting minutes, output a JSON object summarising the final decision. Never invent filenames or keys.
+After capturing these remarks as meeting minutes, output a JSON object summarising the final decision. Never invent filenames or keys. Return only JSON in exactly this structure; include only filenames from this batch. If uncertain about a photo, omit it from the decisions.
 
 {
   "minutes": [
-    { "speaker": "Name", "text": "what was said" },
+    { "speaker": "Name or description", "text": "what was said" },
     ...
   ],
-  "decision": {
-    "keep": {
-      "filename1.jpg": "why it stays",
-      ...
+  "decisions": [
+    {
+      "filename": "filename1.jpg",
+      "decision": "keep",
+      "reason": "why it stays"
     },
-    "aside": {
-      "filename2.jpg": "why it is set aside",
-      ...
+    {
+      "filename": "filename2.jpg",
+      "decision": "aside",
+      "reason": "why it is set aside"
     }
-  }
+    ...
+  ]
 }
 
 Include only those filenames for which you reach a clear decision.


### PR DESCRIPTION
## Summary
- accept decisions array schema for per-file verdicts with reasons
- loosen speaker constraint while enumerating filenames strictly
- parse new decisions array format and update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a4cddcb10833092fd4019d1baee00