### PR TITLE
Adjust OCR e2e test tolerance for imperfect nonce matches

### DIFF
--- a/tests/integration/ollama-ocr.e2e.test.js
+++ b/tests/integration/ollama-ocr.e2e.test.js
@@ -35,6 +35,19 @@ function canonicalizeOcr(text) {
   return alphanumeric.replace(/(.)\1+/g, '$1');
 }
 
+function hammingDistance(a, b) {
+  const first = String(a ?? '');
+  const second = String(b ?? '');
+  const length = Math.min(first.length, second.length);
+  let distance = Math.abs(first.length - second.length);
+  for (let i = 0; i < length; i += 1) {
+    if (first[i] !== second[i]) {
+      distance += 1;
+    }
+  }
+  return distance;
+}
+
 function escapeForSvg(text) {
   return String(text ?? '').replace(/[&<>'"]/g, (char) => {
     switch (char) {
@@ -157,7 +170,13 @@ describeIf('OllamaProvider OCR end-to-end', () => {
       });
 
       expect(typeof reply).toBe('string');
-      expect(canonicalizeOcr(reply)).toBe(nonce);
+      const normalizedReply = canonicalizeOcr(reply);
+      expect(normalizedReply).toHaveLength(NONCE_LENGTH);
+      const distance = hammingDistance(normalizedReply, nonce);
+      const similarity = 1 - distance / NONCE_LENGTH;
+      const maxDistance = Math.floor(NONCE_LENGTH * 0.25);
+      expect(distance).toBeLessThanOrEqual(maxDistance);
+      expect(similarity).toBeGreaterThanOrEqual(0.75);
       expect(capturedPayload).toBeTruthy();
       const imageList = capturedPayload?.messages?.[1]?.images || [];
       expect(imageList).toHaveLength(1);


### PR DESCRIPTION
## Summary
- add a reusable hamming distance helper for OCR nonce comparisons
- relax the end-to-end OCR expectation to allow minor character drift while still enforcing signal strength

## Testing
- npm test -- tests/integration/ollama-ocr.e2e.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e68d0db0a0833087616373eb658e59