### PR TITLE
Add batch debugging helper for OpenAI provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "start": "photo-select",
     "test": "vitest run",
-    "undici:smoke": "node scripts/undici-smoke.mjs"
+    "undici:smoke": "node scripts/undici-smoke.mjs",
+    "debug:batch": "node scripts/debug-batch.mjs"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/debug-batch.mjs
+++ b/scripts/debug-batch.mjs
@@ -1,0 +1,145 @@
+import OpenAI from "openai";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+let openai;
+
+function getClient() {
+  if (!openai) {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      throw new Error("OPENAI_API_KEY not set");
+    }
+    openai = new OpenAI({ apiKey });
+  }
+  return openai;
+}
+
+const pretty = (x) => JSON.stringify(x, null, 2);
+const safeParse = (line) => {
+  try {
+    return JSON.parse(line);
+  } catch {
+    return null;
+  }
+};
+const countBy = (arr) =>
+  arr.reduce((acc, k) => ((acc[k] = (acc[k] || 0) + 1), acc), {});
+
+async function fetchTextFile(fileId) {
+  const client = getClient();
+  const res = await client.files.content(fileId);
+  return await res.text();
+}
+
+async function saveToTmp(name, text) {
+  const out = path.join("/tmp", name);
+  await fs.writeFile(out, text, "utf8");
+  return out;
+}
+
+async function peekJsonl(text, n = 10) {
+  const lines = text.trim().split("\n").filter(Boolean);
+  const first = lines.slice(0, n).map(safeParse).filter(Boolean);
+  return { totalLines: lines.length, first };
+}
+
+function logErrorRow(row) {
+  const cid = row.custom_id ?? "(no custom_id)";
+  const err = row.error || {};
+  const code = err.code ?? err.type ?? "unknown";
+  const msg = err.message ?? "(no message)";
+  const param = err.param ? ` param=${err.param}` : "";
+  console.error(`  • ${cid}: [${code}] ${msg}${param}`);
+}
+
+export async function debugBatch(batchId, { peek = 10 } = {}) {
+  console.error(`🔎 Debugging batch ${batchId} …`);
+  const client = getClient();
+  const b = await client.batches.retrieve(batchId);
+
+  console.error("📋 Batch status:");
+  console.error(pretty({
+    id: b.id,
+    status: b.status,
+    created_at: b.created_at,
+    completion_window: b.completion_window,
+    request_counts: b.request_counts,
+    metadata: b.metadata,
+    model: b.metadata?.model ?? b.default_model ?? "(unknown)",
+    input_file_id: b.input_file_id,
+    output_file_id: b.output_file_id,
+    error_file_id: b.error_file_id
+  }));
+
+  try {
+    const inputText = await fetchTextFile(b.input_file_id);
+    const inputLines = inputText.trim().split("\n").filter(Boolean);
+    console.error(`📥 Input JSONL: ${inputLines.length} line(s).`);
+    if (inputLines.length) {
+      const firstTwo = inputLines.slice(0, 2).join("\n");
+      console.error("  First 2 line(s):\n" + firstTwo);
+    }
+  } catch (e) {
+    console.error("⚠️ Could not fetch input_file_id content:", e.message || e);
+  }
+
+  if (b.error_file_id) {
+    const errText = await fetchTextFile(b.error_file_id);
+    const errPath = await saveToTmp(`batch-${b.id}-errors.jsonl`, errText);
+    console.error(`🧾 Saved error JSONL → ${errPath}`);
+    const { totalLines, first } = await peekJsonl(errText, peek);
+
+    const errorCodes = countBy(
+      first.map((r) => r?.error?.code ?? r?.error?.type ?? "unknown")
+    );
+    console.error(`❗ ${totalLines} error row(s). Summary by code/type:`);
+    Object.entries(errorCodes).forEach(([k, v]) =>
+      console.error(`  - ${k}: ${v}`)
+    );
+
+    console.error(`🔬 First ${first.length} error row(s):`);
+    first.forEach(logErrorRow);
+  } else {
+    console.error("ℹ️ No error_file_id on this batch.");
+  }
+
+  if (b.output_file_id) {
+    const outText = await fetchTextFile(b.output_file_id);
+    const outPath = await saveToTmp(`batch-${b.id}-output.jsonl`, outText);
+    console.error(`✅ Saved output JSONL → ${outPath}`);
+    const { totalLines, first } = await peekJsonl(outText, peek);
+    console.error(`📤 ${totalLines} success row(s). Showing first ${first.length}:`);
+    first.forEach((r, i) =>
+      console.error(`  • [${i + 1}] ${r?.custom_id ?? "(no custom_id)"}`)
+    );
+  } else {
+    console.error("ℹ️ No output_file_id on this batch.");
+  }
+
+  if (!b.output_file_id && !b.error_file_id) {
+    console.error("⚠️ Completed without output **and** without an error file.");
+    console.error(
+      "   This usually means the input JSONL was empty/invalid, or every request was rejected before execution."
+    );
+    console.error(
+      "   The input peek above should confirm whether we actually uploaded valid request rows."
+    );
+  }
+}
+
+if (process.argv[1] && process.argv[1].endsWith("debug-batch.mjs")) {
+  const batchId = process.argv[2];
+  if (!batchId) {
+    console.error("Usage: node scripts/debug-batch.mjs <batchId>");
+    process.exit(2);
+  }
+  if (!process.env.OPENAI_API_KEY) {
+    console.error("❌ OPENAI_API_KEY not set");
+    process.exit(1);
+  }
+  debugBatch(batchId).catch((e) => {
+    console.error("❌ debugBatch failed:", e);
+    process.exit(1);
+  });
+}

--- a/src/providers/openai-batch.js
+++ b/src/providers/openai-batch.js
@@ -7,6 +7,7 @@ import { buildInput, buildMessages, schemaForBatch } from '../chatClient.js';
 import { buildReplySchema } from '../replySchema.js';
 import { computeMaxOutputTokens } from '../tokenEstimate.js';
 import { delay } from '../config.js';
+import { debugBatch } from '../../scripts/debug-batch.mjs';
 
 const DEFAULT_COMPLETION_WINDOW = process.env.PHOTO_SELECT_BATCH_COMPLETION_WINDOW || '24h';
 const DEFAULT_POLL_MS = Number(process.env.PHOTO_SELECT_BATCH_CHECK_INTERVAL_MS || 60000);
@@ -220,6 +221,11 @@ export default class OpenAIBatchProvider {
           input_file_id: inputFile.id,
           endpoint,
           completion_window: this.completionWindow,
+          metadata: {
+            custom_id: customId,
+            model,
+            level: levelKey(levelDir),
+          },
         });
         endpointUsed = endpoint;
         break;
@@ -304,6 +310,14 @@ export default class OpenAIBatchProvider {
       });
       if (job.status === 'completed') {
         if (!job.output_file_id) {
+          console.error(
+            `⚠️  Batch ${handle.batchId} completed without output — running diagnostics…`
+          );
+          try {
+            await debugBatch(handle.batchId);
+          } catch (diagErr) {
+            console.error('❌ debugBatch helper failed:', diagErr);
+          }
           throw new Error(`Batch ${handle.batchId} completed without output`);
         }
         const resp = await this.client.files.content(job.output_file_id);


### PR DESCRIPTION
## Summary
- add a reusable `scripts/debug-batch.mjs` helper to inspect batch diagnostics and save JSONL artifacts
- enrich OpenAI batch submissions with metadata and invoke the helper automatically when a batch completes without output
- expose an `npm run debug:batch` command for ad-hoc troubleshooting

## Testing
- npm test *(fails: missing optional dependencies `handlebars`/`diff` in Vitest environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f6b0a545b883308fd05ada53ae39e6