### PR TITLE
Merge gpt-5-schemas into unify/providers-gpt5

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,11 @@ from OpenAI as soon as they are available. Progress bars advance to a
 "stream" stage while data arrives. Streaming keeps the HTTPS socket alive and
 reduces the chance of retry loops on slow requests.
 
+### HTTP keep‑alive
+
+OpenAI calls reuse a persistent agent so TLS handshakes happen once per run.
+This improves stability during long streams and high concurrency.
+
 ### Custom timeout
 
 Long vision batches can occasionally exceed the default 5‑minute HTTP timeout.
@@ -180,6 +185,13 @@ By default it roughly matches the 4,096-token output limit of many OpenAI models
 `PHOTO_SELECT_TIMEOUT_MS` also governs how long the CLI waits for a response
 from either provider. The default is 20 minutes. Pass `--verbose` or set
 `PHOTO_SELECT_VERBOSE=1` to print additional debugging output when requests fail.
+
+### Workers vs. parallel
+
+`--parallel` caps how many requests are in flight at once. `--workers` creates
+that many long‑lived workers which pull from a shared queue, re‑queueing any
+unclassified images until every file receives a decision. Each batch logs an
+ETA to show how long the level may take to finish.
 
 ### People metadata (optional)
 

--- a/prompts/default_prompt.txt
+++ b/prompts/default_prompt.txt
@@ -6,26 +6,26 @@ All people depicted have signed legal releases granting permission for their lik
 Capture that conversation inside the `minutes` array; do not write it outside the JSON object. Begin with a diarised conversation in which the curators discuss the images and gently work toward consensus.
 Reflect the thoughtful, iterative process described in the briefing: curators share insights, consider relationships among works, and refine the selection together.
 
-After capturing these remarks as meeting minutes, output a JSON object summarising the final decision:
-
-If you are uncertain about a photo, **omit it from the decision block**.
-Never invent filenames or keys.
+After capturing these remarks as meeting minutes, output a JSON object summarising the final decision. Never invent filenames or keys. Return only JSON in exactly this structure; include only filenames from this batch. If uncertain about a photo, omit it from the decisions. Always include a reason for each decision; use empty string if none.
 
 {
   "minutes": [
-    { "speaker": "Name", "text": "what was said" },
+    { "speaker": "Name or description", "text": "what was said" },
     ...
   ],
-  "decision": {
-    "keep": {
-      "filename1.jpg": "why it stays",
-      ...
+  "decisions": [
+    {
+      "filename": "filename1.jpg",
+      "decision": "keep",
+      "reason": "why it stays"
     },
-    "aside": {
-      "filename2.jpg": "why it is set aside",
-      ...
+    {
+      "filename": "filename2.jpg",
+      "decision": "aside",
+      "reason": "why it is set aside"
     }
-  }
+    ...
+  ]
 }
 
 Include only those filenames for which you reach a clear decision.

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,11 @@ program
   )
   .option("--no-recurse", "Process a single directory only")
   .option("-P, --parallel <n>", "Number of concurrent API calls", (v) => Math.max(1, parseInt(v, 10)), 1)
+  .option(
+    "--workers <n>",
+    "Number of worker processes (each runs batches sequentially)",
+    (v) => Math.max(1, parseInt(v, 10))
+  )
   .option("--field-notes", "Enable field notes workflow")
   .option("-v, --verbose", "Store prompts and responses for debugging")
   .parse(process.argv);
@@ -60,6 +65,7 @@ const {
   curators,
   context: contextPath,
   parallel,
+  workers,
   fieldNotes,
   verbose,
   ollamaBaseUrl,
@@ -103,6 +109,7 @@ if (!finalModel) {
       curators,
       contextPath,
       parallel,
+      workers,
       fieldNotes,
       verbose,
     });

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -100,6 +100,7 @@ export async function triageDirectory({
   curators = [],
   contextPath,
   parallel = 1,
+  workers,
   fieldNotes = false,
   verbose = false,
   depth = 0,
@@ -187,6 +188,243 @@ export async function triageDirectory({
     }
 
     console.log(`${indent}📊  ${images.length} unclassified image(s) found`);
+
+    if (workers && workers > 0) {
+      const queue = pickRandom(images, images.length);
+      console.log(
+        `${indent}⏳  Processing ${queue.length} image(s) with ${workers} worker(s)…`
+      );
+      const multibar = new MultiBar(
+        {
+          clearOnComplete: false,
+          hideCursor: true,
+          format: `${indent}{prefix} |{bar}| {stage}`,
+        },
+        Presets.shades_classic
+      );
+      const stageMap = { encoding: 1, request: 2, waiting: 3, stream: 3, done: 4 };
+      const getBar = (idx) =>
+        multibar.create(4, 0, { prefix: `Batch ${idx}`, stage: "queued" });
+      let batchIdx = 0;
+      let completed = 0;
+
+      async function workerFn() {
+        while (true) {
+          if (!queue.length) break;
+          const batch = queue.splice(0, 10);
+          const idx = ++batchIdx;
+          const bar = getBar(idx);
+          await batchStore.run({ batch: idx }, async () => {
+            try {
+              const notesText = notesWriter
+                ? await notesWriter.read()
+                : undefined;
+              const basePrompt = await buildPrompt(promptPath, {
+                curators,
+                contextPath,
+                images: batch,
+                fieldNotes: notesText,
+                hasFieldNotes: !!notesWriter,
+                isSecondPass: false,
+              });
+              let prompt = basePrompt;
+              const start = Date.now();
+              const promptId = crypto.randomUUID();
+              if (verbose) {
+                const pFile = path.join(
+                  levelDir,
+                  '_prompts',
+                  `batch-${idx}-${promptId}.txt`
+                );
+                await writeFile(pFile, prompt, 'utf8');
+              }
+              const savePayload = verbose
+                ? async (obj) => {
+                    const dir = path.join(levelDir, '_payloads');
+                    await mkdir(dir, { recursive: true });
+                    const file = path.join(
+                      dir,
+                      `batch-${idx}-${promptId}.json`
+                    );
+                    await writeFile(file, JSON.stringify(obj, null, 2), 'utf8');
+                  }
+                : undefined;
+              const reply = await provider.chat({
+                prompt,
+                images: batch,
+                model,
+                curators,
+                expectFieldNotesInstructions: !!notesWriter,
+                savePayload,
+                onProgress: (stage) => {
+                  bar.update(stageMap[stage] || 0, { stage });
+                },
+                stream: true,
+              });
+              if (verbose) {
+                const rFile = path.join(
+                  levelDir,
+                  '_responses',
+                  `batch-${idx}-${promptId}.txt`
+                );
+                await writeFile(rFile, reply, 'utf8');
+              }
+              const ms = Date.now() - start;
+              bar.update(4, { stage: "done" });
+              bar.stop();
+              console.log(`${indent}🤖  ChatGPT reply:\n${reply}`);
+              console.log(
+                `${indent}⏱️  Batch ${idx} completed in ${(ms / 1000).toFixed(1)}s`
+              );
+
+              let parsed = parseReply(reply, batch, {
+                expectFieldNotesInstructions: !!notesWriter,
+              });
+              const {
+                keep,
+                aside,
+                notes,
+                minutes,
+                fieldNotesInstructions,
+                fieldNotesMd,
+                commitMessage,
+                unclassified,
+              } = parsed;
+              if (notesWriter && (fieldNotesMd || fieldNotesInstructions)) {
+                if (fieldNotesMd) {
+                  await notesWriter.writeFull(fieldNotesMd);
+                  if (commitMessage) {
+                    await commitFile(
+                      gitRoot,
+                      path.relative(gitRoot, notesWriter.file),
+                      commitMessage
+                    );
+                  }
+                } else if (fieldNotesInstructions) {
+                  const [prev1 = '', prev2 = ''] = await getRevisionHistory(
+                    gitRoot,
+                    notesWriter.file,
+                    2
+                  );
+                  const commitMsgs = await getCommitMessages(
+                    gitRoot,
+                    notesWriter.file
+                  );
+                  let secondPrompt = await buildPrompt(promptPath, {
+                    curators,
+                    contextPath,
+                    images: batch,
+                    fieldNotes: notesText,
+                    fieldNotesPrev: prev1,
+                    fieldNotesPrev2: prev2,
+                    commitMessages: commitMsgs,
+                    hasFieldNotes: !!notesWriter,
+                    isSecondPass: true,
+                  });
+                  secondPrompt += `\nUpdate instructions:\n${fieldNotesInstructions}\n`;
+                  const secondId = crypto.randomUUID();
+                  if (verbose) {
+                    const sp = path.join(
+                      levelDir,
+                      '_prompts',
+                      `batch-${idx}-${secondId}-second.txt`
+                    );
+                    await writeFile(sp, secondPrompt, 'utf8');
+                  }
+                  const secondSavePayload = verbose
+                    ? async (obj) => {
+                        const dir = path.join(levelDir, '_payloads');
+                        await mkdir(dir, { recursive: true });
+                        const file = path.join(
+                          dir,
+                          `batch-${idx}-${secondId}-second.json`
+                        );
+                        await writeFile(
+                          file,
+                          JSON.stringify(obj, null, 2),
+                          'utf8'
+                        );
+                      }
+                    : undefined;
+                  const second = await provider.chat({
+                    prompt: secondPrompt,
+                    images: batch,
+                    model,
+                    curators,
+                    expectFieldNotesMd: true,
+                    savePayload: secondSavePayload,
+                    stream: true,
+                    onProgress: (stage) => {
+                      bar.update(stageMap[stage] || 0, { stage });
+                    },
+                  });
+                  if (verbose) {
+                    const sr = path.join(
+                      levelDir,
+                      '_responses',
+                      `batch-${idx}-${secondId}-second.txt`
+                    );
+                    await writeFile(sr, second, 'utf8');
+                  }
+                  parsed = parseReply(second, batch, { expectFieldNotesMd: true });
+                  if (parsed.fieldNotesMd) {
+                    await notesWriter.writeFull(parsed.fieldNotesMd);
+                    if (parsed.commitMessage) {
+                      await commitFile(
+                        gitRoot,
+                        path.relative(gitRoot, notesWriter.file),
+                        parsed.commitMessage
+                      );
+                    }
+                  }
+                }
+              }
+              if (minutes.length) {
+                const uuid = crypto.randomUUID();
+                const minutesFile = path.join(dir, `minutes-${uuid}.txt`);
+                await writeFile(minutesFile, minutes.join('\n'), 'utf8');
+                console.log(`${indent}📝  Saved meeting minutes to ${minutesFile}`);
+              }
+              const keepDir = path.join(dir, "_keep");
+              const asideDir = path.join(dir, "_aside");
+              await Promise.all([
+                moveFiles(keep, keepDir, notes),
+                moveFiles(aside, asideDir, notes),
+              ]);
+              if (unclassified && unclassified.length) {
+                queue.push(...unclassified);
+              }
+              console.log(
+                `📂  Moved: ${keep.length} keep → ${keepDir}, ${aside.length} aside → ${asideDir}`
+              );
+              completed += keep.length + aside.length;
+              if (completed) {
+                const remaining = totalImages - completed;
+                const elapsed = Date.now() - levelStart;
+                const etaMs = (elapsed / completed) * remaining;
+                console.log(
+                  `${indent}⏳  ETA to finish level: ${formatDuration(etaMs)}`
+                );
+              }
+            } catch (err) {
+              bar.update(4, { stage: "error" });
+              bar.stop();
+              console.warn(
+                `${indent}⚠️  Batch ${idx} failed: ${err.message}`
+              );
+            }
+          });
+        }
+      }
+
+      const pool = Array.from(
+        { length: Math.min(workers, Math.max(queue.length, 1)) },
+        () => workerFn()
+      );
+      await Promise.all(pool);
+      multibar.stop();
+      continue;
+    }
 
     // Step 1 – select up to parallel × 10 images
     const total = Math.min(images.length, parallel * 10);
@@ -377,11 +615,11 @@ export async function triageDirectory({
       }
     }
 
-    const workers = Array.from(
+    const pool = Array.from(
       { length: Math.min(parallel, batches.length) },
       () => worker()
     );
-    await Promise.all(workers);
+    await Promise.all(pool);
     multibar.stop();
     const remaining = (await listImages(dir)).length;
     const processed = totalImages - remaining;

--- a/src/providers/openai.js
+++ b/src/providers/openai.js
@@ -8,8 +8,17 @@ export default class OpenAIProvider {
   async chat({
     expectFieldNotesInstructions = false,
     expectFieldNotesMd = false,
+    model = 'gpt-4o',
     ...opts
   } = {}) {
+    if (/^gpt-5/.test(model)) {
+      return chatCompletion({
+        ...opts,
+        model,
+        expectFieldNotesInstructions,
+        expectFieldNotesMd,
+      });
+    }
     let format = OPENAI_FORMAT_OVERRIDE;
     if (format === undefined) {
       format = {
@@ -25,6 +34,11 @@ export default class OpenAIProvider {
     if (format !== null) {
       opts.responseFormat = format;
     }
-    return chatCompletion(opts);
+    return chatCompletion({
+      ...opts,
+      model,
+      expectFieldNotesInstructions,
+      expectFieldNotesMd,
+    });
   }
 }


### PR DESCRIPTION
## Summary
- enforce strict GPT-5 JSON schema via OpenAI responses API
- add worker-based queue with ETA and requeue support
- document keep‑alive networking and worker usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b5b269780833095a074f0ffd1920f