### PR TITLE
Filter `_UNKNOWN_` placeholders from people metadata (prompt + auto-curators)

### DIFF
--- a/src/lib/people.js
+++ b/src/lib/people.js
@@ -1,0 +1,24 @@
+// src/lib/people.js
+export function isPlaceholder(name) {
+  if (name == null) return true;
+  const s = String(name).trim();
+  // Accept tokens that are *only* a placeholder, optionally with #index or underscores
+  // Matches: "unknown", "_UNKNOWN_", "Unknown #3", "unknown3", "unknown 3"
+  return /^_?unknown(?:\s*#?\d+)?_?$/i.test(s);
+}
+
+export function sanitizePeople(input) {
+  const seen = new Set();
+  const out = [];
+  for (const raw of Array.isArray(input) ? input : []) {
+    if (raw == null) continue;
+    const s = String(raw).trim();
+    if (!s) continue;
+    if (isPlaceholder(s)) continue;
+    if (!seen.has(s)) {
+      seen.add(s);
+      out.push(s);
+    }
+  }
+  return out;
+}

--- a/tests/people.test.js
+++ b/tests/people.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { isPlaceholder, sanitizePeople } from '../src/lib/people.js';
+
+describe('people sanitizer', () => {
+  it('detects placeholder tokens', () => {
+    ['_UNKNOWN_', 'unknown', 'Unknown #2', 'unknown3', 'unknown 3'].forEach(t =>
+      expect(isPlaceholder(t)).toBe(true)
+    );
+    ['Olivia J Mann', 'Beata (neighbor)', 'Unknown Pleasures'].forEach(t =>
+      expect(isPlaceholder(t)).toBe(false)
+    );
+  });
+
+  it('sanitizes, trims, and dedupes', () => {
+    const raw = ['  Olivia J Mann ', '_UNKNOWN_', 'Beata (neighbor)', 'unknown #1', 'Olivia J Mann'];
+    expect(sanitizePeople(raw)).toEqual(['Olivia J Mann', 'Beata (neighbor)']);
+  });
+});

--- a/tests/prompt-people.test.js
+++ b/tests/prompt-people.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+vi.mock('../src/config.js', () => ({ delay: vi.fn() }));
+vi.mock('openai', () => ({ OpenAI: vi.fn(() => ({})), NotFoundError: class {} }));
+
+import { buildMessages } from '../src/chatClient.js';
+
+beforeAll(() => {
+  global.fetch = vi.fn();
+});
+
+afterAll(() => {
+  global.fetch = undefined;
+});
+
+describe('prompt people sanitization', () => {
+  it('filters placeholder people from notes', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ps-prompt-'));
+    const img = path.join(dir, 'A.jpg');
+    await fs.writeFile(img, 'a');
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: ['_UNKNOWN_', 'Olivia J Mann'] }),
+    });
+    const { messages } = await buildMessages('prompt', [img]);
+    const meta = JSON.parse(messages[1].content[1].text);
+    expect(meta).toEqual({ filename: 'A.jpg', people: ['Olivia J Mann'] });
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+});

--- a/tests/templates.test.js
+++ b/tests/templates.test.js
@@ -8,7 +8,7 @@ describe('buildPrompt', () => {
       images: ['DSCF1234.jpg', 'DSCF5678.jpg'],
     });
     expect(prompt).toMatch(
-      'Role play as Ingeborg Gerdes, Alexandra Munroe:\n - Inidicate who is speaking\n - Say what you think'
+      'Role play as Ingeborg Gerdes, Alexandra Munroe:\n - Indicate who is speaking\n - Say what you think'
     );
     expect(prompt).toMatch('Produce between 3 and 5 diarized items');
     expect(minutesMin).toBe(3);


### PR DESCRIPTION
## Summary
- add `sanitizePeople()` utility to trim, dedupe, and drop placeholder names
- strip placeholder tags from per-image notes and auto-curator enrichment with optional verbose logging
- cover sanitizer and prompt path with new tests

## Testing
- `npm test`

## Before / After
- ```diff
- {"filename":"20250531T193841000000Z-DSCF8788.jpg","people":["Jordan Lev (K+M)","_UNKNOWN_"]}
- {"filename":"20250531T193841000000Z-DSCF8788.jpg","people":["Jordan Lev (K+M)"]}
- ```

------
https://chatgpt.com/codex/tasks/task_e_68a11d4897b48330a31df773009c1157