### PR TITLE
Broaden billing limit detection and cover billing abort path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -219,6 +219,15 @@ process.env.PHOTO_SELECT_USER_EFFORT = finalReasoningEffort;
     });
     console.log("🎉  Finished triaging.");
   } catch (err) {
+    if (err?.code === "BILLING_LIMIT") {
+      console.error(
+        "🛑  Billing limit reached. Please review your provider usage before retrying."
+      );
+      if (process.env.PHOTO_SELECT_VERBOSE === "1" && err?.cause) {
+        console.error("  ↳ cause:", err.cause);
+      }
+      process.exit(1);
+    }
     console.error("❌  Error:", err);
     process.exit(1);
   }

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -222,6 +222,32 @@ export async function triageDirectory({
   const indent = "  ".repeat(depth);
   let notesWriter;
 
+  function isBillingLimitError(err) {
+    if (!err) return false;
+    const candidates = [
+      err?.message,
+      err?.error?.message,
+      err?.cause?.message,
+      err?.response?.data?.error?.message,
+      err?.response?.data?.message,
+      err?.response?.error?.message,
+      err?.response?.message,
+      err?.body?.error?.message,
+      err?.body?.message,
+    ]
+      .flat()
+      .filter(Boolean)
+      .map((msg) => String(msg));
+    return candidates.some((message) => /billing (hard )?limit/i.test(message));
+  }
+
+  function createBillingLimitError(err) {
+    const wrapped = new Error("Billing hard limit reached; aborting remaining batches.");
+    wrapped.code = "BILLING_LIMIT";
+    wrapped.cause = err;
+    return wrapped;
+  }
+
   let dynamicWorkers = workers;
   let consecutiveGatewayErrors = 0;
   function isGatewayError(e) {
@@ -355,7 +381,9 @@ export async function triageDirectory({
           }
         };
         let batchIdx = 0;
-        const nextBatch = () => (queue.length ? queue.splice(0, BATCH_SIZE) : null);
+        let abortProcessing = false;
+        const nextBatch = () =>
+          !abortProcessing && queue.length ? queue.splice(0, BATCH_SIZE) : null;
 
         async function workerFn() {
           while (true) {
@@ -572,6 +600,12 @@ export async function triageDirectory({
                 bar.stop();
                 multibar.remove(bar);
                 log(`${indent}⚠️  Batch ${idx} failed: ${err.message}`);
+                if (isBillingLimitError(err) && !abortProcessing) {
+                  abortProcessing = true;
+                  queue.length = 0;
+                  log(`${indent}🛑  Billing limit reached; stopping remaining batches.`);
+                  throw createBillingLimitError(err);
+                }
               }
             });
           }

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -254,4 +254,34 @@ describe("triageDirectory", () => {
     await expect(fs.stat(path.join(tmpDir, '_keep', '1.jpg'))).resolves.toBeTruthy();
   });
 
+  it("stops processing when billing limit is reached", async () => {
+    const provider = {
+      submit: vi.fn(async () => ({})),
+      collect: vi.fn(async () => {
+        const err = new Error("Billing hard limit has been reached");
+        err.response = {
+          data: { error: { message: "Billing hard limit has been reached" } },
+        };
+        throw err;
+      }),
+    };
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await expect(
+        triageDirectory({
+          dir: tmpDir,
+          promptPath: promptFile,
+          model: "test-model",
+          recurse: false,
+          provider,
+        })
+      ).rejects.toMatchObject({ code: "BILLING_LIMIT" });
+    } finally {
+      logSpy.mockRestore();
+    }
+    expect(provider.submit).toHaveBeenCalledTimes(1);
+    await expect(fs.stat(path.join(tmpDir, "1.jpg"))).resolves.toBeTruthy();
+    await expect(fs.stat(path.join(tmpDir, "2.jpg"))).resolves.toBeTruthy();
+  });
+
 });


### PR DESCRIPTION
## Summary
- expand billing limit detection to inspect common nested error messages before halting additional batches
- add an orchestrator test that verifies billing limit errors abort processing without moving files

## Testing
- npm test -- orchestrator *(fails: Vitest cannot load optional dependency `handlebars` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f6275ccf9c8330ac6ee5850a1e33c5