### PR TITLE
Resume triage in deepest nested _keep folders

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -183,6 +183,42 @@ function formatDuration(ms) {
   return `${s}s`;
 }
 
+async function dirExists(p) {
+  try {
+    return (await stat(p)).isDirectory();
+  } catch (err) {
+    if (err?.code === "ENOENT") return false;
+    throw err;
+  }
+}
+
+/**
+ * Follow the _keep chain until we find a directory with unclassified images or
+ * run out of nested _keep folders.
+ *
+ * @param {string} startDir
+ * @returns {Promise<{dir: string, hops: number}>}
+ */
+export async function resolveResumeLevel(startDir) {
+  let current = startDir;
+  let hops = 0;
+
+  while (true) {
+    const imagesHere = await listImages(current);
+    if (imagesHere.length > 0) {
+      return { dir: current, hops };
+    }
+
+    const next = path.join(current, "_keep");
+    if (!(await dirExists(next))) {
+      return { dir: current, hops };
+    }
+
+    current = next;
+    hops += 1;
+  }
+}
+
 /**
  * Recursively triage images until the current directory is empty
  * or contains only _keep/_aside folders.
@@ -198,23 +234,24 @@ function formatDuration(ms) {
 * @param {boolean} [options.fieldNotes=false] Enable field notes workflow
 * @param {number} [options.depth=0]         Internal recursion depth (for logging)
 */
-export async function triageDirectory({
-  dir,
-  promptPath,
-  provider,
-  model,
-  recurse = true,
-  curators = [],
-  contextPath,
-  fieldNotes = false,
-  verbose = false,
-  saveIo = false,
-  workers = 1,
-  verbosity,
-  reasoningEffort,
-  depth = 0,
-  gitRoot,
-}) {
+export async function triageDirectory(options) {
+  let {
+    dir,
+    promptPath,
+    provider,
+    model,
+    recurse = true,
+    curators = [],
+    contextPath,
+    fieldNotes = false,
+    verbose = false,
+    saveIo = false,
+    workers = 1,
+    verbosity,
+    reasoningEffort,
+    depth = 0,
+    gitRoot,
+  } = options;
   if (!provider) {
     const m = await import('./providers/openai.js');
     provider = new m.default();
@@ -274,6 +311,25 @@ export async function triageDirectory({
   }
 
   if (!gitRoot) gitRoot = dir;
+
+  if (recurse) {
+    const { dir: workDir, hops } = await resolveResumeLevel(dir);
+    if (workDir !== dir) {
+      const relative = path.relative(dir, workDir) || ".";
+      const prettyRelative = relative === "." ? "." : relative.split(path.sep).join("/");
+      console.log(
+        `${indent}↘️  No unclassified images at this level; resuming in ${prettyRelative}`
+      );
+      return triageDirectory({
+        ...options,
+        dir: workDir,
+        depth: depth + hops,
+        provider,
+        gitRoot,
+      });
+    }
+  }
+
   if (fieldNotes && depth === 0) {
     await ensureGitRepo(gitRoot);
   }
@@ -645,12 +701,14 @@ export async function triageDirectory({
       }
     };
 
-    const [keepCount, asideCount] = await Promise.all([
+    const [keepCount, asideCount, hasDeeperKeep] = await Promise.all([
       countImages(keepDir),
       countImages(asideDir),
+      dirExists(path.join(keepDir, "_keep")),
     ]);
 
-    if (keepCount > 0 && asideCount > 0) {
+    const keepHasWork = keepCount > 0 || hasDeeperKeep;
+    if (keepHasWork) {
       await triageDirectory({
         dir: keepDir,
         promptPath,

--- a/src/providers/openai-batch.js
+++ b/src/providers/openai-batch.js
@@ -16,8 +16,20 @@ const FALLBACK_ENDPOINT = '/v1/chat/completions';
 
 const TERMINAL_FAILURE = new Set(['failed', 'expired', 'canceled']);
 
+const MAX_SAFE_ID_LENGTH = 200;
+
 function safeId(customId) {
-  return customId.replace(/[^a-zA-Z0-9._-]/g, '_');
+  const sanitized = customId.replace(/[^a-zA-Z0-9._-]/g, '_');
+  if (sanitized.length <= MAX_SAFE_ID_LENGTH) {
+    return sanitized;
+  }
+  const digest = crypto.createHash('sha256').update(sanitized).digest('hex');
+  const suffix = `_${digest.slice(0, 16)}`;
+  const sliceLength = Math.max(1, MAX_SAFE_ID_LENGTH - suffix.length);
+  const base = sanitized.slice(0, sliceLength);
+  const trimmed = base.replace(/[_-]+$/g, '');
+  const prefix = trimmed || base;
+  return `${prefix}${suffix}`;
 }
 
 function levelKey(levelDir) {

--- a/tests/openaiBatchProvider.test.js
+++ b/tests/openaiBatchProvider.test.js
@@ -100,6 +100,26 @@ describe('OpenAIBatchProvider', () => {
     expect(ticket.used_images).toEqual(['1.jpg']);
   });
 
+  it('limits safeId length for deeply nested level directories', async () => {
+    const provider = new OpenAIBatchProvider({ client, enableFallback: false, helpers });
+    let longDir = tmpDir;
+    for (let i = 0; i < 5; i += 1) {
+      longDir = path.join(longDir, `segment-${i}-${'x'.repeat(40)}`);
+    }
+    await fs.mkdir(longDir, { recursive: true });
+    const imagePath = path.join(longDir, 'image.jpg');
+    await fs.writeFile(imagePath, 'data');
+    const handle = await provider.submit({
+      levelDir: longDir,
+      prompt: 'prompt',
+      images: [imagePath],
+      model: 'gpt-5',
+    });
+    expect(handle.safeId.length).toBeLessThanOrEqual(200);
+    const ticketPath = path.join(longDir, '.batch', 'tickets', `${handle.safeId}.ticket.json`);
+    await expect(fs.stat(ticketPath)).resolves.toBeTruthy();
+  });
+
   it('collects completed batch results', async () => {
     const provider = new OpenAIBatchProvider({
       client,

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -90,6 +90,39 @@ describe("triageDirectory", () => {
     await expect(fs.stat(aside2)).resolves.toBeTruthy();
   });
 
+  it("resumes into deepest _keep when parent has no images", async () => {
+    await fs.rm(path.join(tmpDir, "1.jpg"));
+    await fs.rm(path.join(tmpDir, "2.jpg"));
+    const deep = path.join(tmpDir, "_keep", "_keep");
+    await fs.mkdir(deep, { recursive: true });
+    await fs.writeFile(path.join(deep, "1.jpg"), "a");
+    await fs.writeFile(path.join(deep, "2.jpg"), "b");
+
+    chatCompletion
+      .mockResolvedValueOnce(
+        JSON.stringify({ keep: ["1.jpg"], aside: ["2.jpg"] })
+      )
+      .mockResolvedValue(
+        JSON.stringify({ keep: [], aside: ["1.jpg"] })
+      );
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: true,
+    });
+
+    await expect(
+      fs.stat(path.join(deep, "_keep", "_aside", "1.jpg"))
+    ).resolves.toBeTruthy();
+    await expect(
+      fs.stat(path.join(deep, "_aside", "2.jpg"))
+    ).resolves.toBeTruthy();
+
+    chatCompletion.mockReset();
+  });
+
   it("processes batches in parallel", async () => {
     chatCompletion
       .mockResolvedValueOnce(JSON.stringify({ keep: ["1.jpg"], aside: [] }))


### PR DESCRIPTION
## Summary
- add a resolveResumeLevel helper that follows the _keep chain to the next directory with unclassified images before processing
- update triageDirectory to reuse that helper, log resume hops, and treat nested _keep folders as work even if the immediate directory is empty
- extend orchestrator tests to cover resuming from a parent with no images and assert kept/aside files land in the correct subfolders

## Testing
- npm test -- tests/orchestrator.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f798c4728083309f1a9a797b784c04