### PR TITLE
feat: configure HTTP pool and tweak concurrency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,9 +16,10 @@ PHOTO_SELECT_ZERO_DECISION_MAX_STREAK_SMALL=1
 PHOTO_SELECT_ZERO_DECISION_MAX_STREAK_LARGE=2
 
 # Networking
-PHOTO_SELECT_TIMEOUT_MS=600000           # 8–10 min recommended
+PHOTO_SELECT_TIMEOUT_MS=900000           # 15 min
 PHOTO_SELECT_MAX_RETRIES=8
-PHOTO_SELECT_RETRY_BASE_MS=500           # exponential backoff base
+PHOTO_SELECT_RETRY_BASE_MS=1500          # exponential backoff base
+PHOTO_SELECT_MAX_CONCURRENT=6            # cap in-flight requests
 
 # Autoscaling knobs (computed from --workers; see README)
 # PHOTO_SELECT_MAX_SOCKETS=8

--- a/src/index.js
+++ b/src/index.js
@@ -114,6 +114,10 @@ process.env.PHOTO_SELECT_BUMP_TOKENS = String(
   Math.min(4000 + 500 * (workers - 1), 8000)
 );
 
+// Ensure HTTP pool + timeouts honor the env we just set.
+import { configureHttpFromEnv } from './net.js';
+configureHttpFromEnv();
+
 if (verbose) {
   process.env.PHOTO_SELECT_VERBOSE = '1';
 }

--- a/src/net.js
+++ b/src/net.js
@@ -1,0 +1,24 @@
+// Configure Undici global dispatcher from PHOTO_SELECT_* env.
+import { Agent, setGlobalDispatcher } from 'undici';
+
+function num(name, fallback) {
+  const v = Number(process.env[name]);
+  return Number.isFinite(v) ? v : fallback;
+}
+
+export function configureHttpFromEnv() {
+  const connections = num('PHOTO_SELECT_MAX_SOCKETS', 8);
+  const keepAliveTimeout = num('PHOTO_SELECT_KEEPALIVE_MS', 10_000);
+  const keepAliveMaxTimeout = num('PHOTO_SELECT_FREE_SOCKET_TIMEOUT_MS', 60_000);
+  const bodyTimeout = num('PHOTO_SELECT_TIMEOUT_MS', 600_000);
+  const headersTimeout = bodyTimeout;
+
+  setGlobalDispatcher(new Agent({
+    connections,
+    pipelining: 1,
+    keepAliveTimeout,
+    keepAliveMaxTimeout,
+    bodyTimeout,
+    headersTimeout,
+  }));
+}

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -69,6 +69,12 @@ const MAX_LARGE = Number(
 );
 // Enforce hard cap for vision LLM stability.
 const BATCH_SIZE = Math.min(Number(process.env.PHOTO_SELECT_BATCH_SIZE || 10), BATCH_CAP);
+const CONCURRENCY = Number(process.env.PHOTO_SELECT_MAX_CONCURRENT || 10);
+if (process.env.PHOTO_SELECT_VERBOSE === '1') {
+  console.log(
+    `⚙️  BATCH_SIZE=${BATCH_SIZE} (cap=${BATCH_CAP}) CONCURRENCY=${CONCURRENCY} SMALL_THRESHOLD=${SMALL}`
+  );
+}
 
 function prettyLLMReply(raw, { maxMinutes = MAX_MINUTES } = {}) {
   const json = extractJsonBlock(raw);


### PR DESCRIPTION
## Summary
- wire Undici's global dispatcher to PHOTO_SELECT_* settings
- log batch size and concurrency when verbose
- recommend lower concurrency and longer timeouts in `.env.example`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f98530df083309b2e98c3a6f5e756