### PR TITLE
Merge gpt-5-schemas into unify/providers-gpt5

### DIFF
--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -404,45 +404,57 @@ export function parseReply(text, allFiles, opts = {}) {
       commitMessage = obj.commit_message.trim();
     }
 
-    const extract = (node) => {
-      if (!node || typeof node !== 'object') return null;
-      if (Array.isArray(node.minutes)) minutes.push(...node.minutes.map((m) => `${m.speaker}: ${m.text}`));
-
-      if (node.keep && node.aside) return node;
-      if (node.decision && node.decision.keep && node.decision.aside) {
+    if (Array.isArray(obj.decisions)) {
+      if (Array.isArray(obj.minutes)) minutes.push(...obj.minutes.map((m) => `${m.speaker}: ${m.text}`));
+      for (const item of obj.decisions) {
+        const f = lookup(item.filename);
+        if (!f) continue;
+        const d = String(item.decision || '').toLowerCase();
+        if (d === 'keep') keep.add(f);
+        if (d === 'aside') aside.add(f);
+        if (item.reason) notes.set(f, String(item.reason));
+      }
+    } else {
+      const extract = (node) => {
+        if (!node || typeof node !== 'object') return null;
         if (Array.isArray(node.minutes)) minutes.push(...node.minutes.map((m) => `${m.speaker}: ${m.text}`));
-        return node.decision;
-      }
-      for (const val of Object.values(node)) {
-        const found = extract(val);
-        if (found) return found;
-      }
-      return null;
-    };
 
-    const decision = extract(obj);
-    if (decision) {
-      const handle = (group, set) => {
-        const val = decision[group];
-        if (Array.isArray(val)) {
-          for (const n of val) {
-            const f = lookup(n);
-            if (f) set.add(f);
-          }
-        } else if (val && typeof val === 'object') {
-          for (const [n, reason] of Object.entries(val)) {
-            const f = lookup(n);
-            if (f) {
-              set.add(f);
-              if (reason) notes.set(f, String(reason));
-            }
-          }
+        if (node.keep && node.aside) return node;
+        if (node.decision && node.decision.keep && node.decision.aside) {
+          if (Array.isArray(node.minutes)) minutes.push(...node.minutes.map((m) => `${m.speaker}: ${m.text}`));
+          return node.decision;
         }
+        for (const val of Object.values(node)) {
+          const found = extract(val);
+          if (found) return found;
+        }
+        return null;
       };
 
-      handle('keep', keep);
-      handle('aside', aside);
-      // continue to normalization below
+      const decision = extract(obj);
+      if (decision) {
+        const handle = (group, set) => {
+          const val = decision[group];
+          if (Array.isArray(val)) {
+            for (const n of val) {
+              const f = lookup(n);
+              if (f) set.add(f);
+            }
+          } else if (val && typeof val === 'object') {
+            for (const [n, reason] of Object.entries(val)) {
+              const f = lookup(n);
+              if (f) {
+                set.add(f);
+                if (reason) notes.set(f, String(reason));
+              }
+            }
+          }
+        };
+
+        handle('keep', keep);
+        handle('aside', aside);
+        // continue to normalization below
+      }
     }
   } catch {
     // fall through to plain text handling

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,18 @@ program
     "Text file with exhibition context for the curators"
   )
   .option("--no-recurse", "Process a single directory only")
-  .option("-P, --parallel <n>", "Number of concurrent API calls", (v) => Math.max(1, parseInt(v, 10)), 1)
+  .option(
+    "-P, --parallel <n>",
+    "Number of concurrent API calls (classic mode)",
+    (v) => Math.max(1, parseInt(v, 10)),
+    1
+  )
+  .option(
+    "-W, --workers <n>",
+    "Number of worker threads (dynamic queue)",
+    (v) => Math.max(1, parseInt(v, 10)),
+    0
+  )
   .option("--field-notes", "Enable field notes workflow")
   .option("-v, --verbose", "Store prompts and responses for debugging")
   .parse(process.argv);
@@ -60,6 +71,7 @@ const {
   curators,
   context: contextPath,
   parallel,
+  workers,
   fieldNotes,
   verbose,
   ollamaBaseUrl,
@@ -103,6 +115,7 @@ if (!finalModel) {
       curators,
       contextPath,
       parallel,
+      workers,
       fieldNotes,
       verbose,
     });

--- a/src/replySchema.js
+++ b/src/replySchema.js
@@ -1,8 +1,10 @@
-export function buildReplySchema({ instructions = false, fullNotes = false } = {}) {
+import path from 'node:path';
+
+export function buildReplySchema({ instructions = false, fullNotes = false, files = [] } = {}) {
   const schema = {
     type: 'object',
     additionalProperties: false,
-    required: ['minutes', 'decision'],
+    required: ['minutes'],
     properties: {
       minutes: {
         type: 'array',
@@ -16,22 +18,42 @@ export function buildReplySchema({ instructions = false, fullNotes = false } = {
           },
         },
       },
-      decision: {
-        type: 'object',
-        additionalProperties: false,
-        properties: {
-          keep: {
-            type: 'object',
-            additionalProperties: { type: 'string' },
-          },
-          aside: {
-            type: 'object',
-            additionalProperties: { type: 'string' },
-          },
-        },
-      },
     },
   };
+
+  if (files.length) {
+    schema.required.push('decisions');
+    schema.properties.decisions = {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['filename', 'decision', 'reason'],
+        properties: {
+          filename: { type: 'string', enum: files.map((f) => path.basename(f)) },
+          decision: { type: 'string', enum: ['keep', 'aside'] },
+          reason: { type: 'string' },
+        },
+      },
+    };
+  } else {
+    schema.required.push('decision');
+    schema.properties.decision = {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        keep: {
+          type: 'object',
+          additionalProperties: { type: 'string' },
+        },
+        aside: {
+          type: 'object',
+          additionalProperties: { type: 'string' },
+        },
+      },
+    };
+  }
+
   if (instructions) {
     schema.properties.field_notes_instructions = { type: 'string' };
   }

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -89,7 +89,43 @@ describe("triageDirectory", () => {
     await expect(fs.stat(aside2)).resolves.toBeTruthy();
   });
 
-  it("processes batches in parallel", async () => {
+  it("processes batches with workers", async () => {
+    chatCompletion
+      .mockResolvedValueOnce(JSON.stringify({ keep: ["1.jpg"], aside: [] }))
+      .mockResolvedValueOnce(JSON.stringify({ keep: [], aside: ["2.jpg"] }));
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: false,
+      workers: 2,
+    });
+    expect(chatCompletion).toHaveBeenCalledTimes(2);
+    const keepPath = path.join(tmpDir, "_keep", "1.jpg");
+    const asidePath = path.join(tmpDir, "_aside", "2.jpg");
+    await expect(fs.stat(keepPath)).resolves.toBeTruthy();
+    await expect(fs.stat(asidePath)).resolves.toBeTruthy();
+  });
+
+  it("requeues unclassified images", async () => {
+    chatCompletion
+      .mockResolvedValueOnce(JSON.stringify({ keep: ["1.jpg"], aside: [] }))
+      .mockResolvedValueOnce(JSON.stringify({ keep: [], aside: ["2.jpg"] }));
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: false,
+      workers: 1,
+    });
+    expect(chatCompletion).toHaveBeenCalledTimes(2);
+    const keepPath = path.join(tmpDir, "_keep", "1.jpg");
+    const asidePath = path.join(tmpDir, "_aside", "2.jpg");
+    await expect(fs.stat(keepPath)).resolves.toBeTruthy();
+    await expect(fs.stat(asidePath)).resolves.toBeTruthy();
+  });
+
+  it("processes batches in parallel (classic)", async () => {
     chatCompletion
       .mockResolvedValueOnce(JSON.stringify({ keep: ["1.jpg"], aside: [] }))
       .mockResolvedValueOnce(JSON.stringify({ keep: [], aside: ["2.jpg"] }));


### PR DESCRIPTION
## Summary
- add `--workers` flag with dynamic queue, ETA and requeue for unclassified images
- support GPT-5 structured outputs via JSON schema and Responses API auto-switch
- document worker mode and strict GPT-5 schema usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b5b15e9908330967f23bafdaaef09