### PR TITLE
Pretty console output + embed decisions JSON in minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ from OpenAI as soon as they are available. Progress bars advance to a
 "stream" stage while data arrives. Streaming keeps the HTTPS socket alive and
 reduces the chance of retry loops on slow requests.
 
+### Pretty output & minutes JSON
+
+The CLI prettifies model replies and embeds the full decisions JSON in the
+saved minutes by default. Control this behaviour with environment variables:
+
+| variable | default | effect |
+| --- | --- | --- |
+| `PHOTO_SELECT_PRETTY` | `1` | Show a colourised summary of minutes and decisions. Set to `0` for raw text. |
+| `PHOTO_SELECT_PRETTY_MINUTES` | `20` | Number of minute lines to display in the summary. |
+| `PHOTO_SELECT_MINUTES_JSON` | `1` | Append fenced JSON to minutes files. Set to `0` to skip. |
+| `PHOTO_SELECT_MINUTES_JSON_SIDECAR` | `0` | Write a separate `minutes-*.json` alongside the text file when `1`. |
+
 ### Custom timeout
 
 Long vision batches can occasionally exceed the default 5‑minute HTTP timeout.


### PR DESCRIPTION
## Summary
- colorize and summarize model replies for easier terminal scanning
- embed full decisions JSON in saved minutes files with optional sidecar
- document environment toggles for pretty output and JSON embedding

## Testing
- `npm test`
- `node - <<'NODE'` (prettyLLMReply / fallback)
- `node - <<'NODE'` (append JSON to minutes file)
- `PHOTO_SELECT_MINUTES_JSON_SIDECAR=1 node - <<'NODE'` (JSON sidecar)
- `PHOTO_SELECT_PRETTY_MINUTES=1 node - <<'NODE'` (minutes limit)
- `PHOTO_SELECT_PRETTY=0 node - <<'NODE'` (raw output)


------
https://chatgpt.com/codex/tasks/task_e_689a5e986e24833081a0c282c7f25af1