### PR TITLE
Increase Ollama context window defaults

### DIFF
--- a/tests/ollamaProvider.test.js
+++ b/tests/ollamaProvider.test.js
@@ -93,6 +93,11 @@ describe('OllamaProvider', () => {
     const body = JSON.parse(init.body);
     expect(body.messages).toHaveLength(2);
     expect(body.messages[1].images).toEqual(['aW1hZ2UtYnl0ZXM=']);
+    expect(body.options).toEqual({
+      num_predict: 128,
+      num_ctx: 32_768,
+      num_keep: -1,
+    });
   });
 
   it('throws a helpful error when the Ollama daemon is unavailable', async () => {


### PR DESCRIPTION
## Summary
- allow overriding Ollama request limits while defaulting to a 32k token context window and retaining the full prompt
- include num_ctx and num_keep in the Ollama request payload to avoid prompt truncation
- extend the Ollama provider unit test to verify the expanded options

## Testing
- `npm test -- tests/ollamaProvider.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68e2dae8a3008330891cab7feb56ae5a