### PR TITLE
fix(http): make Undici dispatcher opt-in and lazy; add early bootstrap log

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import "./errorHandler.js";
 import { Command } from "commander";
 import path from "node:path";
 import { DEFAULT_PROMPT_PATH } from "./templates.js";
-
+import { configureHttpFromEnv } from "./net.js";
 
 const program = new Command();
 program
@@ -114,9 +114,14 @@ process.env.PHOTO_SELECT_BUMP_TOKENS = String(
   Math.min(4000 + 500 * (workers - 1), 8000)
 );
 
-// Ensure HTTP pool + timeouts honor the env we just set.
-import { configureHttpFromEnv } from './net.js';
-configureHttpFromEnv();
+// Early bootstrap log (helps confirm the process is alive).
+if (process.env.PHOTO_SELECT_VERBOSE === '1') {
+  console.log(`🔧 bootstrap: node=${process.version} workers=${workers} dir=${process.cwd()}`);
+}
+
+// Configure HTTP dispatcher only if explicitly enabled.
+// This is async but we don't block startup on it.
+void configureHttpFromEnv();
 
 if (verbose) {
   process.env.PHOTO_SELECT_VERBOSE = '1';

--- a/src/net.js
+++ b/src/net.js
@@ -1,24 +1,55 @@
-// Configure Undici global dispatcher from PHOTO_SELECT_* env.
-import { Agent, setGlobalDispatcher } from 'undici';
+// Configure HTTP stack from env. By default this is a NO-OP.
+// To enable Undici tuning, set: PHOTO_SELECT_HTTP_DRIVER=undici
+// We keep the import lazy and opt-in to avoid boot hangs on systems
+// where `import('undici')` misbehaves.
 
 function num(name, fallback) {
   const v = Number(process.env[name]);
   return Number.isFinite(v) ? v : fallback;
 }
 
-export function configureHttpFromEnv() {
-  const connections = num('PHOTO_SELECT_MAX_SOCKETS', 8);
-  const keepAliveTimeout = num('PHOTO_SELECT_KEEPALIVE_MS', 10_000);
-  const keepAliveMaxTimeout = num('PHOTO_SELECT_FREE_SOCKET_TIMEOUT_MS', 60_000);
-  const bodyTimeout = num('PHOTO_SELECT_TIMEOUT_MS', 600_000);
-  const headersTimeout = bodyTimeout;
+export async function configureHttpFromEnv() {
+  const driver = String(process.env.PHOTO_SELECT_HTTP_DRIVER || '').toLowerCase();
+  if (driver !== 'undici') {
+    if (process.env.PHOTO_SELECT_VERBOSE === '1') {
+      console.log('⚙️  HTTP: using Node default dispatcher (no Undici override)');
+    }
+    return false;
+  }
 
-  setGlobalDispatcher(new Agent({
-    connections,
-    pipelining: 1,
-    keepAliveTimeout,
-    keepAliveMaxTimeout,
-    bodyTimeout,
-    headersTimeout,
-  }));
+  try {
+    // Prefer CommonJS require when available; fall back to dynamic import.
+    // This tends to be more robust across setups.
+    let Agent, setGlobalDispatcher;
+    try {
+      const { createRequire } = await import('node:module');
+      const require = createRequire(import.meta.url);
+      ({ Agent, setGlobalDispatcher } = require('undici'));
+    } catch {
+      ({ Agent, setGlobalDispatcher } = await import('undici'));
+    }
+
+    const connections = num('PHOTO_SELECT_MAX_SOCKETS', 8);
+    const keepAliveTimeout = num('PHOTO_SELECT_KEEPALIVE_MS', 10_000);
+    const keepAliveMaxTimeout = num('PHOTO_SELECT_FREE_SOCKET_TIMEOUT_MS', 60_000);
+    const bodyTimeout = num('PHOTO_SELECT_TIMEOUT_MS', 600_000);
+    const headersTimeout = bodyTimeout;
+
+    setGlobalDispatcher(new Agent({
+      connections,
+      pipelining: 1,
+      keepAliveTimeout,
+      keepAliveMaxTimeout,
+      bodyTimeout,
+      headersTimeout,
+    }));
+
+    if (process.env.PHOTO_SELECT_VERBOSE === '1') {
+      console.log(`⚙️  HTTP: undici dispatcher set (connections=${connections}, keepAlive=${keepAliveTimeout}ms, freeTimeout=${keepAliveMaxTimeout}ms, bodyTimeout=${bodyTimeout}ms)`);
+    }
+    return true;
+  } catch (e) {
+    console.warn('⚠️  HTTP: failed to configure undici dispatcher; continuing with defaults:', e?.message || e);
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
- make HTTP dispatcher opt-in and lazy to avoid startup hangs
- add bootstrap log and defer async dispatcher configuration

## Testing
- `npm test`
- `node -p "require.resolve('undici')"`
- `node -e "try{ require('undici'); console.log('undici require: ok') }catch(e){ console.error(e); process.exit(1) }"`
- `PHOTO_SELECT_VERBOSE=1 node src/index.js --model gpt-5 --curators "Curator A" --dir tests/fixtures >run.log 2>&1` (shows bootstrap log and default dispatcher message)
- `PHOTO_SELECT_VERBOSE=1 PHOTO_SELECT_HTTP_DRIVER=undici node -e "import('./src/net.js').then(m=>m.configureHttpFromEnv()).then(()=>setTimeout(()=>{},100)).catch(e=>console.error(e));"`

------
https://chatgpt.com/codex/tasks/task_e_689faa8074ec8330a67662ab128c06b1