### PR TITLE
Skip caching zero-decision batches

### DIFF
--- a/src/chatCache.js
+++ b/src/chatCache.js
@@ -1,0 +1,60 @@
+import { readFile, writeFile, rm, mkdir } from "node:fs/promises";
+import path from "node:path";
+
+const CACHE_DIR = process.env.PHOTO_SELECT_CHAT_CACHE_DIR || path.resolve(".cache/batches");
+
+function cachePath(key) {
+  return path.join(CACHE_DIR, `${key}.json`);
+}
+
+export async function readCache(key) {
+  const p = cachePath(key);
+  try {
+    const raw = await readFile(p, "utf8");
+    const entry = JSON.parse(raw);
+    const { keep, aside } = decisionCounts(entry);
+    if (keep + aside === 0) {
+      try { await rm(p); } catch {}
+      return null;
+    }
+    return entry;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeCache(key, value) {
+  const { keep, aside } = decisionCounts(value);
+  if (keep + aside === 0) {
+    console.log(`cache: skip (0 decisions) for ${key}`);
+    return;
+  }
+  await mkdir(CACHE_DIR, { recursive: true });
+  await writeFile(cachePath(key), JSON.stringify(value), "utf8");
+}
+
+export function decisionCounts(entry) {
+  if (!entry) return { keep: 0, aside: 0 };
+  if (Array.isArray(entry.decisions)) {
+    let keep = 0, aside = 0;
+    for (const d of entry.decisions) {
+      if (d && d.decision === "keep") keep++;
+      if (d && d.decision === "aside") aside++;
+    }
+    return { keep, aside };
+  }
+  try {
+    const obj = typeof entry === "string" ? JSON.parse(entry) : entry;
+    if (obj && obj.decision && typeof obj.decision === "object") {
+      const k = obj.decision.keep;
+      const a = obj.decision.aside;
+      const keep = Array.isArray(k) ? k.length : k && typeof k === "object" ? Object.keys(k).length : 0;
+      const aside = Array.isArray(a) ? a.length : a && typeof a === "object" ? Object.keys(a).length : 0;
+      return { keep, aside };
+    }
+  } catch {
+    // ignore JSON errors
+  }
+  return { keep: 0, aside: 0 };
+}
+

--- a/tests/chatCache.test.js
+++ b/tests/chatCache.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+let cacheDir;
+
+beforeEach(async () => {
+  cacheDir = await fs.mkdtemp(path.join(os.tmpdir(), "ps-cache-"));
+  process.env.PHOTO_SELECT_CHAT_CACHE_DIR = cacheDir;
+  vi.resetModules();
+});
+
+afterEach(async () => {
+  delete process.env.PHOTO_SELECT_CHAT_CACHE_DIR;
+  await fs.rm(cacheDir, { recursive: true, force: true });
+  vi.resetModules();
+});
+
+describe("chatCache", () => {
+  it("skips writing when zero decisions", async () => {
+    const { writeCache } = await import("../src/chatCache.js");
+    await writeCache("a", { decisions: [] });
+    const files = await fs.readdir(cacheDir);
+    expect(files.length).toBe(0);
+  });
+
+  it("evicts zero-decision entries on read", async () => {
+    const { readCache } = await import("../src/chatCache.js");
+    const file = path.join(cacheDir, "b.json");
+    await fs.mkdir(cacheDir, { recursive: true });
+    await fs.writeFile(file, JSON.stringify({ decisions: [] }), "utf8");
+    const val = await readCache("b");
+    expect(val).toBeNull();
+    await expect(fs.stat(file)).rejects.toThrow();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add cache helper that deletes entries with no keep/aside decisions
- bypass writing cache files when a batch yields zero decisions
- test cache eviction and write-skip behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bfcf47c9c8330bedf699aa1e780b9