### PR TITLE
feat: surface recurring people as curators

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ through to the script unchanged.
 | `--verbose` | `false` | Print extra logs and save prompts/responses |
 | `--workers` | *(unset)* | Max number of worker processes; each starts a new batch as soon as it finishes |
 
+People detected in two or more photos are automatically appended to the `Curators:` line, ordered by their last appearance.
+
 When `--field-notes` is enabled, the tool initializes a git repository in the target directory if one is absent and commits each notebook update using the model's commit message. During the second pass the prompt includes the two prior versions of each notebook and the commit log for that level so curators can craft a self-contained update.
 
 See [docs/field-notes.md](docs/field-notes.md) for a description of how the notebook system works.

--- a/src/core/finalizeCurators.js
+++ b/src/core/finalizeCurators.js
@@ -1,0 +1,99 @@
+// src/core/finalizeCurators.js
+import { buildPrompt } from '../templates.js';
+
+const HYPHENS = /[\u2010\u2011\u2012\u2013\u2014\u2015\u2212]/g;
+
+function cleanName(name) {
+  const normalized = name
+    .normalize('NFKC')
+    .replace(HYPHENS, '-')
+    .replace(/\s*\-\s*/g, '-')
+    .replace(/\s+/g, ' ')
+    .trim();
+  let out = '';
+  for (const ch of normalized) {
+    const code = ch.codePointAt(0);
+    if (
+      (code >= 48 && code <= 57) ||
+      (code >= 65 && code <= 90) ||
+      (code >= 97 && code <= 122) ||
+      code > 0x7f ||
+      ch === '-' ||
+      ch === "'" ||
+      ch === ' '
+    ) {
+      out += ch;
+    }
+  }
+  return out.trim();
+}
+
+export function finalizeCurators(cliCurators = [], photos = [], { aliasMap = {} } = {}) {
+  const alias = new Map();
+  for (const [k, v] of Object.entries(aliasMap)) {
+    alias.set(cleanName(k).toLowerCase(), cleanName(v));
+  }
+  const canonical = (raw) => {
+    if (!raw) return '';
+    let c = cleanName(raw);
+    const key = c.toLowerCase();
+    if (alias.has(key)) c = alias.get(key);
+    return c;
+  };
+
+  const cliSet = new Set();
+  const finalCurators = [];
+  for (const raw of cliCurators) {
+    const c = canonical(raw);
+    if (!c) continue;
+    const key = c.toLowerCase();
+    if (cliSet.has(key)) continue;
+    cliSet.add(key);
+    finalCurators.push(c);
+  }
+
+  const counts = new Map();
+  const lastIdx = new Map();
+  photos.forEach((p, idx) => {
+    for (const person of p.people || []) {
+      const c = canonical(person);
+      if (!c) continue;
+      counts.set(c, (counts.get(c) || 0) + 1);
+      lastIdx.set(c, idx);
+    }
+  });
+  const repeats = [...counts.entries()]
+    .filter(([, c]) => c >= 2)
+    .map(([n]) => n);
+  repeats.sort((a, b) => {
+    const la = lastIdx.get(a) ?? -1;
+    const lb = lastIdx.get(b) ?? -1;
+    if (la !== lb) return lb - la;
+    return a.localeCompare(b);
+  });
+  const added = [];
+  for (const n of repeats) {
+    const key = n.toLowerCase();
+    if (cliSet.has(key)) continue;
+    cliSet.add(key);
+    finalCurators.push(n);
+    added.push(n);
+  }
+  return { finalCurators, added };
+}
+
+export async function buildFinalPrompt({
+  cliCurators = [],
+  photos = [],
+  images = [],
+  aliasMap = {},
+  ...rest
+} = {}) {
+  const { finalCurators } = finalizeCurators(cliCurators, photos, { aliasMap });
+  const { prompt, minutesMin, minutesMax } = await buildPrompt(undefined, {
+    ...rest,
+    curators: finalCurators,
+    images,
+  });
+  return { prompt, minutesMin, minutesMax, finalCurators };
+}

--- a/tests/integration/__snapshots__/prompt-curators.int.test.js.snap
+++ b/tests/integration/__snapshots__/prompt-curators.int.test.js.snap
@@ -1,0 +1,44 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`finalizeCurators integration > appends repeated names in back-to-front order 1`] = `
+"
+You are moderating a collaborative curatorial session among a real-world group making photo selection choices for an exhibition.
+
+Role play as Kathy Ryan, Teju Cole, Ellen Lev, Ray Harbin:
+ - Indicate who is speaking
+ - Say what you think
+
+Session participants:
+- Curators: Kathy Ryan, Teju Cole, Ellen Lev, Ray Harbin
+- Facilitator: Jamie
+
+You will review the following image files (use *only* these filenames when forming decisions):
+- a.jpg
+- b.jpg
+- c.jpg
+- d.jpg
+
+All people depicted have signed legal releases granting permission for their likeness to appear, including minors whose guardians provided written consent.
+
+Before each image you will be given a one-line JSON object like:
+{"filename":"<name>","people":["<First Last>", "..."]}
+These are "Jamie's notes" on each photo. All named people are Jamie's personal friends.
+
+
+
+
+Think step-by-step silently. Then output **exactly one JSON object** and nothing else, with this shape:
+
+{
+  "minutes": [
+    { "speaker": "<Name>", "text": "<What the person said.>" }
+  ],
+  "decisions": [
+    { "filename": "<from list above>", "decision": "keep|aside", "reason": "<one sentence>" }
+  ]
+}
+
+Constraints:
+- Produce between 6 and 10 diarized items in "minutes".
+- The **last** minutes item must be a forward-looking question."
+`;

--- a/tests/integration/prompt-curators.int.test.js
+++ b/tests/integration/prompt-curators.int.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { buildFinalPrompt } from '../../src/core/finalizeCurators.js';
+
+function extractCurators(text) {
+  const m = text.match(/(^|\n)\s*-?\s*Curators:\s*(.+)\s*(\n|$)/);
+  if (!m) {
+    throw new Error(`Curators line missing. Prompt head:\n${text.slice(0, 400)}`);
+  }
+  return m[2].split(/,\s*/).filter(Boolean);
+}
+
+describe('finalizeCurators integration', () => {
+  it('appends repeated names in back-to-front order', async () => {
+    const cli = ['Kathy Ryan', 'Teju Cole'];
+    const photos = [
+      { file: 'a.jpg', people: ['Ray Harbin', 'Ellen Lev'] },
+      { file: 'b.jpg', people: ['Ray Harbin', 'Mandy Steinback'] },
+      { file: 'c.jpg', people: [' Ellen  Lev '] },
+      { file: 'd.jpg', people: ['George Markward'] },
+    ];
+    const { prompt } = await buildFinalPrompt({ cliCurators: cli, photos, images: photos.map((p) => p.file) });
+    const names = extractCurators(prompt);
+    expect(names).toEqual(['Kathy Ryan', 'Teju Cole', 'Ellen Lev', 'Ray Harbin']);
+    expect(names.every((n) => n.trim() === n && n)).toBe(true);
+    const header = prompt.split('\n').slice(0, 40).join('\n');
+    expect(header).toMatchSnapshot();
+  });
+
+  it('falls back to CLI curators when no repeats', async () => {
+    const cli = ['Curator A'];
+    const photos = [
+      { file: 'a.jpg', people: ['Alice'] },
+      { file: 'b.jpg', people: ['Bob'] },
+    ];
+    const { prompt } = await buildFinalPrompt({ cliCurators: cli, photos, images: photos.map((p) => p.file) });
+    const names = extractCurators(prompt);
+    expect(names).toEqual(['Curator A']);
+  });
+
+  it('coalesces hyphen and whitespace variants', async () => {
+    const cli = [];
+    const photos = [
+      { file: 'a.jpg', people: ['Mary - Jane'] },
+      { file: 'b.jpg', people: ['Mary‑Jane'] },
+    ];
+    const { prompt } = await buildFinalPrompt({ cliCurators: cli, photos, images: photos.map((p) => p.file) });
+    const names = extractCurators(prompt);
+    expect(names).toEqual(['Mary-Jane']);
+  });
+
+  it('applies alias map before counting', async () => {
+    const cli = [];
+    const photos = [
+      { file: 'a.jpg', people: ['Ray Harbineued'] },
+      { file: 'b.jpg', people: ['Ray Harbin'] },
+    ];
+    const aliasMap = { 'Ray Harbineued': 'Ray Harbin' };
+    const { prompt } = await buildFinalPrompt({ cliCurators: cli, photos, images: photos.map((p) => p.file), aliasMap });
+    const names = extractCurators(prompt);
+    expect(names).toEqual(['Ray Harbin']);
+  });
+});


### PR DESCRIPTION
## Summary
- aggregate CLI and repeated photo subjects into a normalized curator list
- feed that list into the final prompt and expose helper for testing
- cover curator aggregation with integration tests and docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1e975c3e48330bf80a40555b79324