### PR TITLE
harden curation pipeline with strict minutes and decision ledger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,19 @@ OPENAI_API_KEY=sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # Optional: base URL for the photo-filter API providing people tags
 # Defaults to http://localhost:3000 when unset
 # PHOTO_FILTER_API_BASE=http://localhost:3000
+
+# Minutes length = [ceil(1.5 * base), ceil(2.5 * base)], where base = max(#curators, #photos)
+PHOTO_SELECT_MINUTES_FACTOR_MIN=1.5
+PHOTO_SELECT_MINUTES_FACTOR_MAX=2.5
+
+# Small batch rule-of-thumb (go stricter on compliance)
+PHOTO_SELECT_SMALL_BATCH_THRESHOLD=10
+
+# “zero decision” tolerance
+PHOTO_SELECT_ZERO_DECISION_MAX_STREAK_SMALL=1
+PHOTO_SELECT_ZERO_DECISION_MAX_STREAK_LARGE=2
+
+# Networking (defaults shown)
+PHOTO_SELECT_TIMEOUT_MS=180000           # 120–180s recommended
+PHOTO_SELECT_MAX_RETRIES=6
+PHOTO_SELECT_RETRY_BASE_MS=1000          # exponential, with jitter

--- a/prompts/default_prompt.hbs
+++ b/prompts/default_prompt.hbs
@@ -1,144 +1,51 @@
-You are moderating a collaborative curatorial session.
+You are moderating a collaborative curatorial session among a real-world group making photo selection choices for an exhibition.
+
+Role play as {{curators}}:
+ - inidicate who is speaking
+ - say what you think
 
 Session participants:
 - Curators: {{curators}}
 - Facilitator: Jamie
 
-You will review the following image files (use *only* these names when forming decisions):
-{{#each images}}
-- {{this}}
+You will review exactly these files (use only these names):
+{{#each images}}- {{this}}
 {{/each}}
 
 {{#if context}}
-Background for today's review:
+Context for today:
 {{context}}
 {{/if}}
 {{#if hasFieldNotes}}
-Field‑notes snapshot prior to this batch:
+Field‑notes snapshot (for reference):
 {{fieldNotes}}
 {{/if}}
 {{#if isSecondPass}}
-{{#if fieldNotesPrev}}
-Previous revision:
+{{#if fieldNotesPrev}}Previous revision:
 {{fieldNotesPrev}}
 {{/if}}
-{{#if fieldNotesPrev2}}
-Earlier revision:
+{{#if fieldNotesPrev2}}Earlier revision:
 {{fieldNotesPrev2}}
 {{/if}}
-{{#if commitMessages}}
-Git commit messages for this level:
-{{#each commitMessages}}
-- {{this}}
+{{#if commitMessages}}Recent commit messages:
+{{#each commitMessages}}- {{this}}
 {{/each}}
 {{/if}}
 {{/if}}
 
-{{!-- ──────────────── PASS‑SPECIFIC INSTRUCTIONS ──────────────── --}}
+OUTPUT FORMAT — exactly two sections, in this order:
 
-{{#unless isSecondPass}}
-When you respond, think step‑by‑step silently and then output **only** a valid JSON object with the following top‑level keys:
-- "minutes" : an array of { "speaker": "<Name>", "text": "<what was said>" }. The final "text" must be a forward‑looking question.
-- "decision" : an object whose optional keys are exactly "keep" and "aside". Each key maps a filename to a one‑sentence rationale. Omit filenames that lack consensus.
-{{#if hasFieldNotes}}
-- "field_notes_instructions" : a single string containing step‑by‑step edits that should be applied to *field‑notes.md*.
+MINUTES ({{minutesMin}}–{{minutesMax}} bullet lines)
+• Each line is a single, pointed sentence in the speaker’s authentic real-world ineffable voice, thinking style, prosody, overtones, registers, and sensibility.
+• Illuminate what the images teach; avoid purple prose.
+• The final line ends with a forward‑looking question.
 
-Rules for **field_notes_instructions**  
-1. Write concise instructions for updating the notebook, justified by today’s images.  
-2. Cite evidence with `[descriptive text](filename.jpg)` links; they will autolink.
-3. If uncertain, insert a "(?)" marker rather than inventing details.
-4. Embed ≤ 3 `![descriptive alt-text](filename.jpg)` inline images.
-5. Return pure JSON – no Markdown fences, no commentary, no extra text.  
-{{/if}}
+=== DECISIONS_JSON ===
+{"decisions":[{"filename":"<from list above>","decision":"keep|aside","reason":"one sentence"}]}
+=== END ===
 
-{{else}} {{!-- SECOND PASS --}}
-
-When you respond, think step‑by‑step silently and then output **only** a valid JSON object with the following top‑level keys:
-- "minutes" : an array of { "speaker": "<Name>", "text": "<what was said>" }. The final "text" must be a forward‑looking question.
-{{#if hasFieldNotes}}
-- "field_notes_md" : the **full, updated contents** of *field‑notes.md* after applying the agreed changes. Provide the entire file for direct replacement—no diffs.
-- "commit_message" : a short git commit message summarizing the updates.
-
-Editorial guidelines for curators – Second‑pass
-
-Preamble – Scope & Rhythm  
-These rules apply to every curator pass that occurs **after** an image‑batch has been ingested by the automation pipeline.  
-One pass = one Git commit; most commits should touch ≤ 50 lines.
-
-────────────────────────────────────────────────────────────────────────
-1. SOURCE‑FIRST
-   • Every new or modified line **must** cite ≥ 1 photo from this batch:  
-     ─ inline link …… [text](IMG_1234.jpg)  
-     ─ or thumbnail … ![text](IMG_1234.jpg)  
-   • If no supporting image exists yet, write “(img ?)” and place the fact
-     under **Outstanding Unknowns** instead of the main narrative.
-
-2. THUMBNAIL BUDGET (max 3)
-   • Embed only when the picture explains something prose cannot.
-   • To add a 4th, first demote an older thumb → plain link.
-
-3. SECTION DISCIPLINE
-   • Preserve the heading hierarchy; append or refine in place.
-   • If relocation is essential, append “⟵ moved from §X.Y [link]”.
-
-4. **SCOPE GUARD**
-   • Stick to *photo‑verifiable facts*. Move strategy, finance, or anecdote to a separate memo—*not* this file.
-
-5. AMBIGUITY
-   • Unknown value … “(?)”  
-   • Approximation … “≈”  
-   • Never fabricate data; let the next batch resolve it.
-
-6. ECONOMY OF PROSE
-   • Bullet points, ≤ 25 words.  
-   • Begin each bullet with a **type tag** →  _Spec:, Risk:, Action:, Note:_
-   • Use nouns & numbers; omit adjectives unless functional (e.g., “hot PSU”).
-
-7. DUPLICATION PASS
-   • Search before adding; merge or update existing bullets.  
-   • If updating, append “(updated)” and a fresh image link.
-
-8. NOMENCLATURE
-   • Copy model/part numbers **exactly** from photo labels.  
-   • Brands in **Title Case**; units in SI / IEC (mm, V, A).
-
-9. IMAGE EXISTENCE CHECK
-   • Before commit: `test -f filename.jpg` (CI will also verify).  
-   • Broken links block the merge.
-
-10. SAFETY FLAGS
-   • Prefix any safety issue with “❗ ” (trip hazard, exposed mains, etc.).  
-   • These are auto‑collected into *risk‑register.md* by CI.
-
-11. **HERO SLOT**
-    • Only one “Primary Hero” embed per file.
-    • Swap it **once per curator** per day max; demote the old hero → link.
-
-12. **TABLE HYGIENE**
-    • When editing a table, update *only* the changed rows; maintain
-      column order and trailing pipe.
-
-13. COMMIT HEADER & FOOTER
-    • Header: `Timestamp UTC | Curator Initials | ≤ 60 char summary`
-    • Footer fenced block:
-      ```Δ‑Summary
-      + Added: …
-      ~ Updated: …
-      - Retired: …
-      ```
-
-14. PEER REVIEW
-    • A second curator must “Approve” before merge to *main*.
-
-15. CHANGE‑SIZE GUARD
-    • > 100 changed lines? Split into logical commits.
-────────────────────────────────────────────────────────────────────────
-{{/if}}
-
-{{/unless}}
-
-{{!-- ──────────────── UNIVERSAL CONSTRAINTS ──────────────── --}}
-
-Never invent filenames, keys, or extra properties. Use only the image list above and the allowed keys.
-
-Return pure JSON—no markdown, no commentary, no extra text.
+Rules:
+• Include every filename exactly once with decision keep|aside.
+• Use only the filenames listed above; never invent names.
+• If uncertain, choose "aside".
+• Return nothing else before/after those two sections.

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -7,11 +7,14 @@ import crypto from "node:crypto";
 import { batchStore } from "./batchContext.js";
 import { delay } from "./config.js";
 
-const DEFAULT_TIMEOUT = 20 * 60 * 1000;
+const DEFAULT_TIMEOUT =
+  Number.parseInt(process.env.PHOTO_SELECT_TIMEOUT_MS, 10) || 180000;
+
 const httpsAgent = new KeepAliveAgent.HttpsAgent({
   keepAlive: true,
-  timeout:
-    Number.parseInt(process.env.PHOTO_SELECT_TIMEOUT_MS, 10) || DEFAULT_TIMEOUT,
+  maxSockets: 4,
+  maxFreeSockets: 4,
+  timeout: DEFAULT_TIMEOUT,
 });
 httpsAgent.on("error", (err) => {
   if (["EPIPE", "ECONNRESET"].includes(err.code)) {
@@ -157,7 +160,7 @@ export async function curatorsFromTags(files) {
  * minutes plus the full JSON decision block without truncation. */
 export const MAX_RESPONSE_TOKENS = 8192;
 
-export function buildGPT5Schema({ files = [] }) {
+export function buildGPT5Schema({ files = [], minutesMin = 3, minutesMax = 12 }) {
   const decisionItem = {
     type: 'object',
     additionalProperties: false,
@@ -179,6 +182,8 @@ export function buildGPT5Schema({ files = [] }) {
         minutes: {
           type: 'array',
           description: 'Transcript of curator discussion',
+          minItems: minutesMin,
+          maxItems: minutesMax,
           items: {
             type: 'object',
             required: ['speaker', 'text'],
@@ -200,9 +205,9 @@ export function buildGPT5Schema({ files = [] }) {
   };
 }
 
-export function schemaForBatch(used, curators = []) {
+export function schemaForBatch(used, curators = [], minutesMin, minutesMax) {
   const files = used.map((f) => path.basename(f));
-  return buildGPT5Schema({ files });
+  return buildGPT5Schema({ files, minutesMin, minutesMax });
 }
 
 export function useResponses(model) {
@@ -215,6 +220,10 @@ function ensureJsonMention(text) {
 
 const CACHE_DIR = path.resolve(".cache");
 const CACHE_KEY_PREFIX = "v5";
+
+const RETRY_BASE = Number(process.env.PHOTO_SELECT_RETRY_BASE_MS || 1000);
+const MAX_RETRIES = Number(process.env.PHOTO_SELECT_MAX_RETRIES || 6);
+const RETRIABLE = new Set([408, 429, 502, 503, 504]);
 
 function useColor() {
   return process.stdout.isTTY && process.env.NO_COLOR !== "1";
@@ -380,12 +389,14 @@ export async function chatCompletion({
   model = "gpt-4o",
   verbosity = "low",
   reasoningEffort = "minimal",
-  maxRetries = 3,
+  maxRetries = MAX_RETRIES,
   cache = true,
   curators = [],
   stream = false,
   onProgress = () => {},
   responseFormat,
+  minutesMin,
+  minutesMax,
 }) {
   const allowedVerbosity = ["low", "medium", "high"];
   const allowedEffort = ["minimal", "low", "medium", "high"];
@@ -441,7 +452,12 @@ export async function chatCompletion({
           const hit = await getCachedReply(key, used);
           if (hit) return hit;
         }
-        const schema = schemaForBatch(used, finalCurators);
+        const schema = schemaForBatch(
+          used,
+          finalCurators,
+          minutesMin,
+          minutesMax
+        );
         onProgress("request");
         onProgress("waiting");
         const baseOpts = {
@@ -460,15 +476,19 @@ export async function chatCompletion({
           reasoning: { effort: reasoningEffort },
           max_output_tokens: MAX_RESPONSE_TOKENS,
         };
-        let rsp = await openai.responses.create(baseOpts);
+        const headers = { "Idempotency-Key": crypto.randomUUID() };
+        let rsp = await openai.responses.create(baseOpts, { headers });
         let { text } = await extractTextWithLogging(rsp);
         if (!text.trim()) {
           console.warn("⚠️ Empty text; retrying with minimal reasoning…");
-          rsp = await openai.responses.create({
-            ...baseOpts,
-            reasoning: { effort: "minimal" },
-            temperature: 0.2,
-          });
+          rsp = await openai.responses.create(
+            {
+              ...baseOpts,
+              reasoning: { effort: "minimal" },
+              temperature: 0.2,
+            },
+            { headers: { "Idempotency-Key": crypto.randomUUID() } }
+          );
           ({ text } = await extractTextWithLogging(rsp));
         }
         if (cache) await setCachedReply(key, text, used);
@@ -557,7 +577,12 @@ export async function chatCompletion({
           verbosity,
           reasoningEffort,
         });
-        const schema = schemaForBatch(used, finalCurators);
+        const schema = schemaForBatch(
+          used,
+          finalCurators,
+          minutesMin,
+          minutesMax
+        );
         onProgress("request");
         onProgress("waiting");
         const baseOpts = {
@@ -576,15 +601,19 @@ export async function chatCompletion({
           reasoning: { effort: reasoningEffort },
           max_output_tokens: MAX_RESPONSE_TOKENS,
         };
-        let rsp = await openai.responses.create(baseOpts);
+        const headers = { "Idempotency-Key": crypto.randomUUID() };
+        let rsp = await openai.responses.create(baseOpts, { headers });
         let { text } = await extractTextWithLogging(rsp);
         if (!text.trim()) {
           console.warn("⚠️ Empty text; retrying with minimal reasoning…");
-          rsp = await openai.responses.create({
-            ...baseOpts,
-            reasoning: { effort: "minimal" },
-            temperature: 0.2,
-          });
+          rsp = await openai.responses.create(
+            {
+              ...baseOpts,
+              reasoning: { effort: "minimal" },
+              temperature: 0.2,
+            },
+            { headers: { "Idempotency-Key": crypto.randomUUID() } }
+          );
           ({ text } = await extractTextWithLogging(rsp));
         }
         if (cache) await setCachedReply(key, text, used);
@@ -592,14 +621,21 @@ export async function chatCompletion({
         return text;
       }
 
-      if (attempt >= maxRetries) throw err;
+      const status = err?.status || err?.code;
+      const transient =
+        RETRIABLE.has(Number(status)) ||
+        ["EPIPE", "ECONNRESET", "ETIMEDOUT"].includes(
+          err?.cause?.code || err?.code
+        );
+      if (!transient || attempt >= maxRetries) throw err;
       attempt += 1;
-      const wait = 2 ** attempt * 1000;
-      const label = isNetwork ? "network error" : "OpenAI error";
-      const codeInfo = err.status ?? code ?? "unknown";
-      console.warn(`${label} (${codeInfo}). Retrying in ${wait} ms…`);
-      console.warn("Full error response:", err);
-      await delay(wait);
+      const base = Math.min(30000, RETRY_BASE * 2 ** attempt);
+      const wait = Math.round(base * (0.7 + Math.random() * 0.6));
+      const retryAfter = Number(err?.headers?.["retry-after"] || 0) * 1000;
+      const delayMs = Math.max(wait, retryAfter);
+      const label = transient ? `retryable error ${status || ''}` : "error";
+      console.warn(`${label}. Retrying in ${delayMs} ms…`);
+      await delay(delayMs);
     }
   }
 }
@@ -611,6 +647,15 @@ export async function chatCompletion({
  *  • “DSCF1234 — keep  …reason…”
  *  • “Set aside: DSCF5678”
  */
+function extractBlock(raw, start, end) {
+  if (!raw) return null;
+  const s = String(raw);
+  const i = s.indexOf(start);
+  const j = s.indexOf(end, i + start.length);
+  if (i === -1 || j === -1) return null;
+  return s.slice(i + start.length, j).trim();
+}
+
 export function parseReply(text, allFiles, meta = {}) {
   let body = text;
   const fenced = body.trim();
@@ -645,112 +690,159 @@ export function parseReply(text, allFiles, meta = {}) {
   let commitMessage;
 
   let parsed = false;
-try {
-  const obj = JSON.parse(body);
-  if (meta.expectFieldNotesDiff && typeof obj.field_notes_diff === "string") {
-    fieldNotesDiff = obj.field_notes_diff;
-  }
-  if (meta.expectFieldNotesMd && typeof obj.field_notes_md === "string") {
-    fieldNotesMd = obj.field_notes_md;
-  }
-  if (
-    meta.expectFieldNotesInstructions &&
-    typeof obj.field_notes_instructions === "string"
-  ) {
-    fieldNotesInstructions = obj.field_notes_instructions;
-  }
-  if (typeof obj.commit_message === "string") {
-    commitMessage = obj.commit_message.trim();
-  }
-  if (obj && Array.isArray(obj.decisions)) {
-    for (const item of obj.decisions) {
-      if (!item || typeof item !== 'object') continue;
-      const base = String(item.filename || '').trim();
-      if (!base) continue;
-      const f = allFiles.find((p) => path.basename(p) === base);
-      if (!f) continue;
-      const choice = String(item.decision || '').toLowerCase();
-      if (choice === 'keep') {
-        keep.add(f);
-      } else if (choice === 'aside') {
-        aside.add(f);
-      }
-      if (typeof item.reason === 'string' && item.reason.trim()) {
-        notes.set(f, item.reason.trim());
-      }
-    }
-    if (Array.isArray(obj.minutes)) {
-      for (const m of obj.minutes) {
-        if (m && typeof m === 'object' && typeof m.speaker === 'string' && typeof m.text === 'string') {
-          minutes.push(m.speaker + ': ' + m.text);
+  const block = extractBlock(text, "=== DECISIONS_JSON ===", "=== END ===");
+  if (block) {
+    try {
+      const obj = JSON.parse(block);
+      if (Array.isArray(obj.decisions)) {
+        for (const d of obj.decisions) {
+          if (!d || typeof d !== "object") continue;
+          const f = lookup(d.filename);
+          if (!f) continue;
+          if (d.decision === "keep") keep.add(f);
+          if (d.decision === "aside") aside.add(f);
+          if (typeof d.reason === "string" && d.reason.trim())
+            notes.set(f, d.reason.trim());
         }
+        parsed = true;
       }
-    }
-    parsed = true;
+    } catch {}
   }
-} catch {
-  // not JSON; fall through
-}
 
-if (!parsed) {
-  try {
-    const obj = JSON.parse(body);
-    const extract = (node) => {
-      if (!node || typeof node !== 'object') return null;
-      if (Array.isArray(node.minutes))
-        minutes.push(...node.minutes.map((m) => m.speaker + ': ' + m.text));
-      if (node.keep && node.aside) return node;
-      if (node.decision && node.decision.keep && node.decision.aside)
-        return node.decision;
-      for (const val of Object.values(node)) {
-        const found = extract(val);
-        if (found) return found;
+  if (!parsed) {
+    try {
+      const obj = JSON.parse(body);
+      if (meta.expectFieldNotesDiff && typeof obj.field_notes_diff === "string") {
+        fieldNotesDiff = obj.field_notes_diff;
       }
-      return null;
-    };
-    const decision = extract(obj);
-    if (decision) {
-      const handle = (group, set) => {
-        const val = decision[group];
-        if (Array.isArray(val)) {
-          for (const item of val) {
-            if (typeof item === 'string') {
-              const f = lookup(item);
-              if (f) set.add(f);
-            } else if (item && typeof item === 'object') {
-              const f = lookup(item.file);
+      if (meta.expectFieldNotesMd && typeof obj.field_notes_md === "string") {
+        fieldNotesMd = obj.field_notes_md;
+      }
+      if (
+        meta.expectFieldNotesInstructions &&
+        typeof obj.field_notes_instructions === "string"
+      ) {
+        fieldNotesInstructions = obj.field_notes_instructions;
+      }
+      if (typeof obj.commit_message === "string") {
+        commitMessage = obj.commit_message.trim();
+      }
+      if (obj && Array.isArray(obj.decisions)) {
+        for (const item of obj.decisions) {
+          if (!item || typeof item !== "object") continue;
+          const base = String(item.filename || "").trim();
+          if (!base) continue;
+          const f = allFiles.find((p) => path.basename(p) === base);
+          if (!f) continue;
+          const choice = String(item.decision || "").toLowerCase();
+          if (choice === "keep") {
+            keep.add(f);
+          } else if (choice === "aside") {
+            aside.add(f);
+          }
+          if (typeof item.reason === "string" && item.reason.trim()) {
+            notes.set(f, item.reason.trim());
+          }
+        }
+        if (Array.isArray(obj.minutes)) {
+          for (const m of obj.minutes) {
+            if (
+              m &&
+              typeof m === "object" &&
+              typeof m.speaker === "string" &&
+              typeof m.text === "string"
+            ) {
+              minutes.push(m.speaker + ": " + m.text);
+            }
+          }
+        }
+        parsed = true;
+      }
+    } catch {
+      // not JSON; fall through
+    }
+  }
+
+  if (!parsed) {
+    try {
+      const obj = JSON.parse(body);
+      const extract = (node) => {
+        if (!node || typeof node !== "object") return null;
+        if (Array.isArray(node.minutes))
+          minutes.push(...node.minutes.map((m) => m.speaker + ": " + m.text));
+        if (node.keep && node.aside) return node;
+        if (node.decision && node.decision.keep && node.decision.aside)
+          return node.decision;
+        for (const val of Object.values(node)) {
+          const found = extract(val);
+          if (found) return found;
+        }
+        return null;
+      };
+      const decision = extract(obj);
+      if (decision) {
+        const handle = (group, set) => {
+          const val = decision[group];
+          if (Array.isArray(val)) {
+            for (const item of val) {
+              if (typeof item === "string") {
+                const f = lookup(item);
+                if (f) set.add(f);
+              } else if (item && typeof item === "object") {
+                const f = lookup(item.file);
+                if (f) {
+                  set.add(f);
+                  if (item.reason) notes.set(f, String(item.reason));
+                }
+              }
+            }
+          } else if (val && typeof val === "object") {
+            for (const [n, reason] of Object.entries(val)) {
+              const f = lookup(n);
               if (f) {
                 set.add(f);
-                if (item.reason) notes.set(f, String(item.reason));
+                if (reason) notes.set(f, String(reason));
               }
             }
           }
-        } else if (val && typeof val === 'object') {
-          for (const [n, reason] of Object.entries(val)) {
+        };
+        handle("keep", keep);
+        handle("aside", aside);
+        if (Array.isArray(decision.unclassified)) {
+          for (const n of decision.unclassified) {
             const f = lookup(n);
-            if (f) {
-              set.add(f);
-              if (reason) notes.set(f, String(reason));
-            }
+            if (f) unclassified.push(f);
           }
         }
-      };
-      handle('keep', keep);
-      handle('aside', aside);
-      if (Array.isArray(decision.unclassified)) {
-        for (const n of decision.unclassified) {
-          const f = lookup(n);
-          if (f) unclassified.push(f);
-        }
+        parsed = true;
+      }
+    } catch {
+      // ignore JSON errors
+    }
+  }
+
+  if (!parsed) {
+    const salvage = [];
+    for (const line of String(body).split("\n")) {
+      const m = line.match(/^(?:\s*)\b(KEEP|ASIDE)\b\s+(\S+)\s+—\s+(.*)$/i);
+      if (m) salvage.push({
+        decision: m[1].toLowerCase(),
+        filename: m[2],
+        reason: m[3] || "",
+      });
+    }
+    if (salvage.length) {
+      for (const { decision, filename, reason } of salvage) {
+        const f = lookup(filename);
+        if (!f) continue;
+        (decision === "keep" ? keep : aside).add(f);
+        if (reason) notes.set(f, reason);
       }
       parsed = true;
     }
-  } catch {
-    // ignore JSON errors
   }
-}
 
-if (!parsed) {
+  if (!parsed) {
     const lines = body.split("\n");
     for (const raw of lines) {
       const line = raw.trim();

--- a/src/providers/ollama.js
+++ b/src/providers/ollama.js
@@ -28,6 +28,8 @@ export default class OllamaProvider {
     savePayload,
     expectFieldNotesInstructions = false,
     expectFieldNotesMd = false,
+    minutesMin,
+    minutesMax,
   } = {}) {
     let attempt = 0;
     while (true) {
@@ -72,6 +74,8 @@ export default class OllamaProvider {
           format = buildReplySchema({
             instructions: expectFieldNotesInstructions,
             fullNotes: expectFieldNotesMd,
+            minutesMin,
+            minutesMax,
           });
         }
         if (format !== null) {

--- a/src/providers/openai.js
+++ b/src/providers/openai.js
@@ -17,6 +17,8 @@ export default class OpenAIProvider {
         schema: buildReplySchema({
           instructions: expectFieldNotesInstructions,
           fullNotes: expectFieldNotesMd,
+          minutesMin: opts.minutesMin,
+          minutesMax: opts.minutesMax,
         }),
       };
     } else if (typeof format === 'string') {

--- a/src/replySchema.js
+++ b/src/replySchema.js
@@ -1,4 +1,9 @@
-export function buildReplySchema({ instructions = false, fullNotes = false } = {}) {
+export function buildReplySchema({
+  instructions = false,
+  fullNotes = false,
+  minutesMin = 3,
+  minutesMax = 12,
+} = {}) {
   const schema = {
     type: 'object',
     additionalProperties: false,
@@ -6,6 +11,8 @@ export function buildReplySchema({ instructions = false, fullNotes = false } = {
     properties: {
       minutes: {
         type: 'array',
+        minItems: minutesMin,
+        maxItems: minutesMax,
         items: {
           type: 'object',
           additionalProperties: false,

--- a/src/templates.js
+++ b/src/templates.js
@@ -2,6 +2,9 @@ import path from 'node:path';
 import fs from 'node:fs/promises';
 import Handlebars from 'handlebars';
 
+const fmin = Number(process.env.PHOTO_SELECT_MINUTES_FACTOR_MIN || 1.5);
+const fmax = Number(process.env.PHOTO_SELECT_MINUTES_FACTOR_MAX || 2.5);
+
 export const DEFAULT_PROMPT_PATH = path.resolve(
   new URL('../prompts/default_prompt.hbs', import.meta.url).pathname
 );
@@ -29,7 +32,10 @@ export async function buildPrompt(
   const context = contextPath
     ? await fs.readFile(contextPath, 'utf8').catch(() => '')
     : '';
-  return renderTemplate(filePath, {
+  const base = Math.max(curators.length || 1, images.length || 1);
+  const minutesMin = Math.ceil(fmin * base);
+  const minutesMax = Math.ceil(fmax * base);
+  const prompt = await renderTemplate(filePath, {
     curators: curators.join(', '),
     images: images.map((f) => path.basename(f)),
     context,
@@ -39,6 +45,9 @@ export async function buildPrompt(
     commitMessages,
     hasFieldNotes,
     isSecondPass,
+    minutesMin,
+    minutesMax,
   });
+  return { prompt, minutesMin, minutesMax };
 }
 

--- a/tests/templates.test.js
+++ b/tests/templates.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { buildPrompt, DEFAULT_PROMPT_PATH } from '../src/templates.js';
+
+const images = ['a.jpg', 'b.jpg'];
+const curators = ['Curator-A', 'Curator-B'];
+
+describe('buildPrompt', () => {
+  it('injects role-play phrase and minutes range', async () => {
+    const { prompt, minutesMin, minutesMax } = await buildPrompt(DEFAULT_PROMPT_PATH, {
+      curators,
+      images,
+    });
+    const line = `Role play as Curator-A, Curator-B:\n - inidicate who is speaking\n - say what you think`;
+    expect(prompt).toContain(line);
+    expect(prompt).toContain(`MINUTES (${minutesMin}–${minutesMax} bullet lines)`);
+  });
+});


### PR DESCRIPTION
## Summary
- add environment knobs for minutes length, networking backoff, and zero-decision thresholds
- compute minutesMin/Max for each batch and require DECISIONS_JSON with role-play prompt
- harden parsing with explicit decision blocks, salvage regex, and repair pass with low-effort retries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cd1f01ed88330a03219f7da35753f