### PR TITLE
feat: add auto reasoning effort option

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ through to the script unchanged.
 | `--curators` | *(unset)* | Comma-separated list of curator names used in the group transcript |
 | `--context` | *(unset)* | Text file with exhibition context for the curators |
 | `--verbosity` | `high` | Verbosity for GPT-5 models (`low`, `medium`, `high`) |
-| `--reasoning-effort` | `high` | Reasoning effort for GPT-5 models (`minimal`, `low`, `medium`, `high`) |
+| `--reasoning-effort` | `high` | Reasoning effort for GPT-5 models (`minimal`, `low`, `medium`, `high`, `auto`) |
 | `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |
 | `--parallel` | *(deprecated)* | Maps to `--workers` and prints a warning |
 | `--field-notes` | `false` | Enable notebook updates via field-notes workflow |

--- a/project-overview.txt
+++ b/project-overview.txt
@@ -1401,7 +1401,7 @@ through to the script unchanged.
 | `--curators` | *(unset)* | Comma-separated list of curator names used in the group transcript |
 | `--context` | *(unset)* | Text file with exhibition context for the curators |
 | `--verbosity` | `high` | Verbosity for GPT-5 models (`low`, `medium`, `high`) |
-| `--reasoning-effort` | `high` | Reasoning effort for GPT-5 models (`minimal`, `low`, `medium`, `high`) |
+| `--reasoning-effort` | `high` | Reasoning effort for GPT-5 models (`minimal`, `low`, `medium`, `high`, `auto`) |
 | `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |
 | `--parallel` | *(deprecated)* | Maps to `--workers` and prints a warning |
 | `--field-notes` | `false` | Enable notebook updates via field-notes workflow |
@@ -3844,7 +3844,7 @@ program
   )
   .option(
     "--reasoning-effort <level>",
-    "Reasoning effort (minimal|low|medium|high)",
+    "Reasoning effort (minimal|low|medium|high|auto)",
     process.env.PHOTO_SELECT_REASONING_EFFORT
   )
   .option("--no-recurse", "Process a single directory only")

--- a/src/effortGuard.js
+++ b/src/effortGuard.js
@@ -2,6 +2,7 @@ export const RANK = { minimal: 0, low: 1, medium: 2, high: 3 };
 
 export function enforceEffortGuard(requestEffort) {
   const user = process.env.PHOTO_SELECT_USER_EFFORT || "minimal";
+  if (user === "auto" || requestEffort === "auto") return;
   if (RANK[requestEffort] < RANK[user]) {
     throw new Error(`EffortGuard: requested ${requestEffort} < user ${user}`);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ program
   )
   .option(
     "--reasoning-effort <level>",
-    "Reasoning effort (minimal|low|medium|high)",
+    "Reasoning effort (minimal|low|medium|high|auto)",
     process.env.PHOTO_SELECT_REASONING_EFFORT
   )
   .option("--no-recurse", "Process a single directory only")
@@ -140,7 +140,7 @@ if (!finalModel) {
   finalModel = provider === 'ollama' ? 'qwen2.5vl:32b' : 'gpt-4o';
 }
 
-let finalReasoningEffort = reasoningEffort;
+let finalReasoningEffort = reasoningEffort?.toLowerCase();
 if (!finalReasoningEffort) {
   finalReasoningEffort = /^gpt-5/.test(finalModel) ? 'low' : 'minimal';
 }

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -432,6 +432,20 @@ describe("chatCompletion", () => {
     expect(args.reasoning.effort).toBe("high");
   });
 
+  it("omits reasoning when effort is auto", async () => {
+    responsesSpy.mockClear();
+    responsesSpy.mockResolvedValueOnce({ output_text: "ok" });
+    await chatCompletion({
+      prompt: "p",
+      images: [],
+      model: "gpt-5",
+      cache: false,
+      reasoningEffort: "auto",
+    });
+    const args = responsesSpy.mock.calls[0][0];
+    expect(args.reasoning).toBeUndefined();
+  });
+
   it("rejects invalid flags", async () => {
     await expect(
       chatCompletion({

--- a/tests/effortGuard.test.js
+++ b/tests/effortGuard.test.js
@@ -7,4 +7,10 @@ describe('effort guard', () => {
     expect(() => enforceEffortGuard('medium')).toThrow(/EffortGuard/);
     delete process.env.PHOTO_SELECT_USER_EFFORT;
   });
+
+  it('allows auto', () => {
+    process.env.PHOTO_SELECT_USER_EFFORT = 'auto';
+    expect(() => enforceEffortGuard('minimal')).not.toThrow();
+    delete process.env.PHOTO_SELECT_USER_EFFORT;
+  });
 });


### PR DESCRIPTION
## Summary
- support `--reasoning-effort auto` CLI flag and omit reasoning field when chosen
- skip effort guard when effort is `auto`
- document and test auto reasoning behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fd52682fc8330a92daec2bfe18254