### PR TITLE
Add OCR transport and e2e tests for Ollama provider

### DIFF
--- a/src/providers/ollama.js
+++ b/src/providers/ollama.js
@@ -239,6 +239,7 @@ export default class OllamaProvider {
     expectFieldNotesMd = false,
     minutesMin,
     minutesMax,
+    options: requestOptions = {},
   } = {}) {
     await ensureModelReady(model);
 
@@ -272,16 +273,20 @@ export default class OllamaProvider {
         const encodedMessages = await encodeMessageImages(finalMessages);
         onProgress("request");
 
+        const baseOptions = {
+          num_predict: OLLAMA_NUM_PREDICT,
+          num_ctx: OLLAMA_NUM_CTX,
+          num_keep: OLLAMA_NUM_KEEP,
+        };
+        const filteredOverrides = Object.fromEntries(
+          Object.entries(requestOptions || {}).filter(([, value]) => value !== undefined)
+        );
         const params = {
           model,
           messages: encodedMessages,
           stream: false,
           keep_alive: KEEP_ALIVE,
-          options: {
-            num_predict: OLLAMA_NUM_PREDICT,
-            num_ctx: OLLAMA_NUM_CTX,
-            // num_keep: OLLAMA_NUM_KEEP,
-          },
+          options: { ...baseOptions, ...filteredOverrides },
         };
 
         // Build the request format. If an environment override is not provided

--- a/tests/integration/ollama-ocr.e2e.test.js
+++ b/tests/integration/ollama-ocr.e2e.test.js
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import sharp from 'sharp';
+
+const shouldRun =
+  process.env.OLLAMA_E2E === '1' && typeof process.env.OLLAMA_MODEL === 'string';
+
+function randomNonce(length = 10) {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  return Array.from({ length }, () =>
+    alphabet.charAt(Math.floor(Math.random() * alphabet.length))
+  ).join('');
+}
+
+async function renderHighContrastPng(text) {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="512">
+    <rect width="100%" height="100%" fill="white"/>
+    <text x="50%" y="50%" font-family="DejaVu Sans, Arial, sans-serif"
+          font-size="160" text-anchor="middle" dominant-baseline="middle" fill="black">${text}</text>
+  </svg>`;
+  return sharp(Buffer.from(svg)).png({ compressionLevel: 0 }).toBuffer();
+}
+
+async function renderBlurredPng(text) {
+  const base = await renderHighContrastPng(text);
+  return sharp(base)
+    .blur(25)
+    .modulate({ saturation: 0.05, brightness: 1 })
+    .png({ compressionLevel: 0 })
+    .toBuffer();
+}
+
+async function writeTempImage(buffer, tempDirs, filename = 'frame.png') {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ollama-ocr-'));
+  tempDirs.push(dir);
+  const filePath = path.join(dir, filename);
+  await fs.writeFile(filePath, buffer);
+  return filePath;
+}
+
+const describeIf = shouldRun ? describe : describe.skip;
+
+describeIf('OllamaProvider OCR end-to-end', () => {
+  let Provider;
+  let provider;
+  let nonce;
+  const tempDirs = [];
+  let originalFormat;
+
+  beforeAll(async () => {
+    nonce = randomNonce(12);
+    originalFormat = process.env.PHOTO_SELECT_OLLAMA_FORMAT;
+    process.env.PHOTO_SELECT_OLLAMA_FORMAT = '';
+    const mod = await import('../../src/providers/ollama.js');
+    Provider = mod.default;
+    provider = new Provider();
+  });
+
+  afterAll(async () => {
+    if (originalFormat === undefined) {
+      delete process.env.PHOTO_SELECT_OLLAMA_FORMAT;
+    } else {
+      process.env.PHOTO_SELECT_OLLAMA_FORMAT = originalFormat;
+    }
+    await Promise.all(
+      tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true }))
+    );
+  });
+
+  const basePrompt =
+    'Read the text in the image; output only that text; else output NONE.';
+
+  it(
+    'returns the nonce only when the clear image is provided',
+    { timeout: 60_000 },
+    async () => {
+      const pngBuffer = await renderHighContrastPng(nonce);
+      const imagePath = await writeTempImage(pngBuffer, tempDirs);
+      let capturedPayload;
+      const reply = await provider.chat({
+        prompt: basePrompt,
+        images: [imagePath],
+        model: process.env.OLLAMA_MODEL,
+        options: { temperature: 0 },
+        savePayload: async (payload) => {
+          capturedPayload = payload;
+        },
+      });
+
+      expect(typeof reply).toBe('string');
+      expect(reply.trim()).toBe(nonce);
+      expect(capturedPayload).toBeTruthy();
+      const imageList = capturedPayload?.messages?.[1]?.images || [];
+      expect(imageList).toHaveLength(1);
+      const encoded = imageList[0];
+      expect(typeof encoded).toBe('string');
+      expect(encoded.length).toBeGreaterThan(200);
+      const decoded = Buffer.from(encoded, 'base64');
+      const { getSurrogateImage } = await import('../../src/imagePreprocessor.js');
+      const expectedBytes = await getSurrogateImage(imagePath);
+      expect(decoded.equals(expectedBytes)).toBe(true);
+      const systemText = String(capturedPayload.messages?.[0]?.content || '');
+      const userText = String(capturedPayload.messages?.[1]?.content || '');
+      expect(systemText).not.toContain(nonce);
+      expect(userText).not.toContain(nonce);
+    }
+  );
+
+  it(
+    'does not return the nonce when no image is provided',
+    { timeout: 30_000 },
+    async () => {
+      const reply = await provider.chat({
+        prompt: basePrompt,
+        images: [],
+        model: process.env.OLLAMA_MODEL,
+        options: { temperature: 0 },
+      });
+      expect(typeof reply).toBe('string');
+      expect(reply.trim()).toBe('NONE');
+    }
+  );
+
+  it(
+    'fails to recover the nonce from a blurred image',
+    { timeout: 60_000 },
+    async () => {
+      const blurredBuffer = await renderBlurredPng(nonce);
+      const blurredPath = await writeTempImage(blurredBuffer, tempDirs, 'blurred.png');
+      const reply = await provider.chat({
+        prompt: basePrompt,
+        images: [blurredPath],
+        model: process.env.OLLAMA_MODEL,
+        options: { temperature: 0 },
+      });
+      expect(typeof reply).toBe('string');
+      expect(reply.trim()).not.toBe(nonce);
+    }
+  );
+});
+


### PR DESCRIPTION
## Summary
- ensure the Ollama provider exposes configurable options and still sends num_keep alongside default settings
- inline a tiny PNG sample directly in the unit suite so payload encoding is verified without keeping a binary fixture while still preventing path leakage
- create an opt-in OCR end-to-end test that renders a random nonce into a PNG, checks payload integrity against the surrogate bytes, and adds negative controls for no-image and blurred-image cases, expecting NONE for blank input

## Testing
- npx vitest run tests/ollamaProvider.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e3d7c91d0c83308425ededdc76ff83