### PR TITLE
Ensure robust photo curation with strict decisions and repair

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,19 @@ OPENAI_API_KEY=sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # Optional: base URL for the photo-filter API providing people tags
 # Defaults to http://localhost:3000 when unset
 # PHOTO_FILTER_API_BASE=http://localhost:3000
+
+# Minutes length = [ceil(1.5 * base), ceil(2.5 * base)], where base = max(#curators, #photos)
+PHOTO_SELECT_MINUTES_FACTOR_MIN=1.5
+PHOTO_SELECT_MINUTES_FACTOR_MAX=2.5
+
+# Small batch rule-of-thumb (go stricter on compliance)
+PHOTO_SELECT_SMALL_BATCH_THRESHOLD=10
+
+# "zero decision" tolerance
+PHOTO_SELECT_ZERO_DECISION_MAX_STREAK_SMALL=1
+PHOTO_SELECT_ZERO_DECISION_MAX_STREAK_LARGE=2
+
+# Networking (defaults shown)
+PHOTO_SELECT_TIMEOUT_MS=180000           # 120–180s recommended
+PHOTO_SELECT_MAX_RETRIES=6
+PHOTO_SELECT_RETRY_BASE_MS=1000          # exponential, with jitter

--- a/prompts/default_prompt.hbs
+++ b/prompts/default_prompt.hbs
@@ -1,144 +1,52 @@
-You are moderating a collaborative curatorial session.
+You are moderating a collaborative curatorial session among a real-world group making photo selection choices for an exhibition.
+
+Role play as {{curators}}:
+ - Indicate who is speaking
+ - Say what you think
 
 Session participants:
 - Curators: {{curators}}
 - Facilitator: Jamie
 
-You will review the following image files (use *only* these names when forming decisions):
-{{#each images}}
-- {{this}}
+You will review exactly these files (use only these names):
+{{#each images}}- {{this}}
 {{/each}}
 
 {{#if context}}
-Background for today's review:
+Context for today:
 {{context}}
 {{/if}}
 {{#if hasFieldNotes}}
-Field‑notes snapshot prior to this batch:
+Field‑notes snapshot (for reference):
 {{fieldNotes}}
 {{/if}}
 {{#if isSecondPass}}
-{{#if fieldNotesPrev}}
-Previous revision:
+{{#if fieldNotesPrev}}Previous revision:
 {{fieldNotesPrev}}
 {{/if}}
-{{#if fieldNotesPrev2}}
-Earlier revision:
+{{#if fieldNotesPrev2}}Earlier revision:
 {{fieldNotesPrev2}}
 {{/if}}
-{{#if commitMessages}}
-Git commit messages for this level:
-{{#each commitMessages}}
-- {{this}}
+{{#if commitMessages}}Recent commit messages:
+{{#each commitMessages}}- {{this}}
 {{/each}}
 {{/if}}
 {{/if}}
 
-{{!-- ──────────────── PASS‑SPECIFIC INSTRUCTIONS ──────────────── --}}
+OUTPUT FORMAT — exactly two sections, in this order:
 
-{{#unless isSecondPass}}
-When you respond, think step‑by‑step silently and then output **only** a valid JSON object with the following top‑level keys:
-- "minutes" : an array of { "speaker": "<Name>", "text": "<what was said>" }. The final "text" must be a forward‑looking question.
-- "decision" : an object whose optional keys are exactly "keep" and "aside". Each key maps a filename to a one‑sentence rationale. Omit filenames that lack consensus.
-{{#if hasFieldNotes}}
-- "field_notes_instructions" : a single string containing step‑by‑step edits that should be applied to *field‑notes.md*.
+MINUTES ({{minutesMin}}–{{minutesMax}} bullet lines)
+• Each line is a single, pointed sentence in the speaker’s real ineffable voice, thinking style, communication style, prosody, language of presence, overtones, registers, sensibilities, concerns, wisdom, skill and expertise.
+• Illuminate what the images teach; avoid purple prose.
+• The final line ends with a forward‑looking question.
 
-Rules for **field_notes_instructions**  
-1. Write concise instructions for updating the notebook, justified by today’s images.  
-2. Cite evidence with `[descriptive text](filename.jpg)` links; they will autolink.
-3. If uncertain, insert a "(?)" marker rather than inventing details.
-4. Embed ≤ 3 `![descriptive alt-text](filename.jpg)` inline images.
-5. Return pure JSON – no Markdown fences, no commentary, no extra text.  
-{{/if}}
+=== DECISIONS_JSON ===
+{"decisions":[{"filename":"<from list above>","decision":"keep|aside","reason":"one sentence"}]}
+=== END ===
 
-{{else}} {{!-- SECOND PASS --}}
+Rules:
+• Include every filename exactly once with decision keep|aside.
+• Use only the filenames listed above; never invent names.
+• If uncertain, choose "aside".
+• Return nothing else before/after those two sections.
 
-When you respond, think step‑by‑step silently and then output **only** a valid JSON object with the following top‑level keys:
-- "minutes" : an array of { "speaker": "<Name>", "text": "<what was said>" }. The final "text" must be a forward‑looking question.
-{{#if hasFieldNotes}}
-- "field_notes_md" : the **full, updated contents** of *field‑notes.md* after applying the agreed changes. Provide the entire file for direct replacement—no diffs.
-- "commit_message" : a short git commit message summarizing the updates.
-
-Editorial guidelines for curators – Second‑pass
-
-Preamble – Scope & Rhythm  
-These rules apply to every curator pass that occurs **after** an image‑batch has been ingested by the automation pipeline.  
-One pass = one Git commit; most commits should touch ≤ 50 lines.
-
-────────────────────────────────────────────────────────────────────────
-1. SOURCE‑FIRST
-   • Every new or modified line **must** cite ≥ 1 photo from this batch:  
-     ─ inline link …… [text](IMG_1234.jpg)  
-     ─ or thumbnail … ![text](IMG_1234.jpg)  
-   • If no supporting image exists yet, write “(img ?)” and place the fact
-     under **Outstanding Unknowns** instead of the main narrative.
-
-2. THUMBNAIL BUDGET (max 3)
-   • Embed only when the picture explains something prose cannot.
-   • To add a 4th, first demote an older thumb → plain link.
-
-3. SECTION DISCIPLINE
-   • Preserve the heading hierarchy; append or refine in place.
-   • If relocation is essential, append “⟵ moved from §X.Y [link]”.
-
-4. **SCOPE GUARD**
-   • Stick to *photo‑verifiable facts*. Move strategy, finance, or anecdote to a separate memo—*not* this file.
-
-5. AMBIGUITY
-   • Unknown value … “(?)”  
-   • Approximation … “≈”  
-   • Never fabricate data; let the next batch resolve it.
-
-6. ECONOMY OF PROSE
-   • Bullet points, ≤ 25 words.  
-   • Begin each bullet with a **type tag** →  _Spec:, Risk:, Action:, Note:_
-   • Use nouns & numbers; omit adjectives unless functional (e.g., “hot PSU”).
-
-7. DUPLICATION PASS
-   • Search before adding; merge or update existing bullets.  
-   • If updating, append “(updated)” and a fresh image link.
-
-8. NOMENCLATURE
-   • Copy model/part numbers **exactly** from photo labels.  
-   • Brands in **Title Case**; units in SI / IEC (mm, V, A).
-
-9. IMAGE EXISTENCE CHECK
-   • Before commit: `test -f filename.jpg` (CI will also verify).  
-   • Broken links block the merge.
-
-10. SAFETY FLAGS
-   • Prefix any safety issue with “❗ ” (trip hazard, exposed mains, etc.).  
-   • These are auto‑collected into *risk‑register.md* by CI.
-
-11. **HERO SLOT**
-    • Only one “Primary Hero” embed per file.
-    • Swap it **once per curator** per day max; demote the old hero → link.
-
-12. **TABLE HYGIENE**
-    • When editing a table, update *only* the changed rows; maintain
-      column order and trailing pipe.
-
-13. COMMIT HEADER & FOOTER
-    • Header: `Timestamp UTC | Curator Initials | ≤ 60 char summary`
-    • Footer fenced block:
-      ```Δ‑Summary
-      + Added: …
-      ~ Updated: …
-      - Retired: …
-      ```
-
-14. PEER REVIEW
-    • A second curator must “Approve” before merge to *main*.
-
-15. CHANGE‑SIZE GUARD
-    • > 100 changed lines? Split into logical commits.
-────────────────────────────────────────────────────────────────────────
-{{/if}}
-
-{{/unless}}
-
-{{!-- ──────────────── UNIVERSAL CONSTRAINTS ──────────────── --}}
-
-Never invent filenames, keys, or extra properties. Use only the image list above and the allowed keys.
-
-Return pure JSON—no markdown, no commentary, no extra text.

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -7,11 +7,13 @@ import crypto from "node:crypto";
 import { batchStore } from "./batchContext.js";
 import { delay } from "./config.js";
 
-const DEFAULT_TIMEOUT = 20 * 60 * 1000;
+const DEFAULT_TIMEOUT = Number.parseInt(process.env.PHOTO_SELECT_TIMEOUT_MS, 10) || 180000;
+
 const httpsAgent = new KeepAliveAgent.HttpsAgent({
   keepAlive: true,
-  timeout:
-    Number.parseInt(process.env.PHOTO_SELECT_TIMEOUT_MS, 10) || DEFAULT_TIMEOUT,
+  maxSockets: 4,
+  maxFreeSockets: 4,
+  timeout: DEFAULT_TIMEOUT,
 });
 httpsAgent.on("error", (err) => {
   if (["EPIPE", "ECONNRESET"].includes(err.code)) {
@@ -27,6 +29,10 @@ const PEOPLE_API_BASE =
 const peopleCache = new Map();
 
 const MAX_DEBUG_BYTES = 5 * 1024 * 1024;
+
+const RETRY_BASE = Number(process.env.PHOTO_SELECT_RETRY_BASE_MS || 1000);
+const MAX_RETRIES = Number(process.env.PHOTO_SELECT_MAX_RETRIES || 6);
+const RETRIABLE = new Set([408, 429, 502, 503, 504]);
 
 function debugDir() {
   const base = process.env.PHOTO_SELECT_DEBUG_DIR || process.cwd();
@@ -153,11 +159,20 @@ export async function curatorsFromTags(files) {
     .map(([n]) => n);
 }
 
+function extractBlock(raw, start, end) {
+  if (!raw) return null;
+  const s = String(raw);
+  const i = s.indexOf(start);
+  const j = s.indexOf(end, i + start.length);
+  if (i === -1 || j === -1) return null;
+  return s.slice(i + start.length, j).trim();
+}
+
 /** Max response tokens allowed from OpenAI. Large enough to hold
  * minutes plus the full JSON decision block without truncation. */
 export const MAX_RESPONSE_TOKENS = 8192;
 
-export function buildGPT5Schema({ files = [] }) {
+export function buildGPT5Schema({ files = [], minutesMin = 3, minutesMax = 12 }) {
   const decisionItem = {
     type: 'object',
     additionalProperties: false,
@@ -166,7 +181,7 @@ export function buildGPT5Schema({ files = [] }) {
     properties: {
       filename: { type: 'string', enum: files },
       decision: { type: 'string', enum: ['keep', 'aside'] },
-      reason: { type: 'string' } // allow empty string when no rationale
+      reason: { type: 'string' }, // allow empty string when no rationale
     },
   };
   return {
@@ -179,6 +194,8 @@ export function buildGPT5Schema({ files = [] }) {
         minutes: {
           type: 'array',
           description: 'Transcript of curator discussion',
+          minItems: minutesMin,
+          maxItems: minutesMax,
           items: {
             type: 'object',
             required: ['speaker', 'text'],
@@ -200,9 +217,9 @@ export function buildGPT5Schema({ files = [] }) {
   };
 }
 
-export function schemaForBatch(used, curators = []) {
+export function schemaForBatch(used, curators = [], minutesMin = 3, minutesMax = 12) {
   const files = used.map((f) => path.basename(f));
-  return buildGPT5Schema({ files });
+  return buildGPT5Schema({ files, minutesMin, minutesMax });
 }
 
 export function useResponses(model) {
@@ -380,12 +397,13 @@ export async function chatCompletion({
   model = "gpt-4o",
   verbosity = "low",
   reasoningEffort = "minimal",
-  maxRetries = 3,
   cache = true,
   curators = [],
   stream = false,
   onProgress = () => {},
   responseFormat,
+  minutesMin = 3,
+  minutesMax = 12,
 }) {
   const allowedVerbosity = ["low", "medium", "high"];
   const allowedEffort = ["minimal", "low", "medium", "high"];
@@ -441,7 +459,7 @@ export async function chatCompletion({
           const hit = await getCachedReply(key, used);
           if (hit) return hit;
         }
-        const schema = schemaForBatch(used, finalCurators);
+        const schema = schemaForBatch(used, finalCurators, minutesMin, minutesMax);
         onProgress("request");
         onProgress("waiting");
         const baseOpts = {
@@ -460,15 +478,19 @@ export async function chatCompletion({
           reasoning: { effort: reasoningEffort },
           max_output_tokens: MAX_RESPONSE_TOKENS,
         };
-        let rsp = await openai.responses.create(baseOpts);
+        const headers = { 'Idempotency-Key': crypto.randomUUID() };
+        let rsp = await openai.responses.create(baseOpts, { headers });
         let { text } = await extractTextWithLogging(rsp);
         if (!text.trim()) {
           console.warn("⚠️ Empty text; retrying with minimal reasoning…");
-          rsp = await openai.responses.create({
-            ...baseOpts,
-            reasoning: { effort: "minimal" },
-            temperature: 0.2,
-          });
+          rsp = await openai.responses.create(
+            {
+              ...baseOpts,
+              reasoning: { effort: "minimal" },
+              temperature: 0.2,
+            },
+            { headers: { 'Idempotency-Key': crypto.randomUUID() } }
+          );
           ({ text } = await extractTextWithLogging(rsp));
         }
         if (cache) await setCachedReply(key, text, used);
@@ -512,10 +534,10 @@ export async function chatCompletion({
       onProgress("waiting");
       let text;
       if (stream) {
-        const streamResp = await openai.chat.completions.create({
-          ...baseParams,
-          stream: true,
-        });
+        const streamResp = await openai.chat.completions.create(
+          { ...baseParams, stream: true },
+          { headers: { 'Idempotency-Key': crypto.randomUUID() } }
+        );
         onProgress("stream");
         text = "";
         for await (const chunk of streamResp) {
@@ -525,7 +547,10 @@ export async function chatCompletion({
           }
         }
       } else {
-        const { choices } = await openai.chat.completions.create(baseParams);
+        const { choices } = await openai.chat.completions.create(
+          baseParams,
+          { headers: { 'Idempotency-Key': crypto.randomUUID() } }
+        );
         text = choices[0].message.content;
       }
       if (cache) await setCachedReply(key, text, used);
@@ -557,7 +582,7 @@ export async function chatCompletion({
           verbosity,
           reasoningEffort,
         });
-        const schema = schemaForBatch(used, finalCurators);
+        const schema = schemaForBatch(used, finalCurators, minutesMin, minutesMax);
         onProgress("request");
         onProgress("waiting");
         const baseOpts = {
@@ -576,15 +601,19 @@ export async function chatCompletion({
           reasoning: { effort: reasoningEffort },
           max_output_tokens: MAX_RESPONSE_TOKENS,
         };
-        let rsp = await openai.responses.create(baseOpts);
+        const headers = { 'Idempotency-Key': crypto.randomUUID() };
+        let rsp = await openai.responses.create(baseOpts, { headers });
         let { text } = await extractTextWithLogging(rsp);
         if (!text.trim()) {
           console.warn("⚠️ Empty text; retrying with minimal reasoning…");
-          rsp = await openai.responses.create({
-            ...baseOpts,
-            reasoning: { effort: "minimal" },
-            temperature: 0.2,
-          });
+          rsp = await openai.responses.create(
+            {
+              ...baseOpts,
+              reasoning: { effort: "minimal" },
+              temperature: 0.2,
+            },
+            { headers: { 'Idempotency-Key': crypto.randomUUID() } }
+          );
           ({ text } = await extractTextWithLogging(rsp));
         }
         if (cache) await setCachedReply(key, text, used);
@@ -592,14 +621,22 @@ export async function chatCompletion({
         return text;
       }
 
-      if (attempt >= maxRetries) throw err;
+      const status = err?.status || err?.code;
+      const transient =
+        RETRIABLE.has(Number(status)) ||
+        ["EPIPE", "ECONNRESET", "ETIMEDOUT"].includes(
+          err?.cause?.code || err?.code
+        );
+      if (!transient || attempt >= MAX_RETRIES) throw err;
       attempt += 1;
-      const wait = 2 ** attempt * 1000;
+      const base = Math.min(30000, RETRY_BASE * (2 ** attempt));
+      const wait = Math.round(base * (0.7 + Math.random() * 0.6));
+      const retryAfter = Number(err?.headers?.['retry-after'] || 0) * 1000;
       const label = isNetwork ? "network error" : "OpenAI error";
       const codeInfo = err.status ?? code ?? "unknown";
-      console.warn(`${label} (${codeInfo}). Retrying in ${wait} ms…`);
+      console.warn(`${label} (${codeInfo}). Retrying in ${Math.max(wait, retryAfter)} ms…`);
       console.warn("Full error response:", err);
-      await delay(wait);
+      await delay(Math.max(wait, retryAfter));
     }
   }
 }
@@ -645,6 +682,35 @@ export function parseReply(text, allFiles, meta = {}) {
   let commitMessage;
 
   let parsed = false;
+
+  const block = extractBlock(text, '=== DECISIONS_JSON ===', '=== END ===');
+  if (block) {
+    try {
+      const obj = JSON.parse(block);
+      if (obj && Array.isArray(obj.decisions)) {
+        for (const item of obj.decisions) {
+          if (!item || typeof item !== 'object') continue;
+          const base = String(item.filename || '').trim();
+          if (!base) continue;
+          const f = allFiles.find((p) => path.basename(p) === base);
+          if (!f) continue;
+          const choice = String(item.decision || '').toLowerCase();
+          if (choice === 'keep') {
+            keep.add(f);
+          } else if (choice === 'aside') {
+            aside.add(f);
+          }
+          if (typeof item.reason === 'string' && item.reason.trim()) {
+            notes.set(f, item.reason.trim());
+          }
+        }
+        parsed = true;
+      }
+    } catch {
+      // ignore block parse errors
+    }
+  }
+
 try {
   const obj = JSON.parse(body);
   if (meta.expectFieldNotesDiff && typeof obj.field_notes_diff === "string") {
@@ -771,8 +837,26 @@ if (!parsed) {
 
           const m = line.match(/(?:keep|aside)[^a-z0-9]*[:\-–—]*\s*(.*)/i);
           if (m && m[1]) notes.set(f, m[1].trim());
-        }
-      }
+  }
+}
+
+if (!parsed) {
+  const salvage = [];
+  for (const line of String(text).split('\n')) {
+    const m = line.match(/^(?:\s*)\b(KEEP|ASIDE)\b\s+(\S+)\s+—\s+(.*)$/i);
+    if (m)
+      salvage.push({ decision: m[1].toLowerCase(), filename: m[2], reason: m[3] || '' });
+  }
+  if (salvage.length) {
+    for (const { decision, filename, reason } of salvage) {
+      const f = lookup(filename);
+      if (!f) continue;
+      (decision === 'keep' ? keep : aside).add(f);
+      if (reason) notes.set(f, reason);
+    }
+    parsed = true;
+  }
+}
     }
   }
 

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -58,7 +58,13 @@ function color(s, code) {
 const dim = (s) => color(s, 2);
 const green = (s) => color(s, 32);
 const yellow = (s) => color(s, 33);
-const MAX_ZERO_DECISION_STREAK = 2;
+const SMALL = Number(process.env.PHOTO_SELECT_SMALL_BATCH_THRESHOLD || 10);
+const MAX_SMALL = Number(
+  process.env.PHOTO_SELECT_ZERO_DECISION_MAX_STREAK_SMALL || 1
+);
+const MAX_LARGE = Number(
+  process.env.PHOTO_SELECT_ZERO_DECISION_MAX_STREAK_LARGE || 2
+);
 
 function prettyLLMReply(raw, { maxMinutes = MAX_MINUTES } = {}) {
   const json = extractJsonBlock(raw);
@@ -319,70 +325,97 @@ export async function triageDirectory({
             await batchStore.run({ batch: idx }, async () => {
               try {
                 const batchStart = Date.now();
-                const remaining = batch.length + queue.length;
-                const isSmall = remaining <= 10;
-                let zeroStreak = 0;
-                let finalize = false;
+                const maxStreak =
+                  batch.length <= SMALL ? MAX_SMALL : MAX_LARGE;
+                let attempts = 0;
                 let reply;
                 let keep = [];
                 let aside = [];
                 let unclassified = [];
                 let notes = new Map();
                 let minutes = [];
-                for (let attempt = 1; attempt <= MAX_ZERO_DECISION_STREAK; attempt++) {
-                  let prompt = await buildPrompt(promptPath, {
-                    curators,
-                    contextPath,
-                    images: batch,
-                    hasFieldNotes: false,
-                    isSecondPass: false,
-                  });
-                  if (finalize) {
-                    prompt +=
-                      "\nFINALIZE MODE:\n- You must assign every image to \"keep\" or \"aside\".\n- Returning zero decisions is invalid.";
-                  }
-                  reply = await provider.chat({
-                    prompt,
-                    images: batch,
-                    model,
-                    curators,
-                    verbosity,
-                    reasoningEffort,
-                    onProgress: (stage) => {
-                      bar.update(stageMap[stage] || 0, { stage });
-                    },
-                    stream: true,
-                  });
-                  ({ keep, aside, unclassified, notes, minutes } = parseReply(
-                    reply,
-                    batch,
-                    { model, verbosity, reasoningEffort }
-                  ));
-                  if (keep.length + aside.length > 0) break;
-                  zeroStreak++;
-                  if (isSmall && zeroStreak < MAX_ZERO_DECISION_STREAK) {
-                    finalize = true;
-                    console.log(
-                      dim("No decisions; not cached; retrying in finalize mode.")
-                    );
-                    continue;
-                  }
-                  if (zeroStreak >= MAX_ZERO_DECISION_STREAK) {
-                    console.log(
-                      dim(
-                        `⚠️  No decisions after ${zeroStreak} attempt(s); marking NEEDS_REVIEW and continuing.`
-                      )
-                    );
-                    const marker = path.join(dir, "NEEDS_REVIEW");
-                    const list = batch
-                      .map((f) => path.basename(f))
+                const context = contextPath
+                  ? await readFile(contextPath, "utf8").catch(() => "")
+                  : "";
+                const first = await buildPrompt(promptPath, {
+                  curators,
+                  contextPath,
+                  images: batch,
+                  hasFieldNotes: false,
+                  isSecondPass: false,
+                });
+                reply = await provider.chat({
+                  prompt: first.prompt,
+                  images: batch,
+                  model,
+                  curators,
+                  verbosity,
+                  reasoningEffort,
+                  minutesMin: first.minutesMin,
+                  minutesMax: first.minutesMax,
+                  onProgress: (stage) => {
+                    bar.update(stageMap[stage] || 0, { stage });
+                  },
+                  stream: true,
+                });
+                ({ keep, aside, unclassified, notes, minutes } = parseReply(
+                  reply,
+                  batch,
+                  { model, verbosity, reasoningEffort }
+                ));
+                if (keep.length + aside.length === 0) {
+                  attempts++;
+                  if (attempts < maxStreak) {
+                    const repair = [
+                      `role play as ${curators.join(", ")}:\n - inidicate who is speaking\n - say what you think`,
+                      "You are continuing the same curatorial session.",
+                      context ? `Context for today:\n${context}` : null,
+                      "Return only the block below. No minutes, no commentary.",
+                      "",
+                      "=== DECISIONS_JSON ===",
+                      '{"decisions":[{"filename":"<from list>","decision":"keep|aside","reason":""}]}',
+                      "=== END ===",
+                      "",
+                      "Files (use each exactly once):",
+                      ...batch.map((f) => `- ${path.basename(f)}`),
+                    ]
+                      .filter(Boolean)
                       .join("\n");
-                    try {
-                      const prev = await readFile(marker, "utf8").catch(() => "");
-                      await writeFile(marker, `${prev}${list}\n`, "utf8");
-                    } catch {}
-                    break;
+                    reply = await provider.chat({
+                      prompt: repair,
+                      images: batch,
+                      model,
+                      curators,
+                      verbosity: "low",
+                      reasoningEffort: "low",
+                      onProgress: (stage) => {
+                        bar.update(stageMap[stage] || 0, { stage });
+                      },
+                      stream: true,
+                      responseFormat: null,
+                    });
+                    ({ keep, aside, unclassified, notes, minutes } = parseReply(
+                      reply,
+                      batch,
+                      { model, verbosity, reasoningEffort }
+                    ));
                   }
+                }
+                if (keep.length + aside.length === 0) {
+                  console.log(
+                    dim(
+                      `⚠️  No decisions after ${attempts} attempt(s); marking NEEDS_REVIEW and continuing.`
+                    )
+                  );
+                  const marker = path.join(dir, "NEEDS_REVIEW");
+                  const list = batch
+                    .map((f) => path.basename(f))
+                    .join("\n");
+                  try {
+                    const prev = await readFile(marker, "utf8").catch(() => "");
+                    await writeFile(marker, `${prev}${list}\n`, "utf8");
+                  } catch {}
+                  return;
                 }
                 const ms = Date.now() - batchStart;
                 bar.update(4, { stage: "done" });

--- a/src/providers/ollama.js
+++ b/src/providers/ollama.js
@@ -28,6 +28,8 @@ export default class OllamaProvider {
     savePayload,
     expectFieldNotesInstructions = false,
     expectFieldNotesMd = false,
+    minutesMin,
+    minutesMax,
   } = {}) {
     let attempt = 0;
     while (true) {
@@ -72,6 +74,8 @@ export default class OllamaProvider {
           format = buildReplySchema({
             instructions: expectFieldNotesInstructions,
             fullNotes: expectFieldNotesMd,
+            minutesMin,
+            minutesMax,
           });
         }
         if (format !== null) {

--- a/src/providers/openai.js
+++ b/src/providers/openai.js
@@ -8,23 +8,28 @@ export default class OpenAIProvider {
   async chat({
     expectFieldNotesInstructions = false,
     expectFieldNotesMd = false,
+    minutesMin,
+    minutesMax,
     ...opts
   } = {}) {
-    let format = OPENAI_FORMAT_OVERRIDE;
+    let format =
+      opts.responseFormat !== undefined
+        ? opts.responseFormat
+        : OPENAI_FORMAT_OVERRIDE;
     if (format === undefined) {
       format = {
         type: 'json_object',
         schema: buildReplySchema({
           instructions: expectFieldNotesInstructions,
           fullNotes: expectFieldNotesMd,
+          minutesMin,
+          minutesMax,
         }),
       };
     } else if (typeof format === 'string') {
-      format = { type: format };
+      format = format ? { type: format } : null;
     }
-    if (format !== null) {
-      opts.responseFormat = format;
-    }
-    return chatCompletion(opts);
+    if (format !== undefined) opts.responseFormat = format ?? undefined;
+    return chatCompletion({ ...opts, minutesMin, minutesMax });
   }
 }

--- a/src/replySchema.js
+++ b/src/replySchema.js
@@ -1,4 +1,4 @@
-export function buildReplySchema({ instructions = false, fullNotes = false } = {}) {
+export function buildReplySchema({ instructions = false, fullNotes = false, minutesMin = 3, minutesMax = 12 } = {}) {
   const schema = {
     type: 'object',
     additionalProperties: false,
@@ -6,6 +6,8 @@ export function buildReplySchema({ instructions = false, fullNotes = false } = {
     properties: {
       minutes: {
         type: 'array',
+        minItems: minutesMin,
+        maxItems: minutesMax,
         items: {
           type: 'object',
           additionalProperties: false,

--- a/src/templates.js
+++ b/src/templates.js
@@ -6,6 +6,9 @@ export const DEFAULT_PROMPT_PATH = path.resolve(
   new URL('../prompts/default_prompt.hbs', import.meta.url).pathname
 );
 
+const fmin = Number(process.env.PHOTO_SELECT_MINUTES_FACTOR_MIN || 1.5);
+const fmax = Number(process.env.PHOTO_SELECT_MINUTES_FACTOR_MAX || 2.5);
+
 export async function renderTemplate(filePath = DEFAULT_PROMPT_PATH, data = {}) {
   const source = await fs.readFile(filePath, 'utf8');
   const template = Handlebars.compile(source, { noEscape: true });
@@ -29,7 +32,10 @@ export async function buildPrompt(
   const context = contextPath
     ? await fs.readFile(contextPath, 'utf8').catch(() => '')
     : '';
-  return renderTemplate(filePath, {
+  const base = Math.max(curators.length || 1, images.length || 1);
+  const minutesMin = Math.ceil(fmin * base);
+  const minutesMax = Math.ceil(fmax * base);
+  const prompt = await renderTemplate(filePath, {
     curators: curators.join(', '),
     images: images.map((f) => path.basename(f)),
     context,
@@ -39,6 +45,9 @@ export async function buildPrompt(
     commitMessages,
     hasFieldNotes,
     isSecondPass,
+    minutesMin,
+    minutesMax,
   });
+  return { prompt, minutesMin, minutesMax };
 }
 

--- a/tests/templates.test.js
+++ b/tests/templates.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { buildPrompt } from '../src/templates.js';
+
+describe('buildPrompt', () => {
+  it('includes role-play phrase and minutes range', async () => {
+    const { prompt, minutesMin, minutesMax } = await buildPrompt(undefined, {
+      curators: ['Curator-A', 'Curator-B'],
+      images: ['a.jpg', 'b.jpg'],
+    });
+    expect(prompt).toMatch(
+      `Role play as Curator-A, Curator-B:\n - Indicate who is speaking\n - Say what you think`
+    );
+    expect(prompt).toContain(
+      `MINUTES (${minutesMin}–${minutesMax} bullet lines)`
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- compute minute length bounds from curator/image counts and render in prompt
- replace default prompt with minutes plus strict DECISIONS_JSON block
- add repair pass with DECISIONS_JSON extraction, retry backoff, and networking knobs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cd29460048330ac1e9e7c827d5b3a