### PR TITLE
Add Undici smoke test script for network debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,30 @@ available RAM.
 
 Use `--workers N` to process batches concurrently. The old `--parallel` flag is deprecated and is automatically mapped to `--workers`. A deprecation warning is printed if you use it.
 
+### Undici smoke test
+
+If you suspect Undici (or DNS/IPv6) is stalling, run the minimal probe:
+
+```bash
+npm i -D undici
+node scripts/undici-smoke.mjs                # defaults to httpbin
+OPENAI_API_KEY=sk-... node scripts/undici-smoke.mjs https://api.openai.com/v1/models
+```
+
+Helpful flags:
+
+```bash
+# Prefer IPv4 if v6 is flaky on your network
+NODE_OPTIONS="--dns-result-order=ipv4first" \
+DEBUG=undici:* \
+SMOKE_CONCURRENCY=8 SMOKE_TIMEOUT_MS=20000 \
+node scripts/undici-smoke.mjs https://httpbin.org/get
+```
+
+The script prints ALPN (h2/h1), remote/local addresses, timing, and whether
+sockets are reused. Once this is healthy, apply the same dispatcher settings
+to the main pipeline.
+
 ### Concurrency & Tuning
 
 Autoscaling widens the pipes without lowering `--reasoning-effort`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "photo-select": "src/index.js"
       },
       "devDependencies": {
+        "undici": "^6.21.3",
         "vitest": "^1.5.0"
       },
       "engines": {
@@ -2647,6 +2648,7 @@
       "version": "6.21.3",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
       "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "start": "photo-select",
-    "test": "vitest run"
+    "test": "vitest run",
+    "undici:smoke": "node scripts/undici-smoke.mjs"
   },
   "engines": {
     "node": ">=20"
@@ -28,6 +29,7 @@
     "undici": "^6.21.3"
   },
   "devDependencies": {
-    "vitest": "^1.5.0"
+    "vitest": "^1.5.0",
+    "undici": "^6.21.3"
   }
 }

--- a/scripts/undici-smoke.mjs
+++ b/scripts/undici-smoke.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// Minimal Undici smoke test: one warm-up request, then N parallel requests.
+// Prints socket/ALPN info via diagnostics_channel.
+import { Agent, setGlobalDispatcher, fetch } from 'undici';
+import dns from 'node:dns';
+import { performance } from 'node:perf_hooks';
+import { channel } from 'node:diagnostics_channel';
+
+const url =
+  process.argv[2] ||
+  (process.env.OPENAI_API_KEY
+    ? 'https://api.openai.com/v1/models'
+    : 'https://httpbin.org/get');
+
+const concurrency   = Number(process.env.SMOKE_CONCURRENCY || 4);
+const timeoutMs     = Number(process.env.SMOKE_TIMEOUT_MS || 15000);
+const connections   = Number(process.env.PHOTO_SELECT_MAX_SOCKETS || 8);
+const keepAliveMs   = Number(process.env.PHOTO_SELECT_KEEPALIVE_MS || 10000);
+const maxKeepAlive  = Number(process.env.PHOTO_SELECT_FREE_SOCKET_TIMEOUT_MS || 60000);
+
+// Tuned global dispatcher (so global fetch/OpenAI client will use it too)
+const agent = new Agent({
+  connections,
+  keepAliveTimeout: keepAliveMs,
+  keepAliveMaxTimeout: maxKeepAlive,
+  headersTimeout: timeoutMs,
+  bodyTimeout: timeoutMs,
+});
+setGlobalDispatcher(agent);
+
+// Lightweight visibility into the socket lifecycle
+let connects = 0, destroyed = 0;
+channel('undici:client:connect').subscribe(({ connectParams }) => {
+  console.log(`↪︎ connect ${connectParams.origin}`);
+});
+channel('undici:client:connected').subscribe(({ socket }) => {
+  connects++;
+  console.log(
+    `✔ connected alpn=${socket.alpnProtocol || 'h1'} ` +
+    `remote=${socket.remoteAddress}:${socket.remotePort} ` +
+    `local=${socket.localAddress}:${socket.localPort}`
+  );
+});
+channel('undici:client:destroy').subscribe(({ error }) => {
+  destroyed++;
+  console.warn(`✖ destroy: ${error?.code || error?.message || 'no error'}`);
+});
+
+console.log(
+  `🔧 node=${process.version} dns=${dns.getDefaultResultOrder?.() || 'system'} ` +
+  `url=${url}`
+);
+console.log(
+  `🔌 undici connections=${connections} keepAlive=${keepAliveMs}ms ` +
+  `maxKeepAlive=${maxKeepAlive}ms concurrency=${concurrency} timeout=${timeoutMs}ms`
+);
+
+const headers = {};
+if (/openai\.com/.test(url) && process.env.OPENAI_API_KEY) {
+  headers.Authorization = `Bearer ${process.env.OPENAI_API_KEY}`;
+}
+
+const t0 = performance.now();
+const first = await fetch(url, { headers, signal: AbortSignal.timeout(timeoutMs) });
+const t1 = performance.now();
+console.log(
+  `① status=${first.status} ${first.statusText} ` +
+  `took=${Math.round(t1 - t0)}ms connection=${first.headers.get('connection') || 'n/a'} ` +
+  `server=${first.headers.get('server') || 'n/a'}`
+);
+const sample = (await first.text()).slice(0, 200).replace(/\s+/g, ' ');
+console.log(`   body[0:200]=${JSON.stringify(sample)}`);
+
+const t2 = performance.now();
+await Promise.all(
+  Array.from({ length: concurrency }, () =>
+    fetch(url, { headers, signal: AbortSignal.timeout(timeoutMs) }).then(r => r.arrayBuffer())
+  )
+);
+const t3 = performance.now();
+console.log(`② ${concurrency}× parallel ok in ${Math.round(t3 - t2)}ms`);
+
+await agent.close();
+console.log(`🔁 sockets opened=${connects} destroyed=${destroyed}`);
+


### PR DESCRIPTION
## Summary
- add `scripts/undici-smoke.mjs` to probe Undici connectivity, ALPN, keep-alive, and timeouts
- document smoke test usage and helpful flags in README
- expose script via `npm run undici:smoke` and include Undici as a dev dependency

## Testing
- `npm test` *(fails: tests/templates.test.js > buildPrompt > injects role-play phrase and minutes range)*
- `npm run undici:smoke` *(fails: TypeError: fetch failed – ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d969d29883309eff87580c608d4d