### PR TITLE
Fix Ollama readiness request payload

### DIFF
--- a/src/providers/ollama.js
+++ b/src/providers/ollama.js
@@ -107,10 +107,13 @@ async function ensureModelReady(model) {
       }
 
       try {
+        if (typeof model !== "string" || !model.trim()) {
+          throw new Error("An Ollama model name must be provided");
+        }
         const res = await fetch(SHOW_ENDPOINT, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ model }),
+          body: JSON.stringify({ name: model }),
         });
         if (res.status === 404) {
           throw new Error(createMissingModelMessage(model));


### PR DESCRIPTION
## Summary
- validate that an Ollama model name is provided before checking readiness
- send the expected `name` field when calling the `/api/show` endpoint

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e56b920ae483309547ddde2543218c