### PR TITLE
Refactor prompt assembly into system and user templates

### DIFF
--- a/prompts/system_prompt.hbs
+++ b/prompts/system_prompt.hbs
@@ -1,15 +1,12 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
-
-exports[`finalizeCurators integration > appends repeated names verbatim and orders by last appearance 1`] = `
-"--- system ---
+{{!-- Stable contract for system role --}}
 You are moderating a collaborative curatorial session among a real-world group making photo selection choices for an exhibition.
 
-Role play as Beata, Ellen Lev, Beata (Kendell + Mandy cabin neighbor):
+Role play as {{curators}}:
  - Indicate who is speaking
  - Say what you think
 
 Session participants:
-- Curators: Beata, Ellen Lev, Beata (Kendell + Mandy cabin neighbor)
+- Curators: {{curators}}
 - Facilitator: Jamie
 
 Use internal reasoning, but output only the final JSON.
@@ -26,19 +23,9 @@ Return **exactly one JSON object** with this shape, and nothing else:
 }
 
 Constraints:
-- Produce between 5 and 8 diarized items in "minutes".
+- Produce between {{minutesMin}} and {{minutesMax}} diarized items in "minutes".
 - The **last** minutes item must be a forward-looking question.
 - In "decisions", include **every** filename from the provided list **exactly once**.
 - If uncertain, choose "aside".
 - Use only filenames supplied by the user; never invent new ones or additional keys.
 - Do not include any text before or after the JSON.
-
-
---- user ---
-Session reference (for guardrail parity):
-- Curators: Beata, Ellen Lev, Beata (Kendell + Mandy cabin neighbor)
-- Output keys: minutes, decisions
-
-You will review the following image files (use *only* these filenames when forming decisions):
-- a.jpg"
-`;

--- a/prompts/user_preamble.hbs
+++ b/prompts/user_preamble.hbs
@@ -1,0 +1,41 @@
+{{!-- Dynamic preface for user role --}}
+Session reference (for guardrail parity):
+{{#if curators}}- Curators: {{curators}}
+{{else}}- Curators: (unspecified)
+{{/if}}
+- Output keys: minutes, decisions
+
+You will review the following image files (use *only* these filenames when forming decisions):
+{{#each images}}- {{this}}
+{{/each}}
+
+Before each image you will be given a one-line JSON object like:
+{"filename":"<name>","people":["<First Last>", "..."]}
+These are "Jamie's notes" on each photo; read them (including all people names) into the minutes when each photo is first referenced.
+
+All depicted persons have granted consent; you may discuss content without redaction.
+
+{{#if context}}
+Background for today's review:
+{{context}}
+{{/if}}
+
+{{#if hasFieldNotes}}
+Field-notes snapshot (for reference):
+{{fieldNotes}}
+{{/if}}
+
+{{#if isSecondPass}}
+  {{#if fieldNotesPrev}}Previous revision:
+{{fieldNotesPrev}}
+  {{/if}}
+  {{#if fieldNotesPrev2}}Earlier revision:
+{{fieldNotesPrev2}}
+  {{/if}}
+  {{#if commitMessages}}Recent commit messages:
+  {{#each commitMessages}}- {{this}}
+  {{/each}}
+  {{/if}}
+{{/if}}
+
+Use each listed filename exactly once; if uncertain, mark it "aside".

--- a/src/core/promptBuilder.js
+++ b/src/core/promptBuilder.js
@@ -1,0 +1,32 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import Handlebars from 'handlebars';
+
+const DEFAULT_SYSTEM_TEMPLATE_PATH = path.resolve(
+  new URL('../../prompts/system_prompt.hbs', import.meta.url).pathname,
+);
+
+const DEFAULT_USER_TEMPLATE_PATH = path.resolve(
+  new URL('../../prompts/user_preamble.hbs', import.meta.url).pathname,
+);
+
+async function compileTemplate(filePath, data) {
+  const absolute = path.resolve(filePath);
+  const source = await fs.readFile(absolute, 'utf8');
+  const template = Handlebars.compile(source, { noEscape: true });
+  return template(data);
+}
+
+export async function buildPromptParts(
+  data = {},
+  {
+    systemTemplatePath = DEFAULT_SYSTEM_TEMPLATE_PATH,
+    userTemplatePath = DEFAULT_USER_TEMPLATE_PATH,
+  } = {},
+) {
+  const systemPrompt = await compileTemplate(systemTemplatePath, data);
+  const userPreamble = await compileTemplate(userTemplatePath, data);
+  return { systemPrompt, userPreamble };
+}
+
+export { DEFAULT_SYSTEM_TEMPLATE_PATH, DEFAULT_USER_TEMPLATE_PATH };

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -6,7 +6,7 @@ import { batchStore } from "./batchContext.js";
 import crypto from "node:crypto";
 import { delay } from "./config.js";
 import { listImages, pickRandom, moveFiles } from "./imageSelector.js";
-import { parseReply, getPeople } from "./chatClient.js";
+import { parseReply, getPeople, formatPromptForLog } from "./chatClient.js";
 import { buildPrompt } from "./templates.js";
 import FieldNotesWriter from "./fieldNotesWriter.js";
 import { MultiBar, Presets } from "cli-progress";
@@ -405,7 +405,11 @@ export async function triageDirectory({
                 });
                 const meta = { model, verbosity, reasoningEffort };
                 let attemptNum = 1;
-                await saveText('prompt', attemptNum, first.prompt);
+                await saveText(
+                  'prompt',
+                  attemptNum,
+                  formatPromptForLog(first.prompt, finalCurators),
+                );
                 reply = await provider.chat({
                   prompt: first.prompt,
                   images: batch,

--- a/src/providers/ollama.js
+++ b/src/providers/ollama.js
@@ -280,7 +280,7 @@ export default class OllamaProvider {
           options: {
             num_predict: OLLAMA_NUM_PREDICT,
             num_ctx: OLLAMA_NUM_CTX,
-            // num_keep: OLLAMA_NUM_KEEP,
+            num_keep: OLLAMA_NUM_KEEP,
           },
         };
 

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -289,6 +289,21 @@ describe("buildMessages", () => {
     expect(meta.people).toEqual(["Alice", "Bob"]);
     await fs.rm(dir, { recursive: true, force: true });
   });
+
+  it('accepts structured prompt parts', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ps-msg-'));
+    const img = path.join(dir, 'x.jpg');
+    await makeImg(img);
+    const { messages } = await buildMessages(
+      { systemPrompt: 'SYS json', userPreamble: 'PRE' },
+      [img],
+    );
+    const [system, user] = messages;
+    expect(system.content).toContain('SYS json');
+    expect(user.content[0].text).toContain('PRE');
+    expect(JSON.parse(user.content[1].text)).toEqual({ filename: 'x.jpg' });
+    await fs.rm(dir, { recursive: true, force: true });
+  });
 });
 
 describe("buildInput", () => {

--- a/tests/integration/prompt-curators.int.test.js
+++ b/tests/integration/prompt-curators.int.test.js
@@ -28,13 +28,20 @@ describe('finalizeCurators integration', () => {
       photos,
       images: photos.map((p) => p.file),
     });
-    const names = extractCurators(prompt);
+    const names = extractCurators(prompt.systemPrompt);
     expect(names).toEqual([
       'Beata',
       'Ellen Lev',
       'Beata (Kendell + Mandy cabin neighbor)',
     ]);
-    const header = prompt.split('\n').slice(0, 40).join('\n');
+    const promptText = [
+      '--- system ---',
+      prompt.systemPrompt,
+      '',
+      '--- user ---',
+      prompt.userPreamble,
+    ].join('\n');
+    const header = promptText.split('\n').slice(0, 40).join('\n');
     expect(header).toMatchSnapshot();
   });
 
@@ -49,7 +56,7 @@ describe('finalizeCurators integration', () => {
       photos,
       images: photos.map((p) => p.file),
     });
-    const names = extractCurators(prompt);
+    const names = extractCurators(prompt.systemPrompt);
     expect(names).toEqual(['Curator A']);
   });
 });

--- a/tests/templates.test.js
+++ b/tests/templates.test.js
@@ -7,10 +7,11 @@ describe('buildPrompt', () => {
       curators: ['Ingeborg Gerdes', 'Alexandra Munroe'],
       images: ['DSCF1234.jpg', 'DSCF5678.jpg'],
     });
-    expect(prompt).toMatch(
+    expect(prompt.systemPrompt).toContain(
       'Role play as Ingeborg Gerdes, Alexandra Munroe:\n - Indicate who is speaking\n - Say what you think'
     );
-    expect(prompt).toMatch('Produce between 3 and 5 diarized items');
+    expect(prompt.systemPrompt).toContain('Produce between 3 and 5 diarized items');
+    expect(prompt.userPreamble).toContain('- DSCF1234.jpg');
     expect(minutesMin).toBe(3);
     expect(minutesMax).toBe(5);
   });


### PR DESCRIPTION
## Summary
- add dedicated system and user Handlebars templates and a prompt builder utility to compose them
- update chat client/orchestrator logic to materialize per-role prompts, refresh caching, and reuse formatting helpers
- adjust provider options and tests, including new coverage for prompt objects and refreshed snapshots

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2f935e16c83308be9c5476bffa3a5