### PR TITLE
Fix Responses API text.format schema shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,8 +364,8 @@ export PHOTO_SELECT_OPENAI_FORMAT=""  # disable the parameter
 
 For chat.completions the request uses
 `response_format: { type: "json_object" }`.
-For the Responses API (gpt-5 models) the schema lives under
-`text.format`.
+For the Responses API (gpt-5 models) the schema is supplied under
+`text.format` with top-level `name`, `schema`, and `strict: true`.
 In both cases the assistant replies with strict JSON, avoiding the need to
 strip Markdown fences.
 The CLI allows up to 8192 tokens in each reply (see `MAX_RESPONSE_TOKENS` in

--- a/project-overview.txt
+++ b/project-overview.txt
@@ -1651,8 +1651,8 @@ export PHOTO_SELECT_OPENAI_FORMAT=""  # disable the parameter
 
 For chat.completions the request uses
 `response_format: { type: "json_object" }`.
-For the Responses API (gpt-5 models) the schema lives under
-`text.format`.
+For the Responses API (gpt-5 models) the schema is supplied under
+`text.format` with top-level `name`, `schema`, and `strict: true`.
 In both cases the assistant replies with strict JSON, avoiding the need to
 strip Markdown fences.
 The CLI allows up to 8192 tokens in each reply (see `MAX_RESPONSE_TOKENS` in

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -474,7 +474,12 @@ export async function chatCompletion({
           input,
           text: {
             verbosity,
-            format: { type: "json_schema", json_schema: schema },
+            format: {
+              type: "json_schema",
+              name: schema.name,
+              schema: schema.schema,
+              strict: true,
+            },
           },
           reasoning: { effort: reasoningEffort },
           max_output_tokens: MAX_RESPONSE_TOKENS,
@@ -594,7 +599,12 @@ export async function chatCompletion({
           input,
           text: {
             verbosity,
-            format: { type: "json_schema", json_schema: schema },
+            format: {
+              type: "json_schema",
+              name: schema.name,
+              schema: schema.schema,
+              strict: true,
+            },
           },
           reasoning: { effort: reasoningEffort },
           max_output_tokens: MAX_RESPONSE_TOKENS,

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -371,9 +371,10 @@ describe("chatCompletion", () => {
     expect(args.text.verbosity).toBe("low");
     expect(args.reasoning.effort).toBe("minimal");
     expect(args.text.format.type).toBe("json_schema");
-    expect(args.text.format.json_schema.name).toBe("PhotoSelectPanelV1");
+    expect(args.text.format.name).toBe("PhotoSelectPanelV1");
+    expect(args.text.format.strict).toBe(true);
     expect(
-      args.text.format.json_schema.schema.properties.minutes.items.properties.speaker.type
+      args.text.format.schema.properties.minutes.items.properties.speaker.type
     ).toBe("string");
     expect(result).toBe("ok");
   });


### PR DESCRIPTION
## Summary
- flatten `text.format` when calling `openai.responses.create`
- add `strict: true` and update tests for flattened schema
- document top-level `name`/`schema` fields for Responses API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e71365bec833093ba33e643a2d9b9