### PR TITLE
Update OpenAI VLM docs and scheduler defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,8 @@ PHOTO_FILTER_API_BASE=http://localhost:3000 \
 
 The CLI calls the Chat Completions API and automatically switches to `/v1/responses` if a model only supports that endpoint. In batch mode, each session is serialized to a single JSONL line and submitted to the Batch API with the same structured-output schema. Any vision-capable chat model listed on OpenAI's [models](https://platform.openai.com/docs/models) page should work, including:
 
-* **GPT‑5 family** – `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, and `gpt-5-chat-latest`
+* **GPT‑5.1 / GPT‑5 family** – `gpt-5.1`, `gpt-5`, `gpt-5-mini`,
+  `gpt-5-nano`, `gpt-5.1-chat-latest`, and `gpt-5-chat-latest`
 * **GPT‑4.1 family** – `gpt-4.1`, `gpt-4.1-mini`, and `gpt-4.1-nano`
 * **GPT‑4o family** – `gpt-4o` (default), `gpt-4o-mini`, `gpt-4o-audio-preview`,
   `gpt-4o-mini-audio-preview`, `gpt-4o-realtime-preview`,
@@ -414,25 +415,26 @@ full 315‑photo set therefore uses about 2.5 million input tokens plus roughl
 
 Approximate price per run:
 
-| model                | input $/1M | output $/1M | est. cost on 315 photos |
-| -------------------- | ---------- | ----------- | ---------------------- |
-| `gpt-5`              | $1.25      | $10.00      | ~$5.62 |
-| `gpt-5-mini`         | $0.25      | $2.00       | ~$1.12 |
-| `gpt-5-nano`         | $0.05      | $0.40       | ~$0.23 |
-| `gpt-4.1`            | $2.00      | $8.00       | ~$7.00 |
-| `gpt-4.1-mini`       | $0.40      | $1.60       | ~$1.40 |
-| `gpt-4.1-nano`       | $0.10      | $0.40       | ~$0.35 |
-| `gpt-4o`             | $2.50      | $10.00      | ~$8.75 |
-| `gpt-4o-mini`        | $0.15      | $0.60       | ~$0.53 |
-| `o4-mini`            | $1.10      | $4.40       | ~$3.85 |
-| `o4-mini-deep-research` | $2.00   | $8.00       | ~$7.00 |
-| `o3`                 | $2.00      | $8.00       | ~$7.00 |
-| `o3-pro`             | $20.00     | $80.00      | ~$70.00 |
-| `o3-mini`            | $1.10      | $4.40       | ~$3.85 |
-| `o3-deep-research`   | $10.00     | $40.00      | ~$35.00 |
-| `o1`                 | $15.00     | $60.00      | ~$52.50 |
-| `o1-pro`             | $150.00    | $600.00     | ~$525.00 |
-| `o1-mini`            | $1.10      | $4.40       | ~$3.85 |
+| model                      | input $/1M | output $/1M | est. cost on 315 photos |
+| -------------------------- | ---------- | ----------- | ---------------------- |
+| `gpt-5.1`                  | $1.25      | $10.00      | ~$5.62 |
+| `gpt-5`                    | $1.25      | $10.00      | ~$5.62 |
+| `gpt-5-mini`               | $0.25      | $2.00       | ~$1.12 |
+| `gpt-5-nano`               | $0.05      | $0.40       | ~$0.23 |
+| `gpt-4.1`                  | $2.00      | $8.00       | ~$7.00 |
+| `gpt-4.1-mini`             | $0.40      | $1.60       | ~$1.40 |
+| `gpt-4.1-nano`             | $0.10      | $0.40       | ~$0.35 |
+| `gpt-4o`                   | $2.50      | $10.00      | ~$8.75 |
+| `gpt-4o-mini`              | $0.15      | $0.60       | ~$0.53 |
+| `o4-mini`                  | $1.10      | $4.40       | ~$3.85 |
+| `o4-mini-deep-research`    | $2.00      | $8.00       | ~$7.00 |
+| `o3`                       | $2.00      | $8.00       | ~$7.00 |
+| `o3-pro`                   | $20.00     | $80.00      | ~$70.00 |
+| `o3-mini`                  | $1.10      | $4.40       | ~$3.85 |
+| `o3-deep-research`         | $10.00     | $40.00      | ~$35.00 |
+| `o1`                       | $15.00     | $60.00      | ~$52.50 |
+| `o1-pro`                   | $150.00    | $600.00     | ~$525.00 |
+| `o1-mini`                  | $1.10      | $4.40       | ~$3.85 |
 
 These figures are approximate and based on current
 [OpenAI pricing](https://openai.com/pricing). Actual costs will vary with output

--- a/src/scheduler 2.js
+++ b/src/scheduler 2.js
@@ -227,6 +227,11 @@ function optNumEnv(name) {
   return Number.isFinite(n) ? n : undefined;
 }
 
+const gpt5Budget = {
+  tpm: numEnv("PHOTO_SELECT_TPM_GPT5", 2_000_000),
+  rpm: numEnv("PHOTO_SELECT_RPM_GPT5", 600),
+};
+
 /** Create a process-wide singleton with sane defaults. */
 export const scheduler = new TokenScheduler({
   maxConcurrent: numEnv("PHOTO_SELECT_MAX_CONCURRENT", 10),
@@ -234,10 +239,10 @@ export const scheduler = new TokenScheduler({
   perModel: {
     // Soft budgets — feel free to lower from your org hard caps:
     // Your org: gpt-5 → 40,000,000 TPM, 15,000 RPM
-    "gpt-5": {
-      tpm: numEnv("PHOTO_SELECT_TPM_GPT5", 2_000_000),
-      rpm: numEnv("PHOTO_SELECT_RPM_GPT5", 600),
-    },
+    "gpt-5": gpt5Budget,
+    "gpt-5.1": gpt5Budget,
+    "gpt-5-chat-latest": gpt5Budget,
+    "gpt-5.1-chat-latest": gpt5Budget,
     "gpt-5-mini": {
       tpm: numEnv("PHOTO_SELECT_TPM_GPT5_MINI", 4_000_000),
       rpm: numEnv("PHOTO_SELECT_RPM_GPT5_MINI", 900),

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -249,6 +249,11 @@ function optNumEnv(name) {
   return Number.isFinite(n) ? n : undefined;
 }
 
+const gpt5Budget = {
+  tpm: numEnv("PHOTO_SELECT_TPM_GPT5", 2_000_000),
+  rpm: numEnv("PHOTO_SELECT_RPM_GPT5", 600),
+};
+
 /** Create a process-wide singleton with sane defaults. */
 export const scheduler = new TokenScheduler({
   maxConcurrent: numEnv("PHOTO_SELECT_MAX_CONCURRENT", 10),
@@ -256,10 +261,10 @@ export const scheduler = new TokenScheduler({
   perModel: {
     // Soft budgets — feel free to lower from your org hard caps:
     // Your org: gpt-5 → 40,000,000 TPM, 15,000 RPM
-    "gpt-5": {
-      tpm: numEnv("PHOTO_SELECT_TPM_GPT5", 2_000_000),
-      rpm: numEnv("PHOTO_SELECT_RPM_GPT5", 600),
-    },
+    "gpt-5": gpt5Budget,
+    "gpt-5.1": gpt5Budget,
+    "gpt-5-chat-latest": gpt5Budget,
+    "gpt-5.1-chat-latest": gpt5Budget,
     "gpt-5-mini": {
       tpm: numEnv("PHOTO_SELECT_TPM_GPT5_MINI", 4_000_000),
       rpm: numEnv("PHOTO_SELECT_RPM_GPT5_MINI", 900),


### PR DESCRIPTION
## Summary
- add GPT-5.1 variants to the supported OpenAI model list and refresh the pricing table with current rates
- align token scheduler budgets for new GPT-5.1 chat variants across both scheduler builds

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f282a3714833093fe0a1f93482559)