### PR TITLE
Wire scheduler concurrency and add image preprocessor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,10 +17,12 @@ PHOTO_SELECT_ZERO_DECISION_MAX_STREAK_LARGE=2
 
 # Networking
 PHOTO_SELECT_HTTP_DRIVER=undici          # use tuned Undici dispatcher
-PHOTO_SELECT_TIMEOUT_MS=900000           # 15 min
+UNDICI_CONNECTIONS=12                    # socket pool
+UNDICI_HEADERS_TIMEOUT_MS=60000
+UNDICI_BODY_TIMEOUT_MS=300000
 PHOTO_SELECT_MAX_RETRIES=8
 PHOTO_SELECT_RETRY_BASE_MS=1500          # exponential backoff base
-PHOTO_SELECT_MAX_CONCURRENT=6            # cap in-flight requests
+CONCURRENCY=10                           # cap in-flight requests
 # NODE_OPTIONS="--dns-result-order=ipv4first --max-old-space-size=32768"
 
 # Autoscaling knobs (computed from --workers; see README)
@@ -28,9 +30,13 @@ PHOTO_SELECT_MAX_CONCURRENT=6            # cap in-flight requests
 # PHOTO_SELECT_MAX_FREE_SOCKETS=4
 # PHOTO_SELECT_KEEPALIVE_MS=10000
 # PHOTO_SELECT_FREE_SOCKET_TIMEOUT_MS=60000
-# UV_THREADPOOL_SIZE=12
+# UV_THREADPOOL_SIZE=32
 # PHOTO_SELECT_BATCH_SIZE=8       # hard-capped at 10 for vision LLMs
 # PHOTO_SELECT_PEOPLE_CONCURRENCY=2
 # PHOTO_SELECT_BUMP_TOKENS=4000
 # PHOTO_SELECT_TPM_SOFT_CAP=4000000     # tokens/min (optional global cap)
 # PHOTO_SELECT_RPM_SOFT_CAP=900         # requests/min (optional global cap)
+
+# Image preprocessing
+PHOTO_SELECT_IMAGE_MAX_EDGE=1600
+PHOTO_SELECT_JPEG_QUALITY=75

--- a/src/imagePreprocessor.js
+++ b/src/imagePreprocessor.js
@@ -1,0 +1,37 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import sharp from 'sharp';
+
+function numEnv(name, fallback) {
+  const v = Number(process.env[name]);
+  return Number.isFinite(v) ? v : fallback;
+}
+
+const CACHE_DIR = path.join(process.cwd(), '.cache', 'images');
+
+export async function getSurrogateImage(file) {
+  const info = await fs.stat(file);
+  const maxEdge = numEnv('PHOTO_SELECT_IMAGE_MAX_EDGE', 1600);
+  const quality = numEnv('PHOTO_SELECT_JPEG_QUALITY', 75);
+  const hash = crypto
+    .createHash('sha1')
+    .update(file)
+    .update(String(info.mtimeMs))
+    .update(String(info.size))
+    .update(String(maxEdge))
+    .update(String(quality))
+    .digest('hex');
+  const cachePath = path.join(CACHE_DIR, `${hash}.jpg`);
+  try {
+    return await fs.readFile(cachePath);
+  } catch {}
+  await fs.mkdir(CACHE_DIR, { recursive: true });
+  const buf = await sharp(file)
+    .rotate()
+    .resize({ width: maxEdge, height: maxEdge, fit: 'inside', withoutEnlargement: true })
+    .jpeg({ quality, mozjpeg: true, chromaSubsampling: '4:2:0' })
+    .toBuffer();
+  await fs.writeFile(cachePath, buf);
+  return buf;
+}

--- a/tests/prompt-people.test.js
+++ b/tests/prompt-people.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import sharp from 'sharp';
 
 vi.mock('../src/config.js', () => ({ delay: vi.fn() }));
 vi.mock('openai', () => ({ OpenAI: vi.fn(() => ({})), NotFoundError: class {} }));
@@ -20,7 +21,11 @@ describe('prompt people sanitization', () => {
   it('filters placeholder people from notes', async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ps-prompt-'));
     const img = path.join(dir, 'A.jpg');
-    await fs.writeFile(img, 'a');
+    await sharp({
+      create: { width: 2, height: 2, channels: 3, background: { r: 0, g: 0, b: 0 } },
+    })
+      .jpeg()
+      .toFile(img);
     global.fetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ data: ['_UNKNOWN_', 'Olivia J Mann'] }),

--- a/tests/scheduler.test.js
+++ b/tests/scheduler.test.js
@@ -23,4 +23,25 @@ describe("TokenScheduler", () => {
     expect(done.length).toBe(4);
     // With tpm=10000, tokens=500 each, concurrency cap = 2
   });
+
+  it("allows updating concurrency at runtime", async () => {
+    const s = new TokenScheduler({
+      maxConcurrent: 1,
+      perModel: { default: { tpm: 10000, rpm: 10 } },
+    });
+    const first = await s.reserve({ model: "m", estTokens: 100 });
+    let started = false;
+    const secondPromise = s
+      .reserve({ model: "m", estTokens: 100 })
+      .then((h) => {
+        started = true;
+        s.commit(h, 100);
+      });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(started).toBe(false);
+    s.setConcurrency(2);
+    await secondPromise;
+    s.commit(first, 100);
+    await s.waitForIdle();
+  });
 });


### PR DESCRIPTION
## Summary
- tie scheduler concurrency to `--concurrency` flag and env
- preprocess images with Sharp and cache by hash
- tune Undici client and drain bodies on error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2786ff9208330be41d42f216459d0