### PR TITLE
Ensure Vitest loads dotenv and handles CJS dependencies

### DIFF
--- a/src/fieldNotesWriter.js
+++ b/src/fieldNotesWriter.js
@@ -5,7 +5,14 @@ import os from 'node:os';
 import crypto from 'node:crypto';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { applyPatch } from 'diff';
+let diffModule;
+
+async function loadDiff() {
+  if (!diffModule) {
+    diffModule = import('diff');
+  }
+  return diffModule;
+}
 
 const exec = promisify(execFile);
 
@@ -93,6 +100,7 @@ export default class FieldNotesWriter {
       await this._exec('patch', [oldPath, patchPath], { cwd: dir });
       updated = await fs.readFile(oldPath, 'utf8');
     } catch (err) {
+      const { applyPatch } = await loadDiff();
       updated = applyPatch(old, diffText);
       if (updated === false) {
         await fs.rm(dir, { recursive: true, force: true });

--- a/src/templates.js
+++ b/src/templates.js
@@ -1,6 +1,13 @@
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import Handlebars from 'handlebars';
+let handlebarsModule;
+
+async function loadHandlebars() {
+  if (!handlebarsModule) {
+    handlebarsModule = import('handlebars').then((mod) => mod.default ?? mod);
+  }
+  return handlebarsModule;
+}
 
 const fmin = Number(process.env.PHOTO_SELECT_MINUTES_FACTOR_MIN || 1.5);
 const fmax = Number(process.env.PHOTO_SELECT_MINUTES_FACTOR_MAX || 2.5);
@@ -11,6 +18,7 @@ export const DEFAULT_PROMPT_PATH = path.resolve(
 
 export async function renderTemplate(filePath = DEFAULT_PROMPT_PATH, data = {}) {
   const source = await fs.readFile(filePath, 'utf8');
+  const Handlebars = await loadHandlebars();
   const template = Handlebars.compile(source, { noEscape: true });
   return template(data);
 }

--- a/tests/integration/ollama-ocr.e2e.test.js
+++ b/tests/integration/ollama-ocr.e2e.test.js
@@ -1,11 +1,16 @@
+import 'dotenv/config';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 import sharp from 'sharp';
 
-const shouldRun =
-  process.env.OLLAMA_E2E === '1' && typeof process.env.OLLAMA_MODEL === 'string';
+const ollamaModel =
+  typeof process.env.OLLAMA_MODEL === 'string'
+    ? process.env.OLLAMA_MODEL.trim()
+    : '';
+
+const shouldRun = process.env.OLLAMA_E2E === '1' && ollamaModel.length > 0;
 
 function randomNonce(length = 10) {
   const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
@@ -82,7 +87,7 @@ describeIf('OllamaProvider OCR end-to-end', () => {
       const reply = await provider.chat({
         prompt: basePrompt,
         images: [imagePath],
-        model: process.env.OLLAMA_MODEL,
+        model: ollamaModel,
         options: { temperature: 0 },
         savePayload: async (payload) => {
           capturedPayload = payload;
@@ -115,7 +120,7 @@ describeIf('OllamaProvider OCR end-to-end', () => {
       const reply = await provider.chat({
         prompt: basePrompt,
         images: [],
-        model: process.env.OLLAMA_MODEL,
+        model: ollamaModel,
         options: { temperature: 0 },
       });
       expect(typeof reply).toBe('string');
@@ -132,7 +137,7 @@ describeIf('OllamaProvider OCR end-to-end', () => {
       const reply = await provider.chat({
         prompt: basePrompt,
         images: [blurredPath],
-        model: process.env.OLLAMA_MODEL,
+        model: ollamaModel,
         options: { temperature: 0 },
       });
       expect(typeof reply).toBe('string');

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    deps: {
+      interopDefault: true,
+      optimizer: {
+        ssr: {
+          include: ['handlebars', 'diff', 'cli-progress'],
+        },
+      },
+    },
+  },
+  ssr: {
+    external: ['handlebars', 'diff', 'cli-progress'],
+  },
+});


### PR DESCRIPTION
## Summary
- load dotenv configuration for the Ollama OCR integration test and guard against blank model names
- lazy-load Handlebars and diff so Vitest can resolve CommonJS dependencies when running tests
- add a Vitest config that keeps CommonJS modules externalized for the Node test environment

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e571e6cdb483309d1f5a30836c2480