### PR TITLE
Deprecate parallel flag and save minutes as JSON

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,11 @@ program
     process.env.PHOTO_SELECT_REASONING_EFFORT
   )
   .option("--no-recurse", "Process a single directory only")
-  .option("-P, --parallel <n>", "Number of concurrent API calls", (v) => Math.max(1, parseInt(v, 10)), 1)
+  .option(
+    "-P, --parallel <n>",
+    "Number of concurrent API calls (deprecated; use --workers)",
+    (v) => Math.max(1, parseInt(v, 10))
+  )
   .option("--field-notes", "Enable field notes workflow")
   .option("-v, --verbose", "Store prompts and responses for debugging")
   .option(
@@ -65,7 +69,7 @@ program
   )
   .parse(process.argv);
 
-const {
+let {
   dir,
   prompt: promptPath,
   provider: providerName,
@@ -82,6 +86,13 @@ const {
   reasoningEffort,
   ollamaBaseUrl,
 } = program.opts();
+
+if (program.getOptionValueSource && program.getOptionValueSource('parallel')) {
+  const n = Number(parallel) || 1;
+  if (!workers) workers = n;
+  console.warn('[DEPRECATION] --parallel is deprecated; using --workers=%d\n', workers);
+}
+if (!workers) workers = 1;
 
 if (verbose) {
   process.env.PHOTO_SELECT_VERBOSE = '1';
@@ -125,7 +136,6 @@ if (!finalReasoningEffort) {
       recurse,
       curators,
       contextPath,
-      parallel,
       fieldNotes,
       verbose,
       workers,

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -13,6 +13,30 @@ import { MultiBar, Presets } from "cli-progress";
 
 const exec = promisify(execFile);
 
+// ---- env & defaults ---------------------------------------------------------
+function envBool(name, def) {
+  const v = process.env[name];
+  if (v == null) return def;
+  if (/^(1|true|yes|on)$/i.test(v)) return true;
+  if (/^(0|false|no|off)$/i.test(v)) return false;
+  return def;
+}
+const PRETTY = envBool("PHOTO_SELECT_PRETTY", true);                 // pretty console summary
+const TRANSCRIPT_TXT = envBool("PHOTO_SELECT_TRANSCRIPT_TXT", false); // optional .txt transcript
+
+function parsePrettyMinutes() {
+  const raw = process.env.PHOTO_SELECT_PRETTY_MINUTES;
+  const isTTY = process.stdout.isTTY;
+  const isCI = !!process.env.CI;
+  if (raw != null) {
+    if (/^(all|∞|infinity|0)$/i.test(raw)) return Infinity;
+    const n = Number(raw);
+    if (Number.isFinite(n) && n >= 0) return n === 0 ? Infinity : n;
+  }
+  return isTTY && !isCI ? Infinity : 20;
+}
+const MAX_MINUTES = parsePrettyMinutes();
+
 function extractJsonBlock(body) {
   if (!body) return null;
   let s = String(body).trim();
@@ -35,7 +59,7 @@ const dim = (s) => color(s, 2);
 const green = (s) => color(s, 32);
 const yellow = (s) => color(s, 33);
 
-function prettyLLMReply(raw) {
+function prettyLLMReply(raw, { maxMinutes = MAX_MINUTES } = {}) {
   const json = extractJsonBlock(raw);
   if (!json) {
     try {
@@ -44,20 +68,20 @@ function prettyLLMReply(raw) {
       return String(raw);
     }
   }
-  const maxMinutes = Number(process.env.PHOTO_SELECT_PRETTY_MINUTES || 20);
   let out = "";
   if (Array.isArray(json.minutes)) {
     out += `${dim("— Minutes —")}\n`;
-    const shown = json.minutes.slice(0, maxMinutes);
-    for (const m of shown) {
+    const slice =
+      maxMinutes === Infinity ? json.minutes : json.minutes.slice(0, maxMinutes);
+    for (const m of slice) {
       if (m && typeof m === "object") {
         const who = (m.speaker ?? "Curator").toString();
         const txt = (m.text ?? "").toString();
         out += `  • ${who}: ${txt}\n`;
       }
     }
-    if (json.minutes.length > shown.length) {
-      out += dim(`  … +${json.minutes.length - shown.length} more\n`);
+    if (maxMinutes !== Infinity && json.minutes.length > slice.length) {
+      out += dim(`  … +${json.minutes.length - slice.length} more\n`);
     }
   }
   if (Array.isArray(json.decisions)) {
@@ -152,9 +176,8 @@ function formatDuration(ms) {
  * @param {boolean} [options.recurse=true]  Whether to descend into _keep folders
  * @param {string[]} [options.curators=[]]   Names inserted into the prompt
  * @param {string} [options.contextPath]     Optional additional context file
- * @param {number} [options.parallel=1]      Number of API requests to run simultaneously
- * @param {boolean} [options.fieldNotes=false] Enable field notes workflow
- * @param {number} [options.depth=0]         Internal recursion depth (for logging)
+* @param {boolean} [options.fieldNotes=false] Enable field notes workflow
+* @param {number} [options.depth=0]         Internal recursion depth (for logging)
 */
 export async function triageDirectory({
   dir,
@@ -164,10 +187,9 @@ export async function triageDirectory({
   recurse = true,
   curators = [],
   contextPath,
-  parallel = 1,
   fieldNotes = false,
   verbose = false,
-  workers,
+  workers = 1,
   verbosity,
   reasoningEffort,
   depth = 0,
@@ -179,6 +201,11 @@ export async function triageDirectory({
   }
   const indent = "  ".repeat(depth);
   let notesWriter;
+
+  if (depth === 0) {
+    const shown = MAX_MINUTES === Infinity ? 'all' : String(MAX_MINUTES);
+    console.log(dim(`UI: pretty=${PRETTY?'on':'off'}, transcript_txt=${TRANSCRIPT_TXT?'on':'off'}, minutes_shown=${shown}`));
+  }
 
   if (!gitRoot) gitRoot = dir;
   if (fieldNotes && depth === 0) {
@@ -255,13 +282,12 @@ export async function triageDirectory({
     }
 
     console.log(`${indent}📊  ${images.length} unclassified image(s) found`);
-    if (workers && workers > 0) {
-      const queue = pickRandom(images, images.length);
-      console.log(
-        `${indent}⏳  Processing ${queue.length} image(s) with ${workers} worker(s)…`
-      );
+    const queue = pickRandom(images, images.length);
+    console.log(
+      `${indent}⏳  Processing ${queue.length} image(s) with ${workers} worker(s)…`
+    );
 
-      const multibar = new MultiBar(
+    const multibar = new MultiBar(
         {
           clearOnComplete: false,
           hideCursor: true,
@@ -315,11 +341,8 @@ export async function triageDirectory({
                 bar.update(4, { stage: "done" });
                 bar.stop();
                 multibar.remove(bar);
-                if (process.env.PHOTO_SELECT_PRETTY !== "0") {
-                  log(
-                    `${indent}🤖  ChatGPT reply (pretty):\n` +
-                      prettyLLMReply(reply)
-                  );
+                if (PRETTY) {
+                  log(`${indent}🤖  ChatGPT reply (pretty):\n` + prettyLLMReply(reply));
                 } else {
                   log(`${indent}🤖  ChatGPT reply:\n${reply}`);
                 }
@@ -332,11 +355,47 @@ export async function triageDirectory({
                   batch,
                   { model, verbosity, reasoningEffort }
                 );
-                if (minutes.length) {
-                  const uuid = crypto.randomUUID();
-                  const minutesFile = path.join(dir, `minutes-${uuid}.txt`);
-                  await writeFile(minutesFile, minutes.join("\n"), "utf8");
-                  log(`${indent}📝  Saved meeting minutes to ${minutesFile}`);
+                // Write primary minutes JSON and optional transcript
+                const uuid = crypto.randomUUID();
+                const jsonPath = path.join(dir, `minutes-${uuid}.json`);
+                const j =
+                  extractJsonBlock(reply) || (() => {
+                    const mk = (arr, tag) =>
+                      arr.map((f) => ({
+                        filename: path.basename(f),
+                        decision: tag,
+                        reason: (notes.get(f) || "").toString(),
+                      }));
+                    const decisions = [
+                      ...mk(keep, "keep"),
+                      ...mk(aside, "aside"),
+                    ];
+                    const minutesObjs = minutes.map((line) => {
+                      const m = line.match(/^([^:]+):\s*(.*)$/);
+                      return m
+                        ? { speaker: m[1], text: m[2] }
+                        : { speaker: "Curator", text: line };
+                    });
+                    return { minutes: minutesObjs, decisions };
+                  })();
+                await writeFile(jsonPath, JSON.stringify(j, null, 2), "utf8");
+                log(`${indent}📝  Saved minutes JSON to ${jsonPath}`);
+                if (TRANSCRIPT_TXT && Array.isArray(j.minutes)) {
+                  const txtPath = path.join(dir, `minutes-${uuid}.txt`);
+                  let out = j.minutes
+                    .map((m) => `${m.speaker || "Curator"}: ${m.text || ""}`)
+                    .join("\n");
+                  if (Array.isArray(j.decisions)) {
+                    const keeps = j.decisions.filter((d) => d.decision === "keep");
+                    const asides = j.decisions.filter((d) => d.decision === "aside");
+                    out += `\n\n— Decisions — ${keeps.length} keep / ${asides.length} aside\n`;
+                    for (const d of keeps)
+                      out += `  KEEP  ${d.filename}${d.reason ? ' — ' + d.reason : ''}\n`;
+                    for (const d of asides)
+                      out += `  ASIDE ${d.filename}${d.reason ? ' — ' + d.reason : ''}\n`;
+                  }
+                  await writeFile(txtPath, out, "utf8");
+                  log(`${indent}📝  Saved transcript TXT to ${txtPath}`);
                 }
                 const keepDir = path.join(dir, "_keep");
                 const asideDir = path.join(dir, "_aside");
@@ -387,228 +446,6 @@ export async function triageDirectory({
           `${indent}⏳  ETA to finish level: ${formatDuration(etaMs)}`
         );
       }
-      continue;
-    } else {
-    // Step 1 – select up to parallel × 10 images
-    const total = Math.min(images.length, parallel * 10);
-    const selection = pickRandom(images, total);
-    console.log(`${indent}🔍  Selected ${selection.length} image(s)`);
-
-    const batches = [];
-    for (let i = 0; i < selection.length; i += 10) {
-      batches.push(selection.slice(i, i + 10));
-    }
-
-    console.log(`${indent}⏳  Sending ${batches.length} batch(es) to ChatGPT…`);
-
-    const multibar = new MultiBar(
-      {
-        clearOnComplete: false,
-        hideCursor: true,
-        format: `${indent}{prefix} |{bar}| {stage}`,
-      },
-      Presets.shades_classic
-    );
-    const stageMap = { encoding: 1, request: 2, waiting: 3, done: 4 };
-    const bars = batches.map((_, i) =>
-      multibar.create(4, 0, { prefix: `Batch ${i + 1}`, stage: "queued" })
-    );
-
-    let nextIndex = 0;
-    async function worker() {
-      while (true) {
-        const idx = nextIndex++;
-        if (idx >= batches.length) break;
-        const batch = batches[idx];
-        const bar = bars[idx];
-        await batchStore.run({ batch: idx + 1 }, async () => {
-          try {
-            const notesText = notesWriter ? await notesWriter.read() : undefined;
-            const basePrompt = await buildPrompt(promptPath, {
-              curators,
-              contextPath,
-              images: batch,
-              fieldNotes: notesText,
-              hasFieldNotes: !!notesWriter,
-              isSecondPass: false,
-            });
-            let prompt = basePrompt;
-            const start = Date.now();
-            const promptId = crypto.randomUUID();
-            if (verbose) {
-              const pFile = path.join(levelDir, '_prompts', `batch-${idx + 1}-${promptId}.txt`);
-              await writeFile(pFile, prompt, 'utf8');
-            }
-            const savePayload = verbose
-              ? async (obj) => {
-                  const dir = path.join(levelDir, '_payloads');
-                  await mkdir(dir, { recursive: true });
-                  const file = path.join(
-                    dir,
-                    `batch-${idx + 1}-${promptId}.json`
-                  );
-                  await writeFile(file, JSON.stringify(obj, null, 2), 'utf8');
-                }
-              : undefined;
-            const reply = await provider.chat({
-              prompt,
-              images: batch,
-              model,
-              curators,
-              verbosity,
-              reasoningEffort,
-              expectFieldNotesInstructions: !!notesWriter,
-              savePayload,
-              onProgress: (stage) => {
-                bar.update(stageMap[stage] || 0, { stage });
-              },
-              stream: true,
-            });
-            if (verbose) {
-              const rFile = path.join(levelDir, '_responses', `batch-${idx + 1}-${promptId}.txt`);
-              await writeFile(rFile, reply, 'utf8');
-            }
-            const ms = Date.now() - start;
-            bar.update(4, { stage: "done" });
-            bar.stop();
-            console.log(`${indent}🤖  ChatGPT reply:\n${reply}`);
-            console.log(`${indent}⏱️  Batch ${idx + 1} completed in ${(ms / 1000).toFixed(1)}s`);
-
-            let parsed = parseReply(reply, batch, {
-              expectFieldNotesInstructions: !!notesWriter,
-              model,
-              verbosity,
-              reasoningEffort,
-            });
-            const {
-              keep,
-              aside,
-              notes,
-              minutes,
-              fieldNotesInstructions,
-              fieldNotesMd,
-            } = parsed;
-            if (notesWriter && (fieldNotesMd || fieldNotesInstructions)) {
-              if (fieldNotesMd) {
-                await notesWriter.writeFull(fieldNotesMd);
-                if (parsed.commitMessage) {
-                  await commitFile(
-                    gitRoot,
-                    path.relative(gitRoot, notesWriter.file),
-                    parsed.commitMessage
-                  );
-                }
-              } else if (fieldNotesInstructions) {
-                const [prev1 = "", prev2 = ""] = await getRevisionHistory(
-                  gitRoot,
-                  notesWriter.file,
-                  2
-                );
-                const commitMsgs = await getCommitMessages(
-                  gitRoot,
-                  notesWriter.file
-                );
-                let secondPrompt = await buildPrompt(promptPath, {
-                  curators,
-                  contextPath,
-                  images: batch,
-                  fieldNotes: notesText,
-                  fieldNotesPrev: prev1,
-                  fieldNotesPrev2: prev2,
-                  commitMessages: commitMsgs,
-                  hasFieldNotes: !!notesWriter,
-                  isSecondPass: true,
-                });
-                secondPrompt += `\nUpdate instructions:\n${fieldNotesInstructions}\n`;
-                const secondId = crypto.randomUUID();
-                if (verbose) {
-                  const sp = path.join(levelDir, '_prompts', `batch-${idx + 1}-${secondId}-second.txt`);
-                  await writeFile(sp, secondPrompt, 'utf8');
-                }
-                const secondSavePayload = verbose
-                  ? async (obj) => {
-                      const dir = path.join(levelDir, '_payloads');
-                      await mkdir(dir, { recursive: true });
-                      const file = path.join(
-                        dir,
-                        `batch-${idx + 1}-${secondId}-second.json`
-                      );
-                      await writeFile(file, JSON.stringify(obj, null, 2), 'utf8');
-                    }
-                  : undefined;
-                const second = await provider.chat({
-                  prompt: secondPrompt,
-                  images: batch,
-                  model,
-                  curators,
-                  verbosity,
-                  reasoningEffort,
-                  expectFieldNotesMd: true,
-                  savePayload: secondSavePayload,
-                  stream: true,
-                  onProgress: (stage) => {
-                    bar.update(stageMap[stage] || 0, { stage });
-                  },
-                });
-                if (verbose) {
-                  const sr = path.join(levelDir, '_responses', `batch-${idx + 1}-${secondId}-second.txt`);
-                  await writeFile(sr, second, 'utf8');
-                }
-                parsed = parseReply(second, batch, {
-                  expectFieldNotesMd: true,
-                });
-                if (parsed.fieldNotesMd) {
-                  await notesWriter.writeFull(parsed.fieldNotesMd);
-                  if (parsed.commitMessage) {
-                    await commitFile(
-                      gitRoot,
-                      path.relative(gitRoot, notesWriter.file),
-                      parsed.commitMessage
-                    );
-                  }
-                }
-              }
-            }
-            if (minutes.length) {
-              const uuid = crypto.randomUUID();
-              const minutesFile = path.join(dir, `minutes-${uuid}.txt`);
-              await writeFile(minutesFile, minutes.join('\n'), 'utf8');
-              console.log(`${indent}📝  Saved meeting minutes to ${minutesFile}`);
-            }
-
-            const keepDir = path.join(dir, "_keep");
-            const asideDir = path.join(dir, "_aside");
-            await Promise.all([
-              moveFiles(keep, keepDir, notes),
-              moveFiles(aside, asideDir, notes),
-            ]);
-
-            console.log(
-              `📂  Moved: ${keep.length} keep → ${keepDir}, ${aside.length} aside → ${asideDir}`
-            );
-          } catch (err) {
-            bar.update(4, { stage: "error" });
-            bar.stop();
-            console.warn(`${indent}⚠️  Batch ${idx + 1} failed: ${err.message}`);
-          }
-        });
-      }
-    }
-
-    const workers = Array.from(
-      { length: Math.min(parallel, batches.length) },
-      () => worker()
-    );
-    await Promise.all(workers);
-    multibar.stop();
-    const remaining = (await listImages(dir)).length;
-    const processed = totalImages - remaining;
-    if (processed) {
-      const elapsed = Date.now() - levelStart;
-      const etaMs = (elapsed / processed) * remaining;
-      console.log(`${indent}⏳  ETA to finish level: ${formatDuration(etaMs)}`);
-    }
-  }
 }
 
   // Step 5 – recurse into keepDir if both keep and aside exist
@@ -631,8 +468,11 @@ export async function triageDirectory({
         recurse,
         curators,
         contextPath,
-        parallel,
         fieldNotes,
+        verbose,
+        workers,
+        verbosity,
+        reasoningEffort,
         depth: depth + 1,
         gitRoot,
       });


### PR DESCRIPTION
## Summary
- deprecate `--parallel` and route to `--workers`
- save minutes as `minutes-*.json` and optionally emit transcript `.txt`
- show full minutes on TTY with configurable cap and UI banner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bd0db12dc83308fa02d7c25e566a5