### PR TITLE
Implement resumable archive staging with manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ through to the script unchanged.
 | `--field-notes` | `false` | Enable notebook updates via field-notes workflow |
 | `--verbose` | `false` | Print extra logs |
 | `--save-io` | `false` | Save prompts and responses for debugging |
+| `--update [bool]` | `true` | Reuse archived files when unchanged; `false` forces re-clone |
+| `--force-rebuild` | `false` | Ignore the archive manifest and rebuild every file |
+| `--stage-concurrency` | *(unset)* | Override filesystem staging concurrency (`PHOTO_SELECT_STAGE_CONCURRENCY` / `PHOTO_SELECT_FS_CONCURRENCY`) |
 | `--workers` | *(unset)* | Max number of concurrent sessions. For batch, this caps in-flight jobs per level |
 | `--batch-check-interval` | `60s` | Poll cadence for `photo-select batch watch` |
 | `--batch-window` | `24h` | Completion window requested for batch jobs |
@@ -188,6 +191,18 @@ PHOTO_SELECT_MAX_OLD_SPACE_MB=8192 \
 
 The value is passed directly to `--max-old-space-size`, so adjust it to match your
 available RAM.
+
+#### Resume semantics
+
+Interrupted runs resume quickly. Each `_level-*` archive keeps an append-only manifest
+(`.ps-manifest.jsonl` plus a snapshot `.manifest.json`), a staging log (`.staged.jsonl`),
+and a heartbeat file (`.run.json`). After all files finish cloning, a `.ok` sentinel is
+written. On restart, `photo-select` skips any level that already has `.ok`, and for
+other levels it skips individual files whose size/mtime match the manifest. Use
+`--update false` to disable this cache (re-cloning every file) or `--force-rebuild`
+to ignore existing manifests. Filesystem concurrency defaults to 12 (from
+`PHOTO_SELECT_FS_CONCURRENCY`); override it with `PHOTO_SELECT_STAGE_CONCURRENCY`
+or the `--stage-concurrency` flag when staging needs to be throttled.
 
 ### Concurrency: `--workers` (recommended)
 

--- a/src/archive/ensureArchiveLevel.js
+++ b/src/archive/ensureArchiveLevel.js
@@ -1,0 +1,188 @@
+import { writeFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+import { ensureClone } from "./ensureClone.js";
+import { Manifest } from "./manifest.js";
+import { StageTracker } from "./stageTracker.js";
+import { SimpleSemaphore } from "../lib/semaphore.js";
+
+const DEFAULT_PROGRESS_INTERVAL = 1000;
+let didLogStrategy = false;
+
+function ensureMetadataShield(levelDir) {
+  const marker = path.join(levelDir, ".metadata_never_index");
+  return writeFile(marker, "").catch(() => {});
+}
+
+function computeConcurrency({ cliValue }) {
+  if (Number.isFinite(cliValue) && cliValue > 0) {
+    return cliValue;
+  }
+  const envStage = Number(process.env.PHOTO_SELECT_STAGE_CONCURRENCY);
+  if (Number.isFinite(envStage) && envStage > 0) return envStage;
+  const envFs = Number(process.env.PHOTO_SELECT_FS_CONCURRENCY);
+  if (Number.isFinite(envFs) && envFs > 0) return envFs;
+  return 12;
+}
+
+export async function ensureArchiveLevel({
+  levelDir,
+  files,
+  update = true,
+  forceRebuild = false,
+  stageConcurrency,
+  verbose = false,
+}) {
+  const concurrency = computeConcurrency({ cliValue: stageConcurrency });
+  if (!didLogStrategy) {
+    const apfs = process.platform === "darwin" ? "yes" : "no";
+    console.log(
+      `staging: mode=clone-if-missing stage_concurrency=${concurrency} apfs_clone=${apfs}`
+    );
+    didLogStrategy = true;
+  }
+
+  await mkdir(levelDir, { recursive: true });
+  await ensureMetadataShield(levelDir);
+
+  const manifest = new Manifest(levelDir);
+  const tracker = new StageTracker(levelDir);
+  const sentinelExists = update && !forceRebuild ? await tracker.hasOk() : false;
+  if (sentinelExists) {
+    if (verbose) {
+      console.log(
+        `${path.basename(levelDir)} resume: cloned=${tracker.counters.cloned} copied=${tracker.counters.copied} skipped=${tracker.counters.skipped} failed=${tracker.counters.failed} remaining=0`
+      );
+    }
+    return {
+      created: 0,
+      refreshed: 0,
+      skipped: files.length,
+      errors: 0,
+    };
+  }
+
+  if (forceRebuild) {
+    await tracker.reset();
+    manifest.clear();
+    await manifest.removeFiles();
+  } else {
+    await manifest.load();
+    await tracker.load();
+  }
+
+  const skipSet = new Set(tracker.completed);
+  const counters = { created: 0, refreshed: 0, skipped: 0, errors: 0 };
+  const failedFiles = [];
+  const queue = new SimpleSemaphore(concurrency);
+  const start = Date.now();
+  let processed = 0;
+  let flushed = 0;
+
+  const levelName = path.basename(levelDir);
+  if (verbose) {
+    const remaining = Math.max(files.length - skipSet.size, 0);
+    console.log(
+      `${levelName} resume: cloned=${tracker.counters.cloned} copied=${tracker.counters.copied} skipped=${tracker.counters.skipped} failed=${tracker.counters.failed} remaining=${remaining}`
+    );
+  }
+
+  const tasks = files.map(async (src) => {
+    const dest = path.join(levelDir, path.basename(src));
+    const rel = path.relative(levelDir, dest);
+    tracker.incrementQueued();
+
+    if (update && !forceRebuild && skipSet.has(rel)) {
+      counters.skipped++;
+      tracker.recordSkip();
+      processed++;
+      if (processed % DEFAULT_PROGRESS_INTERVAL === 0 && verbose) {
+        console.log(
+          `archive progress: level=${levelName} processed=${processed}/${files.length}`
+        );
+      }
+      if (processed - flushed >= 250) {
+        flushed = processed;
+        await tracker.updateRunFile();
+      }
+      return;
+    }
+
+    await queue.run(async () => {
+      try {
+        const outcome = await ensureClone(src, dest, {
+          manifest: update ? manifest : undefined,
+          root: levelDir,
+          update,
+          force: forceRebuild || !update,
+          on: {
+            created: (_, info) => {
+              counters.created++;
+              tracker.recordCompletion({
+                src,
+                dest,
+                status: "created",
+                mode: info?.mode === "copy" ? "copy" : "clone",
+              });
+            },
+            refreshed: (_, info) => {
+              counters.refreshed++;
+              tracker.recordCompletion({
+                src,
+                dest,
+                status: "refreshed",
+                mode: info?.mode === "copy" ? "copy" : "clone",
+              });
+            },
+            skipped: () => {
+              counters.skipped++;
+              tracker.recordSkip();
+            },
+          },
+        });
+        if (outcome === "skipped") {
+          skipSet.add(rel);
+        }
+      } catch (err) {
+        counters.errors++;
+        tracker.recordFailure();
+        if (verbose) {
+          console.warn(`archive: failed to stage ${src}: ${err.message}`);
+        }
+        failedFiles.push({ src, error: err });
+      } finally {
+        processed++;
+        if (processed % DEFAULT_PROGRESS_INTERVAL === 0 && verbose) {
+          console.log(
+            `archive progress: level=${levelName} processed=${processed}/${files.length}`
+          );
+        }
+        if (processed - flushed >= 250) {
+          flushed = processed;
+          await Promise.all([tracker.flush(), manifest.flush(), tracker.updateRunFile()]);
+        }
+      }
+    });
+  });
+
+  await Promise.all(tasks);
+  await tracker.flush();
+  await manifest.flush();
+  await tracker.updateRunFile();
+
+  if (counters.errors === 0) {
+    await tracker.markComplete();
+  }
+
+  const elapsed = Date.now() - start;
+  console.log(
+    `archive: created=${counters.created} refreshed=${counters.refreshed} skipped=${counters.skipped} errors=${counters.errors} elapsed=${Math.round(
+      elapsed / 1000
+    )}s`
+  );
+
+  await manifest.writeSnapshot().catch(() => {});
+
+  return { ...counters, failed: failedFiles.map((f) => f.src) };
+}
+
+export default ensureArchiveLevel;

--- a/src/archive/ensureClone.js
+++ b/src/archive/ensureClone.js
@@ -1,0 +1,77 @@
+import { stat, unlink, mkdir } from "node:fs/promises";
+import path from "node:path";
+import { cloneIfMissing } from "../fsx.js";
+
+function fingerprint(stats) {
+  return { size: stats.size, mtimeMs: stats.mtimeMs };
+}
+
+function sameFingerprint(a, b) {
+  return !!a && !!b && a.size === b.size && a.mtimeMs === b.mtimeMs;
+}
+
+async function safeStat(p) {
+  try {
+    return await stat(p);
+  } catch (err) {
+    if (err?.code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+export async function ensureClone(
+  src,
+  dest,
+  { manifest, root, update = true, force = false, on } = {}
+) {
+  const rel = root ? path.relative(root, dest) : dest;
+  await mkdir(path.dirname(dest), { recursive: true });
+  const srcStats = await stat(src);
+  const fp = fingerprint(srcStats);
+
+  if (force) {
+    await unlink(dest).catch(() => {});
+  }
+
+  if (update && !force && manifest) {
+    const prior = manifest.get(rel);
+    if (sameFingerprint(prior, fp)) {
+      const destStats = await safeStat(dest);
+      if (destStats && sameFingerprint(fp, fingerprint(destStats))) {
+        manifest.set(rel, fp);
+        on?.skipped?.(rel, { reason: "manifest" });
+        return "skipped";
+      }
+    }
+  }
+
+  if (!update && !force) {
+    await unlink(dest).catch(() => {});
+  }
+
+  const result = await cloneIfMissing(src, dest);
+
+  if (result.status === "skipped") {
+    manifest?.set(rel, fp);
+    on?.skipped?.(rel, { reason: "dest-exists" });
+    return "skipped";
+  }
+
+  if (result.status === "updated") {
+    manifest?.set(rel, fp);
+    on?.refreshed?.(rel, { mode: result.mode });
+    return "refreshed";
+  }
+
+  if (result.status === "cloned" || result.status === "copied") {
+    manifest?.set(rel, fp);
+    const mode = result.status === "cloned" ? "clone" : "copy";
+    on?.created?.(rel, { mode });
+    return "created";
+  }
+
+  manifest?.set(rel, fp);
+  return "created";
+}
+
+export default ensureClone;

--- a/src/archive/manifest.js
+++ b/src/archive/manifest.js
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import { createReadStream } from "node:fs";
+import { appendFile, mkdir, rename, writeFile, rm } from "node:fs/promises";
+import readline from "node:readline";
+import path from "node:path";
+
+function lineToRecord(line) {
+  try {
+    return JSON.parse(line);
+  } catch {
+    return null;
+  }
+}
+
+export class Manifest {
+  constructor(root, file = ".ps-manifest.jsonl") {
+    this.root = root;
+    this.file = path.join(root, file);
+    this.map = new Map();
+    this._buffer = [];
+    this._loaded = false;
+  }
+
+  get size() {
+    return this.map.size;
+  }
+
+  async load() {
+    if (this._loaded) return;
+    this._loaded = true;
+    if (!fs.existsSync(this.file)) return;
+    const rl = readline.createInterface({
+      input: createReadStream(this.file),
+      crlfDelay: Infinity,
+    });
+    for await (const line of rl) {
+      if (!line) continue;
+      const rec = lineToRecord(line);
+      if (rec && rec.rel) {
+        this.map.set(rec.rel, { size: rec.size, mtimeMs: rec.mtimeMs });
+      }
+    }
+  }
+
+  clear() {
+    this.map.clear();
+    this._buffer.length = 0;
+    this._loaded = true;
+  }
+
+  get(rel) {
+    return this.map.get(rel);
+  }
+
+  set(rel, fp) {
+    if (!rel) return;
+    this.map.set(rel, { size: fp.size, mtimeMs: fp.mtimeMs });
+    this._buffer.push(JSON.stringify({ rel, ...fp }) + "\n");
+  }
+
+  async flush() {
+    if (!this._buffer.length) return;
+    await mkdir(this.root, { recursive: true });
+    await appendFile(this.file, this._buffer.join(""));
+    this._buffer.length = 0;
+  }
+
+  async writeSnapshot(target = ".manifest.json") {
+    await mkdir(this.root, { recursive: true });
+    const out = path.join(this.root, target);
+    const tmp = `${out}.tmp`;
+    const payload = Object.fromEntries(this.map.entries());
+    await writeFile(tmp, JSON.stringify(payload, null, 2));
+    await rename(tmp, out);
+  }
+
+  async removeFiles() {
+    await rm(this.file, { force: true }).catch(() => {});
+    const snapshot = path.join(this.root, ".manifest.json");
+    await rm(snapshot, { force: true }).catch(() => {});
+  }
+}
+
+export default Manifest;

--- a/src/archive/stageTracker.js
+++ b/src/archive/stageTracker.js
@@ -1,0 +1,145 @@
+import fs from "node:fs";
+import { createReadStream } from "node:fs";
+import { appendFile, mkdir, writeFile, rm, stat } from "node:fs/promises";
+import readline from "node:readline";
+import path from "node:path";
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+export class StageTracker {
+  constructor(root) {
+    this.root = root;
+    this.file = path.join(root, ".staged.jsonl");
+    this.runFile = path.join(root, ".run.json");
+    this.okFile = path.join(root, ".ok");
+    this.completed = new Set();
+    this._buffer = [];
+    this.counters = { cloned: 0, copied: 0, skipped: 0, updated: 0, failed: 0 };
+    this.queued = 0;
+    this.startedAt = null;
+    this.updatedAt = null;
+  }
+
+  async hasOk() {
+    try {
+      const st = await stat(this.okFile);
+      return st.isFile();
+    } catch (err) {
+      if (err?.code === "ENOENT") return false;
+      throw err;
+    }
+  }
+
+  async load() {
+    if (fs.existsSync(this.runFile)) {
+      try {
+        const data = JSON.parse(fs.readFileSync(this.runFile, "utf8"));
+        this.counters = {
+          cloned: data.cloned || 0,
+          copied: data.copied || 0,
+          skipped: data.skipped || 0,
+          updated: data.updated || 0,
+          failed: data.failed || 0,
+        };
+        this.queued = data.queued || 0;
+        this.startedAt = data.startedAt || null;
+        this.updatedAt = data.updatedAt || null;
+      } catch {
+        // ignore corrupted run file; will be rewritten
+      }
+    }
+    if (!fs.existsSync(this.file)) return;
+    const rl = readline.createInterface({
+      input: createReadStream(this.file),
+      crlfDelay: Infinity,
+    });
+    for await (const line of rl) {
+      if (!line) continue;
+      try {
+        const rec = JSON.parse(line);
+        if (rec?.dest) {
+          const rel = path.relative(this.root, rec.dest);
+          this.completed.add(rel);
+        }
+      } catch {
+        // ignore malformed entries
+      }
+    }
+  }
+
+  recordCompletion({ src, dest, status, mode }) {
+    const rel = path.relative(this.root, dest);
+    this.completed.add(rel);
+    if (status === "refreshed") {
+      this.counters.updated++;
+    } else if (mode === "copy") {
+      this.counters.copied++;
+    } else {
+      this.counters.cloned++;
+    }
+    const rec = {
+      src,
+      dest,
+      mode: mode === "copy" ? "copied" : "cloned",
+      status,
+    };
+    this._buffer.push(JSON.stringify(rec) + "\n");
+  }
+
+  recordSkip() {
+    this.counters.skipped++;
+  }
+
+  recordFailure() {
+    this.counters.failed++;
+  }
+
+  incrementQueued() {
+    this.queued++;
+  }
+
+  async flush() {
+    if (!this._buffer.length) return;
+    await mkdir(this.root, { recursive: true });
+    await appendFile(this.file, this._buffer.join(""));
+    this._buffer.length = 0;
+  }
+
+  async updateRunFile() {
+    if (!this.startedAt) this.startedAt = nowIso();
+    this.updatedAt = nowIso();
+    const payload = {
+      queued: this.queued,
+      cloned: this.counters.cloned,
+      copied: this.counters.copied,
+      skipped: this.counters.skipped,
+      updated: this.counters.updated,
+      failed: this.counters.failed,
+      startedAt: this.startedAt,
+      updatedAt: this.updatedAt,
+    };
+    await mkdir(this.root, { recursive: true });
+    await writeFile(this.runFile, JSON.stringify(payload, null, 2));
+  }
+
+  async markComplete() {
+    await mkdir(this.root, { recursive: true });
+    await writeFile(this.okFile, "", "utf8");
+  }
+
+  async reset() {
+    this.completed.clear();
+    this._buffer.length = 0;
+    this.counters = { cloned: 0, copied: 0, skipped: 0, updated: 0, failed: 0 };
+    this.queued = 0;
+    this.startedAt = null;
+    this.updatedAt = null;
+    await rm(this.file, { force: true }).catch(() => {});
+    await rm(this.runFile, { force: true }).catch(() => {});
+    await rm(this.okFile, { force: true }).catch(() => {});
+  }
+}
+
+export default StageTracker;

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -16,6 +16,7 @@ import {
 import { enforceEffortGuard } from "./effortGuard.js";
 import { getSurrogateImage } from "./imagePreprocessor.js";
 import { drain } from "./net.js";
+import { SimpleSemaphore } from "./lib/semaphore.js";
 
 function numEnv(name, fallback) {
   const v = process.env[name];
@@ -90,26 +91,6 @@ if (!USE_UNDICI && !isPeopleLookupDisabled()) {
         maxSockets: PEOPLE_CONCURRENCY,
         maxFreeSockets: PEOPLE_CONCURRENCY,
       });
-}
-class SimpleSemaphore {
-  constructor(max) {
-    this.max = max;
-    this.inUse = 0;
-    this.q = [];
-  }
-  async run(fn) {
-    if (this.inUse >= this.max) {
-      await new Promise((resolve) => this.q.push(resolve));
-    }
-    this.inUse++;
-    try {
-      return await fn();
-    } finally {
-      this.inUse = Math.max(0, this.inUse - 1);
-      const next = this.q.shift();
-      if (next) next();
-    }
-  }
 }
 const peopleSem = new SimpleSemaphore(PEOPLE_CONCURRENCY);
 const peopleCache = new Map();

--- a/src/fsx.js
+++ b/src/fsx.js
@@ -1,0 +1,62 @@
+import { mkdir, stat, copyFile } from "node:fs/promises";
+import { constants as C } from "node:fs";
+import path from "node:path";
+
+const EPSILON_MS = Number(process.env.PHOTO_SELECT_CLONE_EPSILON_MS || 10);
+const FALLBACK_CODES = new Set(["EINVAL", "ENOTSUP", "EOPNOTSUPP", "EXDEV", "ERR_FS_COPYFILE_IMPL"]);
+
+async function ensureParent(file) {
+  await mkdir(path.dirname(file), { recursive: true });
+}
+
+async function safeStat(p) {
+  try {
+    return await stat(p);
+  } catch (err) {
+    if (err?.code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+export async function cloneIfMissing(src, dest) {
+  await ensureParent(dest);
+  try {
+    await copyFile(src, dest, C.COPYFILE_FICLONE | C.COPYFILE_EXCL);
+    return { status: "cloned", mode: "clone" };
+  } catch (err) {
+    if (err?.code === "EEXIST") {
+      const [srcStats, destStats] = await Promise.all([stat(src), safeStat(dest)]);
+      if (destStats && srcStats.size === destStats.size) {
+        if (destStats.mtimeMs >= srcStats.mtimeMs - EPSILON_MS) {
+          return { status: "skipped", mode: null };
+        }
+      }
+      try {
+        await copyFile(src, dest, C.COPYFILE_FICLONE);
+        return { status: "updated", mode: "clone" };
+      } catch (cloneErr) {
+        if (!FALLBACK_CODES.has(cloneErr?.code)) {
+          throw cloneErr;
+        }
+      }
+      await copyFile(src, dest);
+      return { status: "updated", mode: "copy" };
+    }
+
+    if (FALLBACK_CODES.has(err?.code)) {
+      try {
+        await copyFile(src, dest, C.COPYFILE_EXCL);
+        return { status: "copied", mode: "copy" };
+      } catch (fallbackErr) {
+        if (fallbackErr?.code === "EEXIST") {
+          return { status: "skipped", mode: null };
+        }
+        throw fallbackErr;
+      }
+    }
+
+    throw err;
+  }
+}
+
+export default cloneIfMissing;

--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,18 @@ program
     "Save full prompts and responses for debugging"
   )
   .option(
+    "--update [bool]",
+    "Idempotent archive (skip unchanged files)",
+    (value) => parseEnvFlag(value, true),
+    true
+  )
+  .option("--force-rebuild", "Ignore manifest; rebuild archive")
+  .option(
+    "--stage-concurrency <n>",
+    "Maximum concurrent archive clones",
+    (v) => Math.max(1, parseInt(v, 10))
+  )
+  .option(
     "--workers <n>",
     "Number of worker processes (each runs batches sequentially)",
     (v) => Math.max(1, parseInt(v, 10))
@@ -110,6 +122,9 @@ let {
   fieldNotes,
   verbose,
   saveIo,
+  update,
+  forceRebuild,
+  stageConcurrency,
   workers,
   verbosity,
   reasoningEffort,
@@ -235,6 +250,9 @@ process.env.PHOTO_SELECT_USER_EFFORT = finalReasoningEffort;
       fieldNotes,
       verbose,
       saveIo,
+      update,
+      forceRebuild,
+      stageConcurrency,
       workers,
       verbosity,
       reasoningEffort: finalReasoningEffort,

--- a/src/lib/semaphore.js
+++ b/src/lib/semaphore.js
@@ -1,0 +1,29 @@
+export class SimpleSemaphore {
+  constructor(max = 1) {
+    if (!Number.isFinite(max) || max <= 0) {
+      throw new Error(`SimpleSemaphore requires max >= 1 (received ${max})`);
+    }
+    this.max = max;
+    this.inUse = 0;
+    this.queue = [];
+  }
+
+  async run(fn) {
+    if (typeof fn !== "function") {
+      throw new TypeError("SimpleSemaphore.run expects a function");
+    }
+    if (this.inUse >= this.max) {
+      await new Promise((resolve) => this.queue.push(resolve));
+    }
+    this.inUse++;
+    try {
+      return await fn();
+    } finally {
+      this.inUse = Math.max(0, this.inUse - 1);
+      const next = this.queue.shift();
+      if (next) next();
+    }
+  }
+}
+
+export default SimpleSemaphore;

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -4,8 +4,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { batchStore } from "./batchContext.js";
 import crypto from "node:crypto";
-import { delay } from "./config.js";
-import { copyFilePreferClone } from "./fs-clone.js";
+import { ensureArchiveLevel } from "./archive/ensureArchiveLevel.js";
 import { listImages, pickRandom, moveFiles } from "./imageSelector.js";
 import { parseReply, getPeople } from "./chatClient.js";
 import { buildPrompt } from "./templates.js";
@@ -252,6 +251,9 @@ export async function triageDirectory(options) {
     reasoningEffort,
     depth = 0,
     gitRoot,
+    update = true,
+    forceRebuild = false,
+    stageConcurrency,
   } = options;
   if (!provider) {
     const m = await import('./providers/openai.js');
@@ -327,6 +329,9 @@ export async function triageDirectory(options) {
         depth: depth + hops,
         provider,
         gitRoot,
+        update,
+        forceRebuild,
+        stageConcurrency,
       });
     }
   }
@@ -355,46 +360,22 @@ export async function triageDirectory(options) {
     await mkdir(path.join(levelDir, '_prompts'), { recursive: true });
     await mkdir(path.join(levelDir, '_responses'), { recursive: true });
   }
-  const failedArchives = [];
-  const copyFileSafe = async (
-    src,
-    dest,
-    attempt = 0,
-    maxAttempts = 3
-  ) => {
-    try {
-      await copyFilePreferClone(src, dest);
-    } catch (err) {
-      if (err?.code === "ECANCELED" && attempt < maxAttempts) {
-        const wait = (attempt + 1) * 1000;
-        console.warn(`${indent}⏳  Waiting for network file ${src} (${wait}ms)…`);
-        try {
-          await stat(src);
-        } catch {
-          // ignore
-        }
-        await delay(wait);
-        return copyFileSafe(src, dest, attempt + 1, maxAttempts);
-      }
-      throw err;
-    }
-  };
-  await Promise.all(
-    initImages.map(async (file) => {
-      const dest = path.join(levelDir, path.basename(file));
-      try {
-        await copyFileSafe(file, dest);
-      } catch (err) {
-        failedArchives.push(file);
-        console.warn(`${indent}⚠️  Failed to archive ${file}: ${err.message}`);
-      }
-    })
-  );
-  if (failedArchives.length) {
+  if (!update && depth === 0) {
+    console.warn("⚠️ archive update disabled — will re-clone all files");
+  }
+  const archiveResult = await ensureArchiveLevel({
+    levelDir,
+    files: initImages,
+    update,
+    forceRebuild,
+    stageConcurrency,
+    verbose,
+  });
+  if (archiveResult.failed?.length) {
     const listPath = path.join(levelDir, "failed-archives.txt");
-    await writeFile(listPath, failedArchives.join("\n"), "utf8");
+    await writeFile(listPath, archiveResult.failed.join("\n"), "utf8");
     console.warn(
-      `${indent}⚠️  ${failedArchives.length} file(s) failed to archive; see ${listPath}`
+      `${indent}⚠️  ${archiveResult.failed.length} file(s) failed to archive; see ${listPath}`
     );
   }
 
@@ -726,6 +707,9 @@ export async function triageDirectory(options) {
         reasoningEffort,
         depth: depth + 1,
         gitRoot,
+        update,
+        forceRebuild,
+        stageConcurrency,
       });
     } else if (keepCount || asideCount) {
       const status = keepCount ? "kept" : "set aside";

--- a/tests/archive/ensureClone.test.js
+++ b/tests/archive/ensureClone.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import path from "node:path";
+import os from "node:os";
+import * as fs from "node:fs/promises";
+import { ensureClone } from "../../src/archive/ensureClone.js";
+import { Manifest } from "../../src/archive/manifest.js";
+import * as fsx from "../../src/fsx.js";
+
+async function createTmpDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), "ps-ensure-"));
+}
+
+describe("ensureClone", () => {
+  let tmpDir;
+  let manifest;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    manifest = new Manifest(path.join(tmpDir, "archive"));
+    await fs.mkdir(path.join(tmpDir, "archive"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates on first run", async () => {
+    const root = path.join(tmpDir, "archive");
+    const src = path.join(tmpDir, "photo-a.jpg");
+    const dest = path.join(root, "photo-a.jpg");
+    await fs.writeFile(src, "data-a");
+    const result = await ensureClone(src, dest, { manifest, root });
+    expect(result).toBe("created");
+    const rel = path.relative(root, dest);
+    expect(manifest.get(rel)).toBeDefined();
+  });
+
+  it("skips when fingerprint matches", async () => {
+    const root = path.join(tmpDir, "archive");
+    const src = path.join(tmpDir, "photo-b.jpg");
+    const dest = path.join(root, "photo-b.jpg");
+    await fs.writeFile(src, "data-b");
+    await ensureClone(src, dest, { manifest, root });
+    const result = await ensureClone(src, dest, { manifest, root });
+    expect(result).toBe("skipped");
+  });
+
+  it("refreshes when the source changes", async () => {
+    const root = path.join(tmpDir, "archive");
+    const src = path.join(tmpDir, "photo-c.jpg");
+    const dest = path.join(root, "photo-c.jpg");
+    await fs.writeFile(src, "data-c");
+    await ensureClone(src, dest, { manifest, root });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await fs.writeFile(src, "data-c-updated");
+    const result = await ensureClone(src, dest, { manifest, root });
+    expect(result).toBe("refreshed");
+  });
+
+  it("reports created when clone falls back to copy", async () => {
+    const root = path.join(tmpDir, "archive");
+    const src = path.join(tmpDir, "photo-d.jpg");
+    const dest = path.join(root, "photo-d.jpg");
+    await fs.writeFile(src, "data-d");
+    const spy = vi
+      .spyOn(fsx, "cloneIfMissing")
+      .mockResolvedValue({ status: "copied", mode: "copy" });
+    const result = await ensureClone(src, dest, { manifest, root });
+    expect(result).toBe("created");
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/tests/archive/staging.integration.test.js
+++ b/tests/archive/staging.integration.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import path from "node:path";
+import os from "node:os";
+import * as fs from "node:fs/promises";
+import { ensureArchiveLevel } from "../../src/archive/ensureArchiveLevel.js";
+import * as fsx from "../../src/fsx.js";
+
+async function makeTmpDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), "ps-stage-"));
+}
+
+describe("ensureArchiveLevel integration", () => {
+  let tmpDir;
+  let levelDir;
+  let files;
+  let logSpy;
+  let warnSpy;
+
+  beforeEach(async () => {
+    tmpDir = await makeTmpDir();
+    levelDir = path.join(tmpDir, "_level-001");
+    await fs.mkdir(levelDir, { recursive: true });
+    files = [];
+    for (const name of ["a.jpg", "b.jpg", "c.jpg"]) {
+      const file = path.join(tmpDir, name);
+      await fs.writeFile(file, name);
+      files.push(file);
+    }
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("stages once and skips on resume", async () => {
+    const first = await ensureArchiveLevel({
+      levelDir,
+      files,
+      update: true,
+      verbose: false,
+    });
+    expect(first.created).toBe(files.length);
+    expect(first.errors).toBe(0);
+    const stagedLog = await fs.readFile(path.join(levelDir, ".staged.jsonl"), "utf8");
+    expect(stagedLog.trim().split("\n").filter(Boolean).length).toBe(files.length);
+    await expect(fs.stat(path.join(levelDir, ".ok"))).resolves.toBeTruthy();
+
+    const cloneSpy = vi.spyOn(fsx, "cloneIfMissing").mockImplementation(async () => {
+      throw new Error("clone should not be called on resume");
+    });
+
+    const second = await ensureArchiveLevel({
+      levelDir,
+      files,
+      update: true,
+      verbose: false,
+    });
+    expect(second.skipped).toBe(files.length);
+    expect(second.created).toBe(0);
+    expect(cloneSpy).not.toHaveBeenCalled();
+
+    const runData = JSON.parse(
+      await fs.readFile(path.join(levelDir, ".run.json"), "utf8")
+    );
+    expect(runData.cloned).toBeGreaterThanOrEqual(files.length);
+  });
+});

--- a/tests/fsx.test.js
+++ b/tests/fsx.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import path from "node:path";
+import os from "node:os";
+import * as fs from "node:fs/promises";
+import { constants as C } from "node:fs";
+
+async function createTmpDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), "ps-fsx-"));
+}
+
+describe("cloneIfMissing", () => {
+  let tmpDir;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("clones when destination is absent", async () => {
+    const { cloneIfMissing } = await import("../src/fsx.js");
+    const src = path.join(tmpDir, "a.txt");
+    const dest = path.join(tmpDir, "b.txt");
+    await fs.writeFile(src, "alpha");
+    const result = await cloneIfMissing(src, dest);
+    expect(["cloned", "copied"]).toContain(result.status);
+    expect(await fs.readFile(dest, "utf8")).toBe("alpha");
+  });
+
+  it("skips when the destination matches the source", async () => {
+    const { cloneIfMissing } = await import("../src/fsx.js");
+    const src = path.join(tmpDir, "c.txt");
+    const dest = path.join(tmpDir, "d.txt");
+    await fs.writeFile(src, "alpha");
+    await cloneIfMissing(src, dest);
+    const result = await cloneIfMissing(src, dest);
+    expect(result.status).toBe("skipped");
+  });
+
+  it("refreshes when the source changes", async () => {
+    const { cloneIfMissing } = await import("../src/fsx.js");
+    const src = path.join(tmpDir, "e.txt");
+    const dest = path.join(tmpDir, "f.txt");
+    await fs.writeFile(src, "alpha");
+    await cloneIfMissing(src, dest);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await fs.writeFile(src, "beta-extended");
+    const result = await cloneIfMissing(src, dest);
+    expect(result.status).toBe("updated");
+    expect(await fs.readFile(dest, "utf8")).toBe("beta-extended");
+  });
+
+  it("falls back to copy when clone is not supported", async () => {
+    vi.doMock("node:fs/promises", async () => {
+      const actual = await vi.importActual("node:fs/promises");
+      return {
+        ...actual,
+        copyFile: vi.fn(async (source, target, flags) => {
+          if (flags === (C.COPYFILE_FICLONE | C.COPYFILE_EXCL)) {
+            const err = new Error("not supported");
+            err.code = "ENOTSUP";
+            throw err;
+          }
+          return actual.copyFile(source, target, flags);
+        }),
+      };
+    });
+    const { cloneIfMissing } = await import("../src/fsx.js");
+    const src = path.join(tmpDir, "g.txt");
+    const dest = path.join(tmpDir, "h.txt");
+    await fs.writeFile(src, "gamma");
+    const result = await cloneIfMissing(src, dest);
+    expect(result.status).toBe("copied");
+    expect(await fs.readFile(dest, "utf8")).toBe("gamma");
+    vi.doUnmock("node:fs/promises");
+  });
+});


### PR DESCRIPTION
## Summary
- add archive helpers that reuse manifests, track staging runs, and prefer APFS clones while falling back when unsupported
- update the orchestrator/CLI to expose --update, --force-rebuild, and --stage-concurrency along with documentation for resume semantics
- add targeted unit and integration tests covering clone helpers and resumable staging behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690d0298782083308e7adaaf0b858470