### PR TITLE
Use text.format for Responses API JSON schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,15 +355,19 @@ through that API, so no extra flags are needed.
 
 OpenAI requests now include a JSON schema so the API returns typed responses.
 Set `PHOTO_SELECT_OPENAI_FORMAT` to override this or provide an empty string to
-skip the `response_format` parameter entirely.
+skip the format parameter entirely on chat.completions.
 
 ```bash
 export PHOTO_SELECT_OPENAI_FORMAT='{"type":"json_object","schema":{...}}'
 export PHOTO_SELECT_OPENAI_FORMAT=""  # disable the parameter
 ```
 
-The OpenAI request uses `response_format: { type: "json_object" }` so the
-assistant replies with strict JSON, avoiding the need to strip Markdown fences.
+For chat.completions the request uses
+`response_format: { type: "json_object" }`.
+For the Responses API (gpt-5 models) the schema lives under
+`text.format`.
+In both cases the assistant replies with strict JSON, avoiding the need to
+strip Markdown fences.
 The CLI allows up to 8192 tokens in each reply (see `MAX_RESPONSE_TOKENS` in
 `src/chatClient.js`) so the minutes and JSON decision block are returned in
 full.

--- a/project-overview.txt
+++ b/project-overview.txt
@@ -1642,15 +1642,19 @@ through that API, so no extra flags are needed.
 
 OpenAI requests now include a JSON schema so the API returns typed responses.
 Set `PHOTO_SELECT_OPENAI_FORMAT` to override this or provide an empty string to
-skip the `response_format` parameter entirely.
+skip the format parameter entirely on chat.completions.
 
 ```bash
 export PHOTO_SELECT_OPENAI_FORMAT='{"type":"json_object","schema":{...}}'
 export PHOTO_SELECT_OPENAI_FORMAT=""  # disable the parameter
 ```
 
-The OpenAI request uses `response_format: { type: "json_object" }` so the
-assistant replies with strict JSON, avoiding the need to strip Markdown fences.
+For chat.completions the request uses
+`response_format: { type: "json_object" }`.
+For the Responses API (gpt-5 models) the schema lives under
+`text.format`.
+In both cases the assistant replies with strict JSON, avoiding the need to
+strip Markdown fences.
 The CLI allows up to 8192 tokens in each reply (see `MAX_RESPONSE_TOKENS` in
 `src/chatClient.js`) so the minutes and JSON decision block are returned in
 full.

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -472,8 +472,10 @@ export async function chatCompletion({
           model,
           instructions,
           input,
-          response_format: { type: "json_schema", json_schema: schema },
-          text: { verbosity },
+          text: {
+            verbosity,
+            format: { type: "json_schema", json_schema: schema },
+          },
           reasoning: { effort: reasoningEffort },
           max_output_tokens: MAX_RESPONSE_TOKENS,
         };
@@ -590,8 +592,10 @@ export async function chatCompletion({
           model,
           instructions,
           input,
-          response_format: { type: "json_schema", json_schema: schema },
-          text: { verbosity },
+          text: {
+            verbosity,
+            format: { type: "json_schema", json_schema: schema },
+          },
           reasoning: { effort: reasoningEffort },
           max_output_tokens: MAX_RESPONSE_TOKENS,
         };

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -370,10 +370,10 @@ describe("chatCompletion", () => {
     const args = responsesSpy.mock.calls[0][0];
     expect(args.text.verbosity).toBe("low");
     expect(args.reasoning.effort).toBe("minimal");
-    expect(args.response_format.type).toBe("json_schema");
-    expect(args.response_format.json_schema.name).toBe("PhotoSelectPanelV1");
+    expect(args.text.format.type).toBe("json_schema");
+    expect(args.text.format.json_schema.name).toBe("PhotoSelectPanelV1");
     expect(
-      args.response_format.json_schema.schema.properties.minutes.items.properties.speaker.type
+      args.text.format.json_schema.schema.properties.minutes.items.properties.speaker.type
     ).toBe("string");
     expect(result).toBe("ok");
   });


### PR DESCRIPTION
## Summary
- switch gpt-5 Responses API requests to send JSON schema via `text.format`
- update tests and docs for `text.format`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e6589cf7083308a03acda09906900