### PR TITLE
feat: prefer APFS clones for per-level archives

### DIFF
--- a/src/fs-clone.js
+++ b/src/fs-clone.js
@@ -1,0 +1,23 @@
+import * as fsp from "node:fs/promises";
+import { constants as FSC } from "node:fs";
+
+export async function copyFilePreferClone(src, dest, { overwrite = true } = {}) {
+  const mode = FSC.COPYFILE_FICLONE;
+  try {
+    await fsp.copyFile(src, dest, mode);
+  } catch (err) {
+    if (
+      err?.code === "ENOTSUP" ||
+      err?.code === "EINVAL" ||
+      err?.code === "EOPNOTSUPP" ||
+      err?.code === "EXDEV" ||
+      err?.code === "ERR_FS_COPYFILE_IMPL"
+    ) {
+      await fsp.copyFile(src, dest);
+    } else if (err?.code === "EEXIST" && overwrite === false) {
+      return;
+    } else {
+      throw err;
+    }
+  }
+}

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -1,10 +1,11 @@
 import path from "node:path";
-import { readFile, writeFile, mkdir, stat, copyFile } from "node:fs/promises";
+import { readFile, writeFile, mkdir, stat } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { batchStore } from "./batchContext.js";
 import crypto from "node:crypto";
 import { delay } from "./config.js";
+import { copyFilePreferClone } from "./fs-clone.js";
 import { listImages, pickRandom, moveFiles } from "./imageSelector.js";
 import { parseReply, getPeople } from "./chatClient.js";
 import { buildPrompt } from "./templates.js";
@@ -362,7 +363,7 @@ export async function triageDirectory(options) {
     maxAttempts = 3
   ) => {
     try {
-      await copyFile(src, dest);
+      await copyFilePreferClone(src, dest);
     } catch (err) {
       if (err?.code === "ECANCELED" && attempt < maxAttempts) {
         const wait = (attempt + 1) * 1000;


### PR DESCRIPTION
## Summary
- add a filesystem helper that prefers copy-on-write clones when copying files
- use the helper during per-level archive creation to reduce disk usage on clone-capable filesystems

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690a678c5ec4833082e4c9df4488ef51