### PR TITLE
perf: parallelize per-batch people lookups in orchestrator

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -457,12 +457,14 @@ export async function triageDirectory(options) {
                   }
                 };
 
-                const photos = [];
-                for (const file of batch) {
-                  const name = path.basename(file);
-                  const people = sanitizePeople(await getPeople(name));
-                  photos.push({ file: name, people });
-                }
+                const names = batch.map((file) => path.basename(file));
+                const peopleLists = await Promise.all(
+                  names.map((name) => getPeople(name))
+                );
+                const photos = names.map((name, i) => ({
+                  file: name,
+                  people: sanitizePeople(peopleLists[i]),
+                }));
                 const { finalCurators, added } = finalizeCurators(curators, photos);
                 if (added.length) {
                   log(


### PR DESCRIPTION
### Motivation
- Speed up batch processing by performing per-batch `getPeople(name)` lookups concurrently instead of awaiting them sequentially, while preserving existing behavior and order.

### Description
- Replaced the sequential loop in `src/orchestrator.js` with a localized `Promise.all` over `names`, then rebuilt `photos` by mapping results back to the original index and calling `sanitizePeople` on each resolved list so batch order and sanitization are preserved.

### Testing
- Ran the full test suite with `npm test`; the automated tests completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d908b0633883309803ab27a80c5a53)