### PR TITLE
Add CLI toggle to disable photo-filter lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ on startup.
 
 ### People metadata (optional)
 
-Set `PHOTO_FILTER_API_BASE` to the base URL of your [photo‑filter](https://github.com/openhouse/photo-filter) service to include face‑tag data in the prompt. The CLI assumes the service is available at `http://localhost:3000` when the variable is unset and logs a warning if requests fail. For each image it fetches `/api/photos/by-filename/<filename>/persons` and sends a JSON blob like `{ "filename": "DSCF1234.jpg", "people": ["Alice", "Bob"] }` before the image itself. Results are cached per filename for the duration of the run.
+Set `PHOTO_FILTER_API_BASE` to the base URL of your [photo‑filter](https://github.com/openhouse/photo-filter) service to include face‑tag data in the prompt. The CLI assumes the service is available at `http://localhost:3000` when the variable is unset and logs a warning if requests fail. For each image it fetches `/api/photos/by-filename/<filename>/persons` and sends a JSON blob like `{ "filename": "DSCF1234.jpg", "people": ["Alice", "Bob"] }` before the image itself. Results are cached per filename for the duration of the run. Pass `--disable-photo-filter` (or set `PHOTO_SELECT_DISABLE_PEOPLE=1`) to skip these lookups for a single job.
 
 Example:
 

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -24,6 +24,19 @@ function numEnv(name, fallback) {
   return Number.isFinite(n) ? n : fallback;
 }
 
+function boolEnv(name, fallback = false) {
+  const v = process.env[name];
+  if (v == null || v === "") return fallback;
+  if (typeof v === "boolean") return v;
+  if (/^(1|true|yes|on)$/i.test(String(v))) return true;
+  if (/^(0|false|no|off)$/i.test(String(v))) return false;
+  return fallback;
+}
+
+function isPeopleLookupDisabled() {
+  return boolEnv("PHOTO_SELECT_DISABLE_PEOPLE", false);
+}
+
 const HTTP_DRIVER = String(
   process.env.PHOTO_SELECT_HTTP_DRIVER || ""
 ).toLowerCase();
@@ -65,7 +78,7 @@ const PEOPLE_API_BASE =
   process.env.PHOTO_FILTER_API_BASE || "http://localhost:3000";
 const PEOPLE_CONCURRENCY = numEnv("PHOTO_SELECT_PEOPLE_CONCURRENCY", 2);
 let peopleAgent;
-if (!USE_UNDICI) {
+if (!USE_UNDICI && !isPeopleLookupDisabled()) {
   peopleAgent = PEOPLE_API_BASE.startsWith("https")
     ? new KeepAliveAgent.HttpsAgent({
         keepAlive: true,
@@ -188,6 +201,10 @@ async function extractTextWithLogging(rsp) {
 
 export async function getPeople(filename) {
   if (peopleCache.has(filename)) return peopleCache.get(filename);
+  if (isPeopleLookupDisabled()) {
+    peopleCache.set(filename, []);
+    return [];
+  }
   try {
     const url = `${PEOPLE_API_BASE}/api/photos/by-filename/${encodeURIComponent(
       filename
@@ -211,6 +228,7 @@ export async function getPeople(filename) {
 
 /** Return any people who appear in more than one file */
 export async function curatorsFromTags(files) {
+  if (isPeopleLookupDisabled()) return [];
   const counts = new Map();
   for (const file of files) {
     const name = path.basename(file);

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,19 @@ import { DEFAULT_PROMPT_PATH } from "./templates.js";
 import { configureHttpFromEnv, closeDispatcher } from "./net.js";
 import { scheduler } from "./scheduler.js";
 
+function parseEnvFlag(value, fallback = false) {
+  if (value == null || value === "") return fallback;
+  if (typeof value === "boolean") return value;
+  if (/^(1|true|yes|on)$/i.test(String(value))) return true;
+  if (/^(0|false|no|off)$/i.test(String(value))) return false;
+  return fallback;
+}
+
+const disablePhotoFilterDefault = parseEnvFlag(
+  process.env.PHOTO_SELECT_DISABLE_PEOPLE,
+  false
+);
+
 const program = new Command();
 program
   .name("photo-select")
@@ -77,6 +90,11 @@ program
     "Maximum in-flight OpenAI requests",
     (v) => Math.max(1, parseInt(v, 10))
   )
+  .option(
+    "--disable-photo-filter",
+    "Disable photo-filter API lookups for this job",
+    disablePhotoFilterDefault
+  )
   .parse(process.argv);
 
 let {
@@ -97,6 +115,7 @@ let {
   reasoningEffort,
   ollamaBaseUrl,
   concurrency: concurrencyFlag,
+  disablePhotoFilter,
 } = program.opts();
 
 if (program.getOptionValueSource && program.getOptionValueSource('parallel')) {
@@ -176,6 +195,9 @@ if (apiKey) {
 }
 if (ollamaBaseUrl) {
   process.env.OLLAMA_BASE_URL = ollamaBaseUrl;
+}
+if (disablePhotoFilter) {
+  process.env.PHOTO_SELECT_DISABLE_PEOPLE = '1';
 }
 
 const provider = providerName || 'openai';

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -339,6 +339,23 @@ describe("curatorsFromTags", () => {
     expect(names).toContain("_UNKNOWN_");
     global.fetch.mockReset();
   });
+
+  it("skips network calls when disabled", async () => {
+    const imgs = ["/tmp/a.jpg", "/tmp/b.jpg"];
+    global.fetch.mockReset();
+    process.env.PHOTO_SELECT_DISABLE_PEOPLE = "1";
+    try {
+      const names = await curatorsFromTags(imgs);
+      expect(names).toEqual([]);
+      expect(global.fetch).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.PHOTO_SELECT_DISABLE_PEOPLE;
+      global.fetch.mockImplementation(async () => ({
+        ok: true,
+        json: async () => ({ data: [] }),
+      }));
+    }
+  });
 });
 
 describe("chatCompletion", () => {


### PR DESCRIPTION
## Summary
- add a `--disable-photo-filter` CLI option that honours the existing PHOTO_SELECT_DISABLE_PEOPLE environment flag
- skip photo-filter metadata requests when the flag is set, including curatorsFromTags, and cache empty results
- document the new toggle and cover it with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690cbedcf4008330bedb4b9f0ef613d7