### PR TITLE
fix: require decision reasons

### DIFF
--- a/prompts/default_prompt.txt
+++ b/prompts/default_prompt.txt
@@ -6,7 +6,7 @@ All people depicted have signed legal releases granting permission for their lik
 Capture that conversation inside the `minutes` array; do not write it outside the JSON object. Begin with a diarised conversation in which the curators discuss the images and gently work toward consensus.
 Reflect the thoughtful, iterative process described in the briefing: curators share insights, consider relationships among works, and refine the selection together.
 
-After capturing these remarks as meeting minutes, output a JSON object summarising the final decision. Never invent filenames or keys. Return only JSON in exactly this structure; include only filenames from this batch. If uncertain about a photo, omit it from the decisions.
+After capturing these remarks as meeting minutes, output a JSON object summarising the final decision. Never invent filenames or keys. Return only JSON in exactly this structure; include only filenames from this batch. If uncertain about a photo, omit it from the decisions. Always include a reason for each decision; use empty string if none.
 
 {
   "minutes": [
@@ -14,11 +14,11 @@ After capturing these remarks as meeting minutes, output a JSON object summarisi
     ...
   ],
   "decisions": [
-    {
-      "filename": "filename1.jpg",
-      "decision": "keep",
-      "reason": "why it stays"
-    },
+      {
+        "filename": "filename1.jpg",
+        "decision": "keep",
+        "reason": "why it stays (use empty string if none)"
+      },
     {
       "filename": "filename2.jpg",
       "decision": "aside",

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -161,11 +161,12 @@ export function buildGPT5Schema({ files = [] }) {
   const decisionItem = {
     type: 'object',
     additionalProperties: false,
-    required: ['filename', 'decision'],
+    // Strict JSON schema requires required[] to include every key in properties.
+    required: ['filename', 'decision', 'reason'],
     properties: {
       filename: { type: 'string', enum: files },
       decision: { type: 'string', enum: ['keep', 'aside'] },
-      reason: { type: 'string' },
+      reason: { type: 'string' } // allow empty string when no rationale
     },
   };
   return {

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -462,6 +462,7 @@ describe("buildGPT5Schema", () => {
     const item = schema.schema.properties.decisions.items;
     expect(item.properties.filename.enum).toEqual(["a.jpg", "b.jpg"]);
     expect(item.properties.decision.enum).toEqual(["keep", "aside"]);
+    expect(item.required).toEqual(["filename", "decision", "reason"]);
     expect(schema.schema.properties.minutes.items.properties.speaker.type).toBe("string");
   });
 


### PR DESCRIPTION
## Summary
- enforce `reason` as required for each decision in strict JSON schema
- clarify default prompt to always include a reason, permitting empty strings
- assert schema requires `reason` in unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a54d8acc08330b1bbf5aea777a8e3