### PR TITLE
Handle zero-decision model replies safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,12 @@ full.
 
 Responses from OpenAI are cached under a `.cache` directory using a hash of the
 prompt, model, and file metadata. Subsequent runs with the same inputs reuse the
-saved reply instead of hitting the API.
+saved reply instead of hitting the API. The tool never caches model responses
+that contain zero decisions (0 keeps + 0 asides). Such entries are skipped on
+write and evicted on read. If a batch still produces no decisions, the run is
+retried (finalize mode when 10 or fewer images remain). After two consecutive
+no-decision replies, the batch is marked `NEEDS_REVIEW` and processing
+continues.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- Skip caching replies with no keep/aside decisions and evict existing 0-decision cache files
- Retry small batches in finalize mode and mark NEEDS_REVIEW after repeated indecision
- Document zero-decision caching policy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bfcf47c9c8330bedf699aa1e780b9