### PR TITLE
Stabilize batch transport: atomic surrogate cache, image guards, GPT‑5 token fix, and gentler diagnostics

### DIFF
--- a/scripts/debug-batch.mjs
+++ b/scripts/debug-batch.mjs
@@ -26,10 +26,31 @@ const safeParse = (line) => {
 const countBy = (arr) =>
   arr.reduce((acc, k) => ((acc[k] = (acc[k] || 0) + 1), acc), {});
 
+function missingScopeMessage(err, operation) {
+  const msg = String(
+    err?.error?.message ||
+    err?.message ||
+    err?.response?.data?.error?.message ||
+    ""
+  );
+  const scope = msg.match(/api\.[a-z]+\.[a-z]+/i)?.[0];
+  if (!scope) return null;
+  return `⚠️ Missing scope ${scope} required for ${operation}; skipping that diagnostic step.`;
+}
+
 async function fetchTextFile(fileId) {
   const client = getClient();
-  const res = await client.files.content(fileId);
-  return await res.text();
+  try {
+    const res = await client.files.content(fileId);
+    return await res.text();
+  } catch (err) {
+    const scopeMsg = missingScopeMessage(err, `reading file ${fileId}`);
+    if (scopeMsg) {
+      console.error(scopeMsg);
+      return null;
+    }
+    throw err;
+  }
 }
 
 async function saveToTmp(name, text) {
@@ -80,7 +101,17 @@ function logErrorRow(row) {
 export async function debugBatch(batchId, { peek = 10 } = {}) {
   console.error(`🔎 Debugging batch ${batchId} …`);
   const client = getClient();
-  const b = await client.batches.retrieve(batchId);
+  let b;
+  try {
+    b = await client.batches.retrieve(batchId);
+  } catch (err) {
+    const scopeMsg = missingScopeMessage(err, `retrieving batch ${batchId}`);
+    if (scopeMsg) {
+      console.error(scopeMsg);
+      return;
+    }
+    throw err;
+  }
 
   console.error("📋 Batch status:");
   console.error(pretty({
@@ -98,6 +129,7 @@ export async function debugBatch(batchId, { peek = 10 } = {}) {
 
   try {
     const inputText = await fetchTextFile(b.input_file_id);
+    if (!inputText) return;
     const inputLines = inputText.trim().split("\n").filter(Boolean);
     console.error(`📥 Input JSONL: ${inputLines.length} line(s).`);
     if (inputLines.length) {
@@ -110,6 +142,7 @@ export async function debugBatch(batchId, { peek = 10 } = {}) {
 
   if (b.error_file_id) {
     const errText = await fetchTextFile(b.error_file_id);
+    if (!errText) return;
     const errPath = await saveToTmp(`batch-${b.id}-errors.jsonl`, errText);
     console.error(`🧾 Saved error JSONL → ${errPath}`);
     const { totalLines, first } = await peekJsonl(errText, peek);
@@ -133,6 +166,7 @@ export async function debugBatch(batchId, { peek = 10 } = {}) {
 
   if (b.output_file_id) {
     const outText = await fetchTextFile(b.output_file_id);
+    if (!outText) return;
     const outPath = await saveToTmp(`batch-${b.id}-output.jsonl`, outText);
     console.error(`✅ Saved output JSONL → ${outPath}`);
     const { totalLines, first } = await peekJsonl(outText, peek);

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -144,12 +144,15 @@ async function extractTextWithLogging(rsp) {
     rsp.output?.flatMap((o) =>
       o.type === "message" ? (o.content || []).map((c) => c.type) : [o.type]
     ) || [];
-  console.log(
-    `\uD83D\uDD0E responses.create content types: ${types.join(", ")}`
-  );
-  console.log(
-    `\uD83D\uDD0E output_text length: ${rsp.output_text?.length || 0}`
-  );
+  const verbose = process.env.PHOTO_SELECT_VERBOSE === "1";
+  if (verbose) {
+    console.error(
+      `\uD83D\uDD0E responses.create content types: ${types.join(", ")}`
+    );
+    console.error(
+      `\uD83D\uDD0E output_text length: ${rsp.output_text?.length || 0}`
+    );
+  }
   const { text, json, hasMessage } = extractPayload(rsp);
   const debug = process.env.PHOTO_SELECT_DEBUG;
   if (!hasMessage || !text.trim() || debug) {
@@ -167,7 +170,7 @@ async function extractTextWithLogging(rsp) {
     if (!hasMessage || !text.trim()) {
       await logWarn(`⚠️ Empty text; full Responses payload saved to ${f}`);
     } else {
-      console.log(`\uD83D\uDC1B  Saved raw Responses payload to ${f}`);
+      console.error(`\uD83D\uDC1B  Saved raw Responses payload to ${f}`);
       await appendFile(
         path.join(dir, "warnings.log"),
         `Saved Responses payload to ${f}\n`
@@ -175,7 +178,7 @@ async function extractTextWithLogging(rsp) {
     }
   }
   if (debug) {
-    console.log(`\uD83D\uDC1B  First 400 chars: ${text.slice(0, 400)}`);
+    console.error(`\uD83D\uDC1B  First 400 chars: ${text.slice(0, 400)}`);
   }
   return { text, json, hasMessage };
 }
@@ -316,6 +319,21 @@ function useColor() {
 }
 const dim = (s) => (useColor() ? `\x1b[2m${s}\x1b[0m` : s);
 
+function buildImageDataUrl({ buffer, file, mimeType = "image/jpeg" }) {
+  if (!buffer || buffer.length <= 0) {
+    throw new Error(`Empty image buffer for ${file}`);
+  }
+  const base64 = buffer.toString("base64");
+  if (!base64) {
+    throw new Error(`Empty base64 image payload for ${file}`);
+  }
+  const url = `data:${mimeType};base64,${base64}`;
+  if (!url.startsWith("data:image/") || !url.includes(";base64,")) {
+    throw new Error(`Malformed data URL for ${file}`);
+  }
+  return url;
+}
+
 async function getCachedReply(key, used = []) {
   try {
     const file = path.join(CACHE_DIR, `${key}.txt`);
@@ -386,13 +404,13 @@ export async function buildMessages(prompt, images, curators = []) {
     let buffer;
     try {
       buffer = await getSurrogateImage(abs);
-    } catch {
+    } catch (err) {
+      if (/empty surrogate/i.test(String(err?.message || ""))) throw err;
       continue;
     }
+    const dataUrl = buildImageDataUrl({ buffer, file });
     used.push(file);
-    const base64 = buffer.toString("base64");
     const name = path.basename(file);
-    const ext = path.extname(file).slice(1) || "jpeg";
     const peopleRaw = await getPeople(name);
     const people = sanitizePeople(peopleRaw);
     const dropped = peopleRaw.filter((p) => isPlaceholder(p));
@@ -409,7 +427,7 @@ export async function buildMessages(prompt, images, curators = []) {
       {
         type: "image_url",
         image_url: {
-          url: `data:image/${ext};base64,${base64}`,
+          url: dataUrl,
           detail: "high",
         },
       }
@@ -441,13 +459,13 @@ export async function buildInput(prompt, images, curators = []) {
     let buffer;
     try {
       buffer = await getSurrogateImage(abs);
-    } catch {
+    } catch (err) {
+      if (/empty surrogate/i.test(String(err?.message || ""))) throw err;
       continue;
     }
+    const dataUrl = buildImageDataUrl({ buffer, file });
     used.push(file);
-    const base64 = buffer.toString("base64");
     const name = path.basename(file);
-    const ext = path.extname(file).slice(1) || "jpeg";
     const peopleRaw = await getPeople(name);
     const people = sanitizePeople(peopleRaw);
     const dropped = peopleRaw.filter((p) => isPlaceholder(p));
@@ -463,7 +481,7 @@ export async function buildInput(prompt, images, curators = []) {
       { type: "input_text", text: JSON.stringify(info) },
       {
         type: "input_image",
-        image_url: `data:image/${ext};base64,${base64}`,
+        image_url: dataUrl,
         detail: "high",
       }
     );
@@ -732,7 +750,7 @@ export async function chatCompletion({
       } else if (responseFormat !== null) {
         baseParams.response_format = responseFormat;
       }
-      const needsCompletionTokens = /^o\d/.test(model);
+      const needsCompletionTokens = /^o\d/.test(model) || /^gpt-5/i.test(model);
       if (needsCompletionTokens) {
         baseParams.max_completion_tokens = max_output_tokens;
       } else {

--- a/src/imagePreprocessor.js
+++ b/src/imagePreprocessor.js
@@ -9,6 +9,16 @@ function numEnv(name, fallback) {
 }
 
 const CACHE_DIR = path.join(process.cwd(), '.cache', 'images');
+const inflight = new Map();
+
+async function readValidCache(cachePath) {
+  try {
+    const buf = await fs.readFile(cachePath);
+    if (buf.length > 0) return buf;
+    await fs.rm(cachePath, { force: true });
+  } catch {}
+  return null;
+}
 
 export async function getSurrogateImage(file) {
   const info = await fs.stat(file);
@@ -23,15 +33,29 @@ export async function getSurrogateImage(file) {
     .update(String(quality))
     .digest('hex');
   const cachePath = path.join(CACHE_DIR, `${hash}.jpg`);
-  try {
-    return await fs.readFile(cachePath);
-  } catch {}
-  await fs.mkdir(CACHE_DIR, { recursive: true });
-  const buf = await sharp(file)
-    .rotate()
-    .resize({ width: maxEdge, height: maxEdge, fit: 'inside', withoutEnlargement: true })
-    .jpeg({ quality, mozjpeg: true, chromaSubsampling: '4:2:0' })
-    .toBuffer();
-  await fs.writeFile(cachePath, buf);
-  return buf;
+  const cached = await readValidCache(cachePath);
+  if (cached) return cached;
+
+  if (!inflight.has(cachePath)) {
+    inflight.set(
+      cachePath,
+      (async () => {
+        await fs.mkdir(CACHE_DIR, { recursive: true });
+        const buf = await sharp(file)
+          .rotate()
+          .resize({ width: maxEdge, height: maxEdge, fit: 'inside', withoutEnlargement: true })
+          .jpeg({ quality, mozjpeg: true, chromaSubsampling: '4:2:0' })
+          .toBuffer();
+        if (!buf?.length) {
+          throw new Error(`Generated empty surrogate for ${file}`);
+        }
+        const tempPath = `${cachePath}.${process.pid}.${Date.now()}.tmp`;
+        await fs.writeFile(tempPath, buf);
+        await fs.rename(tempPath, cachePath);
+        return buf;
+      })().finally(() => inflight.delete(cachePath))
+    );
+  }
+
+  return inflight.get(cachePath);
 }

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -413,10 +413,9 @@ export async function triageDirectory(options) {
         const getBar = (idx) =>
           multibar.create(4, 0, { prefix: `Batch ${idx}`, stage: "queued" });
         const log = (msg) => {
-          for (const line of String(msg).split(/\n/)) {
-            multibar.log(line + "\n");
-            if (process.env.NODE_ENV === "test") console.log(line);
-          }
+          const text = String(msg).endsWith("\n") ? String(msg) : `${String(msg)}\n`;
+          multibar.log(text);
+          if (process.env.NODE_ENV === "test") console.log(text.trimEnd());
         };
         let batchIdx = 0;
         let abortProcessing = false;

--- a/src/providers/openai-batch.js
+++ b/src/providers/openai-batch.js
@@ -110,6 +110,17 @@ function extractStructured(payload) {
   return { text: JSON.stringify(payload), json: null };
 }
 
+function inferMissingScope(err) {
+  const msg = String(
+    err?.error?.message ||
+    err?.message ||
+    err?.response?.data?.error?.message ||
+    ''
+  );
+  const match = msg.match(/api\.[a-z]+\.[a-z]+/i);
+  return match ? match[0] : null;
+}
+
 async function streamToText(resp) {
   if (typeof resp.text === 'function') {
     return resp.text();
@@ -322,15 +333,55 @@ export default class OpenAIBatchProvider {
       });
       if (job.status === 'completed') {
         if (!job.output_file_id) {
-          console.error(
-            `⚠️  Batch ${handle.batchId} completed without output — running diagnostics…`
-          );
+          let rootCause;
+          if (job.error_file_id) {
+            try {
+              const errResp = await this.client.files.content(job.error_file_id);
+              const errText = await streamToText(errResp);
+              const firstError = errText
+                .split(/\r?\n/)
+                .filter(Boolean)
+                .map((line) => {
+                  try {
+                    return JSON.parse(line);
+                  } catch {
+                    return null;
+                  }
+                })
+                .find((row) => row?.error || row?.response?.body);
+              if (firstError?.error?.message) {
+                rootCause = firstError.error.message;
+              } else {
+                const body = typeof firstError?.response?.body === 'string'
+                  ? JSON.parse(firstError.response.body)
+                  : firstError?.response?.body;
+                if (body?.error?.message) {
+                  rootCause = body.error.message;
+                }
+              }
+            } catch (err) {
+              const scope = inferMissingScope(err);
+              if (scope) {
+                console.error(`⚠️  Missing scope ${scope} while reading batch error file ${job.error_file_id}.`);
+              }
+            }
+          }
+          console.error(`⚠️  Batch ${handle.batchId} completed without output${rootCause ? `: ${rootCause}` : ''}`);
           try {
             await debugBatch(handle.batchId);
           } catch (diagErr) {
-            console.error('❌ debugBatch helper failed:', diagErr);
+            const scope = inferMissingScope(diagErr);
+            if (scope) {
+              console.error(`⚠️  Missing scope ${scope}; skipping extended batch diagnostics.`);
+            } else {
+              console.error('❌ debugBatch helper failed:', diagErr?.message || diagErr);
+            }
           }
-          throw new Error(`Batch ${handle.batchId} completed without output`);
+          throw new Error(
+            rootCause
+              ? `Batch ${handle.batchId} completed without output: ${rootCause}`
+              : `Batch ${handle.batchId} completed without output`
+          );
         }
         const resp = await this.client.files.content(job.output_file_id);
         const text = await streamToText(resp);
@@ -430,7 +481,7 @@ export default class OpenAIBatchProvider {
       minutesMax,
       images: used.map((file) => path.basename(file)),
     });
-    const max_tokens = computeMaxOutputTokens({
+    const max_completion_tokens = computeMaxOutputTokens({
       decisionsCount: used.length,
       minutesCount: minutesMax,
       effort: 'low',
@@ -446,7 +497,7 @@ export default class OpenAIBatchProvider {
           strict: true,
         },
       },
-      max_tokens,
+      max_completion_tokens,
       temperature: 0.7,
     };
     if (verbosity) {


### PR DESCRIPTION
### Motivation
- Prevent malformed/empty base64 image payloads reaching the provider by hardening surrogate cache and request construction. 
- Avoid concurrent surrogate races and duplicate work under parallel batch workers. 
- Make batch diagnostics and fallback behavior resilient to missing API scopes and prevent noisy cascading failures.

### Description
- Hardened surrogate cache in `src/imagePreprocessor.js`: cache reads now validate and evict zero-byte files, writes are atomic (temp file + `rename`), and an in-memory `inflight` map prevents duplicate concurrent generation of the same surrogate. 
- Added strict image validation in `src/chatClient.js`: introduced `buildImageDataUrl()` that throws on empty buffers / empty base64 / malformed data URLs and uses the surrogate MIME (`image/jpeg`) for surrogate-backed requests; code skips unsupported source-image decode failures but fails loudly on empty surrogate generation. 
- Normalised GPT‑5/chat‑completions token params: chat-completions paths now use `max_completion_tokens` for GPT‑5 models (also updated fallback builder in `src/providers/openai-batch.js`) to avoid `max_tokens` rejections. 
- Improved batch collection & diagnostics in `src/providers/openai-batch.js` and `scripts/debug-batch.mjs`: when a batch is `completed` without `output_file_id`, `collect()` inspects `error_file_id` first and surfaces item-level root cause; `debug-batch` and `collect()` now detect likely missing `api.*` scopes and emit concise messages instead of cascading failures. 
- Reduced log interleaving in `src/orchestrator.js` by making multibar log writes atomic per message block and routing verbose/diagnostic responses to error stream only when verbose/debug is enabled. 

Files changed: `src/imagePreprocessor.js`, `src/chatClient.js`, `src/providers/openai-batch.js`, `scripts/debug-batch.mjs`, `src/orchestrator.js`.

### Testing
- Ran targeted suites: `npx vitest run tests/chatClient.test.js tests/openaiBatchProvider.test.js` and those passed (transport- and image-related tests OK). 
- Ran full test run via `npm test`; outcome: most suites passed, with a pre-existing snapshot mismatch remaining in `tests/integration/prompt-curators.int.test.js` (unrelated prompt header whitespace/order change), so overall transport/batch-focused suites succeeded while one snapshot needs update. 
- Manual smoke checks: ensured `getSurrogateImage()` returns non-empty buffers, surrogate files are written atomically, and `chatClient` will throw/skip on empty surrogate buffers (prevents empty `data:image/...;base64,` payloads).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9fc9d07083309725c899b443d756)