### PR TITLE
Fix people lookup payloads and batch fallback schema

### DIFF
--- a/scripts/debug-batch.mjs
+++ b/scripts/debug-batch.mjs
@@ -44,13 +44,37 @@ async function peekJsonl(text, n = 10) {
   return { totalLines: lines.length, first };
 }
 
+function extractError(row) {
+  let err = row?.error || null;
+  if (!err && row?.response?.body) {
+    try {
+      const body =
+        typeof row.response.body === "string"
+          ? JSON.parse(row.response.body)
+          : row.response.body;
+      if (body?.error) {
+        err = body.error;
+      }
+    } catch {
+      // ignore parse errors
+    }
+  }
+  return err;
+}
+
 function logErrorRow(row) {
   const cid = row.custom_id ?? "(no custom_id)";
-  const err = row.error || {};
+  const err = extractError(row) || {};
   const code = err.code ?? err.type ?? "unknown";
   const msg = err.message ?? "(no message)";
   const param = err.param ? ` param=${err.param}` : "";
   console.error(`  • ${cid}: [${code}] ${msg}${param}`);
+  if ((code === "unknown" || msg === "(no message)") && (row.error || row.response)) {
+    console.error(
+      "    raw error object:",
+      JSON.stringify(row.error ?? row.response, null, 2)
+    );
+  }
 }
 
 export async function debugBatch(batchId, { peek = 10 } = {}) {
@@ -91,7 +115,10 @@ export async function debugBatch(batchId, { peek = 10 } = {}) {
     const { totalLines, first } = await peekJsonl(errText, peek);
 
     const errorCodes = countBy(
-      first.map((r) => r?.error?.code ?? r?.error?.type ?? "unknown")
+      first.map((r) => {
+        const err = extractError(r);
+        return err?.code ?? err?.type ?? "unknown";
+      })
     );
     console.error(`❗ ${totalLines} error row(s). Summary by code/type:`);
     Object.entries(errorCodes).forEach(([k, v]) =>

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -186,6 +186,29 @@ export async function getPeople(filename) {
     peopleCache.set(filename, []);
     return [];
   }
+  const normalizePeople = (payload) => {
+    let rawNames;
+    if (Array.isArray(payload?.people)) {
+      rawNames = payload.people;
+    } else if (Array.isArray(payload?.data)) {
+      rawNames = payload.data;
+    } else {
+      rawNames = [];
+      if (process.env.PHOTO_SELECT_VERBOSE === "1") {
+        console.warn(
+          `⚠️ Unexpected people payload for ${filename}: ${JSON.stringify(payload)}`
+        );
+      }
+    }
+    const names = rawNames
+      .map((entry) => {
+        if (typeof entry === "string") return entry;
+        if (entry && typeof entry.name === "string") return entry.name;
+        return null;
+      })
+      .filter(Boolean);
+    return sanitizePeople(names);
+  };
   try {
     const url = `${PEOPLE_API_BASE}/api/photos/by-filename/${encodeURIComponent(
       filename
@@ -195,7 +218,7 @@ export async function getPeople(filename) {
     );
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const json = await res.json();
-    const names = Array.isArray(json.data) ? json.data : [];
+    const names = normalizePeople(json);
     peopleCache.set(filename, names);
     return names;
   } catch (err) {

--- a/src/providers/openai-batch.js
+++ b/src/providers/openai-batch.js
@@ -438,7 +438,14 @@ export default class OpenAIBatchProvider {
     const body = {
       model,
       messages,
-      response_format: { type: 'json_schema', json_schema: schema },
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'photo_select_reply',
+          schema,
+          strict: true,
+        },
+      },
       max_tokens,
       temperature: 0.7,
     };

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -336,7 +336,7 @@ describe("curatorsFromTags", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => ({ data: ["_UNKNOWN_"] }) })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ data: ["_UNKNOWN_"] }) });
     const names = await curatorsFromTags(imgs);
-    expect(names).toContain("_UNKNOWN_");
+    expect(names).toEqual([]);
     global.fetch.mockReset();
   });
 

--- a/tests/openaiBatchProvider.test.js
+++ b/tests/openaiBatchProvider.test.js
@@ -177,4 +177,54 @@ describe('OpenAIBatchProvider', () => {
     const resultsPath = path.join(tmpDir, '.batch', 'results', `${handle.batchId}.jsonl`);
     await expect(fs.stat(resultsPath)).resolves.toBeTruthy();
   });
+
+  it('wraps chat completions fallback schema and preserves messages', async () => {
+    const imagePath = path.join(tmpDir, 'with-people.jpg');
+    await fs.writeFile(imagePath, 'data');
+
+    const messagePayload = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'input_text',
+            text: JSON.stringify({ filename: 'with-people.jpg', people: ['Ada', { name: 'Bob' }] }),
+          },
+          { type: 'input_image_url', image_url: { url: 'data:image/jpeg;base64,AAA' } },
+        ],
+      },
+    ];
+    const replySchema = { type: 'object', properties: { minutes: { type: 'array' } } };
+
+    helpers.buildMessages = vi.fn(async () => ({ messages: messagePayload, used: [imagePath] }));
+    helpers.buildReplySchema = vi.fn(() => replySchema);
+
+    const provider = new OpenAIBatchProvider({ client, helpers });
+    client.batches.create
+      .mockRejectedValueOnce(new Error('responses submit failed'))
+      .mockResolvedValueOnce({ id: 'batch_fb', status: 'validating' });
+    client.files.create
+      .mockResolvedValueOnce({ id: 'file_default' })
+      .mockResolvedValueOnce({ id: 'file_fallback' });
+
+    const handle = await provider.submit({
+      levelDir: tmpDir,
+      prompt: 'prompt',
+      images: [imagePath],
+      model: 'gpt-5',
+      curators: ['Curator'],
+    });
+
+    expect(handle.endpoint).toBe('/v1/chat/completions');
+    const inputsDir = path.join(tmpDir, '.batch', 'inputs');
+    const files = await fs.readdir(inputsDir);
+    const jsonl = await fs.readFile(path.join(inputsDir, files[0]), 'utf8');
+    const line = JSON.parse(jsonl.trim());
+    expect(line.url).toBe('/v1/chat/completions');
+    expect(line.body.messages).toEqual(messagePayload);
+    expect(line.body.response_format).toEqual({
+      type: 'json_schema',
+      json_schema: { name: 'photo_select_reply', schema: replySchema, strict: true },
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Normalize people lookups to accept the photo-filter `people` payload shape, map objects with names to strings, and log unexpected responses
- Wrap chat-completions batch fallback schemas correctly and add a regression test that preserves message payloads
- Improve batch debug logging by extracting errors from response bodies

## Testing
- npx vitest run tests/openaiBatchProvider.test.js tests/chatClient.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937a2d4beac8330be47a1d4839282cf)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalizes people API responses, correctly wraps the chat-completions fallback JSON schema while preserving messages, and improves batch error extraction/logging.
> 
> - **People Lookup (`src/chatClient.js`)**:
>   - Normalize payloads to accept `people` or `data` arrays; map `{ name }` objects to strings; sanitize results; verbose log on unexpected payloads.
>   - `getPeople` consumers now receive filtered names (placeholders removed); `curatorsFromTags` reflects this behavior.
> - **Batch Provider (`src/providers/openai-batch.js`)**:
>   - Chat-completions fallback: wrap `response_format` as `{ type: 'json_schema', json_schema: { name: 'photo_select_reply', schema, strict: true } }` and preserve original `messages`.
> - **Debugging (`scripts/debug-batch.mjs`)**:
>   - Extract errors from `response.body` via `extractError`; improved `logErrorRow` with raw object dump when missing code/message; summarize error codes using extracted errors.
> - **Tests**:
>   - Add/adjust tests for people normalization, placeholder filtering, and fallback schema/message preservation in batch provider.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61d3a1a6dac33f6a430df5b223adde361545edc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->