### PR TITLE
Fix shallowest-first cascade scheduling

### DIFF
--- a/src/archive/ensureArchiveLevel.js
+++ b/src/archive/ensureArchiveLevel.js
@@ -46,26 +46,15 @@ export async function ensureArchiveLevel({
 
   const manifest = new Manifest(levelDir);
   const tracker = new StageTracker(levelDir);
-  const sentinelExists = update && !forceRebuild ? await tracker.hasOk() : false;
-  if (sentinelExists) {
-    if (verbose) {
-      console.log(
-        `${path.basename(levelDir)} resume: cloned=${tracker.counters.cloned} copied=${tracker.counters.copied} skipped=${tracker.counters.skipped} failed=${tracker.counters.failed} remaining=0`
-      );
-    }
-    return {
-      created: 0,
-      refreshed: 0,
-      skipped: files.length,
-      errors: 0,
-    };
-  }
 
   if (forceRebuild) {
     await tracker.reset();
     manifest.clear();
     await manifest.removeFiles();
   } else {
+    // Even when .ok exists, load the append-only tracker/manifest before
+    // deciding what to skip.  A level archive can be complete for the files
+    // seen in an earlier pass while still needing to accept late arrivals.
     await manifest.load();
     await tracker.load();
   }

--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,11 @@ program
   )
   .option("--no-recurse", "Process a single directory only")
   .option(
+    "--retry-needs-review",
+    "Re-include files listed in NEEDS_REVIEW for an explicit retry",
+    parseEnvFlag(process.env.PHOTO_SELECT_RETRY_NEEDS_REVIEW, false)
+  )
+  .option(
     "-P, --parallel <n>",
     "Number of concurrent API calls (deprecated; use --workers)",
     (v) => Math.max(1, parseInt(v, 10))
@@ -131,6 +136,7 @@ let {
   ollamaBaseUrl,
   concurrency: concurrencyFlag,
   disablePhotoFilter,
+  retryNeedsReview,
 } = program.opts();
 
 if (program.getOptionValueSource && program.getOptionValueSource('parallel')) {
@@ -256,6 +262,7 @@ process.env.PHOTO_SELECT_USER_EFFORT = finalReasoningEffort;
       workers,
       verbosity,
       reasoningEffort: finalReasoningEffort,
+      retryNeedsReview,
     });
     console.log("🎉  Finished triaging.");
   } catch (err) {

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -195,6 +195,142 @@ async function readNeedsReviewNames(dir) {
     return new Set();
   }
 }
+
+async function writeNeedsReviewEntries(dir, entries) {
+  const marker = path.join(dir, "NEEDS_REVIEW");
+  const existing = new Map();
+  try {
+    const raw = await readFile(marker, "utf8");
+    for (const line of raw.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const [name, ...rest] = trimmed.split(/\s+/);
+      existing.set(name, rest.join(" "));
+    }
+  } catch {
+    /* no marker yet */
+  }
+  for (const { name, reason } of entries) {
+    existing.set(name, reason || "NEEDS_REVIEW");
+  }
+  const lines = [...existing.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, reason]) => `${name}	${reason}`);
+  await writeFile(marker, lines.length ? `${lines.join("\n")}\n` : "", "utf8");
+}
+
+async function clearNeedsReviewEntries(dir, files) {
+  if (!files.length) return;
+  const marker = path.join(dir, "NEEDS_REVIEW");
+  const clear = new Set(files.map((file) => path.basename(file)));
+  let raw;
+  try {
+    raw = await readFile(marker, "utf8");
+  } catch {
+    return;
+  }
+  const kept = raw
+    .split(/\r?\n/)
+    .filter((line) => {
+      const name = line.trim().split(/\s+/)[0];
+      return name && !clear.has(name);
+    });
+  await writeFile(marker, kept.length ? `${kept.join("\n")}\n` : "", "utf8");
+}
+
+export async function listLevelState(dir, { retryNeedsReview = envBool("PHOTO_SELECT_RETRY_NEEDS_REVIEW", false) } = {}) {
+  const allImages = await listImages(dir);
+  const needsReviewNames = await readNeedsReviewNames(dir);
+  const eligibleImages = [];
+  const needsReviewImages = [];
+
+  for (const file of allImages) {
+    if (needsReviewNames.has(path.basename(file))) {
+      needsReviewImages.push(file);
+      if (retryNeedsReview) eligibleImages.push(file);
+    } else {
+      eligibleImages.push(file);
+    }
+  }
+
+  return {
+    allImages,
+    eligibleImages,
+    needsReviewImages,
+    ignoredImagesOrFiles: [],
+    needsReviewNames,
+  };
+}
+
+export async function findShallowestLevelWithEligibleImages(rootDir, options = {}) {
+  const allowDescendWithNeedsReview = options.allowDescendWithNeedsReview ?? envBool("PHOTO_SELECT_ALLOW_DESCEND_WITH_NEEDS_REVIEW", false);
+  let current = rootDir;
+  let depth = 0;
+
+  while (await dirExists(current)) {
+    const state = await listLevelState(current, options);
+    const level = depth + 1;
+    if (state.eligibleImages.length > 0) {
+      console.log(`${"  ".repeat(depth)}📊  level ${level}: ${state.eligibleImages.length} eligible image(s), ${state.needsReviewImages.length} NEEDS_REVIEW held`);
+      return { dir: current, depth, level, state };
+    }
+    if (state.needsReviewImages.length > 0) {
+      console.warn(`${"  ".repeat(depth)}⚠️  level ${level}: 0 eligible image(s), ${state.needsReviewImages.length} held for NEEDS_REVIEW in ${current}`);
+      if (!allowDescendWithNeedsReview) {
+        return { dir: current, depth, level, state, blocked: true, blockedCount: state.needsReviewImages.length };
+      }
+      console.log(`${"  ".repeat(depth)}↘️  no eligible work at level ${level}; checking _keep`);
+    }
+    const next = path.join(current, "_keep");
+    if (!(await dirExists(next))) return null;
+    current = next;
+    depth += 1;
+  }
+  return null;
+}
+
+export async function triageTree(options) {
+  const rootDir = options.dir;
+  let lastDepth = 0;
+
+  while (true) {
+    const work = await findShallowestLevelWithEligibleImages(rootDir, options);
+    if (!work) {
+      console.log("✅  No pending image files found in cascade.");
+      break;
+    }
+    if (work.blocked) {
+      console.warn(`⚠️  Cascade blocked at ${work.dir}: ${work.blockedCount} file(s) need review. Not descending.`);
+      break;
+    }
+    console.log(`${"  ".repeat(work.depth)}🧭  scheduler selected: level=${work.level} source=${work.dir} eligible=${work.state.eligibleImages.length}`);
+    if (work.depth < lastDepth) {
+      console.log(`${"  ".repeat(work.depth)}↩️  returning to shallower level before continuing deeper`);
+    }
+    const result = await triageDirectory({
+      ...options,
+      dir: work.dir,
+      depth: work.depth,
+      recurse: false,
+      _cascadeLevel: true,
+      gitRoot: options.gitRoot || rootDir,
+    });
+    if (result?.blocked) {
+      console.warn(`⚠️  Cascade blocked at ${work.dir}: ${result.blockedCount} file(s) need review. Not descending.`);
+      break;
+    }
+    const postState = await listLevelState(work.dir, options);
+    console.log(`${"  ".repeat(work.depth)}🔎  level drain check: level=${work.level} source=${work.dir} eligible=${postState.eligibleImages.length}`);
+    if (postState.eligibleImages.length > 0) {
+      console.log(`${"  ".repeat(work.depth)}🔁  level still has eligible files; repeating level=${work.level}`);
+    } else {
+      console.log(`${"  ".repeat(work.depth)}✅  level drained; checking shallowest source again`);
+    }
+    lastDepth = work.depth;
+    console.log("🔁  Re-scanning cascade from base before descending further…");
+  }
+}
+
 async function ensureGitRepo(dir) {
   try {
     await stat(path.join(dir, ".git"));
@@ -328,10 +464,21 @@ export async function triageDirectory(options) {
     update = true,
     forceRebuild = false,
     stageConcurrency,
+    retryNeedsReview = envBool("PHOTO_SELECT_RETRY_NEEDS_REVIEW", false),
+    allowDescendWithNeedsReview = envBool("PHOTO_SELECT_ALLOW_DESCEND_WITH_NEEDS_REVIEW", false),
+    _cascadeLevel = false,
   } = options;
   if (!provider) {
     const m = await import('./providers/openai.js');
     provider = new m.default();
+  }
+  if (recurse && depth === 0 && !_cascadeLevel) {
+    return triageTree({
+      ...options,
+      provider,
+      retryNeedsReview,
+      allowDescendWithNeedsReview,
+    });
   }
   const indent = "  ".repeat(depth);
   let notesWriter;
@@ -425,10 +572,7 @@ export async function triageDirectory(options) {
     });
     return provider.collect(handle);
   };
-  const initImages = await listImages(dir);
   const levelStart = Date.now();
-  const totalImages = initImages.length;
-  const totalBatches = Math.ceil(totalImages / BATCH_SIZE);
   await mkdir(levelDir, { recursive: true });
   if (saveIo) {
     await mkdir(path.join(levelDir, '_prompts'), { recursive: true });
@@ -436,21 +580,6 @@ export async function triageDirectory(options) {
   }
   if (!update && depth === 0) {
     console.warn("⚠️ archive update disabled — will re-clone all files");
-  }
-  const archiveResult = await ensureArchiveLevel({
-    levelDir,
-    files: initImages,
-    update,
-    forceRebuild,
-    stageConcurrency,
-    verbose,
-  });
-  if (archiveResult.failed?.length) {
-    const listPath = path.join(levelDir, "failed-archives.txt");
-    await writeFile(listPath, archiveResult.failed.join("\n"), "utf8");
-    console.warn(
-      `${indent}⚠️  ${archiveResult.failed.length} file(s) failed to archive; see ${listPath}`
-    );
   }
 
   if (fieldNotes) {
@@ -460,13 +589,37 @@ export async function triageDirectory(options) {
   }
 
   let completedBatches = 0;
+  const retrySuppressedNames = new Set();
 
   while (true) {
-    const needsReview = await readNeedsReviewNames(dir);
-    const images = (await listImages(dir)).filter((file) => !needsReview.has(path.basename(file)));
+    const state = await listLevelState(dir, { retryNeedsReview });
+    const images = state.eligibleImages.filter(
+      (file) => !retrySuppressedNames.has(path.basename(file))
+    );
+    console.log(`${indent}📊  level ${depth + 1}: ${state.allImages.length} source image(s): ${images.length} eligible, ${state.needsReviewImages.length} NEEDS_REVIEW`);
     if (images.length === 0) {
-      console.log(`${indent}✅  Nothing to do in ${dir}`);
+      if (state.needsReviewImages.length > 0) {
+        console.warn(`${indent}⚠️  Level blocked: ${dir} has ${state.needsReviewImages.length} image file(s) needing review. Not descending.`);
+        return { blocked: true, blockedCount: state.needsReviewImages.length };
+      }
+      console.log(`${indent}✅  Level settled: ${dir} has 0 active image files.`);
       break;
+    }
+
+    const archiveResult = await ensureArchiveLevel({
+      levelDir,
+      files: images,
+      update,
+      forceRebuild,
+      stageConcurrency,
+      verbose,
+    });
+    if (archiveResult.failed?.length) {
+      const listPath = path.join(levelDir, "failed-archives.txt");
+      await writeFile(listPath, archiveResult.failed.join("\n"), "utf8");
+      console.warn(
+        `${indent}⚠️  ${archiveResult.failed.length} file(s) failed to archive; see ${listPath}`
+      );
     }
 
     console.log(`${indent}📊  ${images.length} unclassified image(s) found`);
@@ -532,13 +685,12 @@ export async function triageDirectory(options) {
                 };
 
                 const markNeedsReview = async (reason) => {
-                  const marker = path.join(dir, "NEEDS_REVIEW");
-                  const lines = batch
-                    .map((f) => `${path.basename(f)}	${reason}`)
-                    .join("\n");
                   try {
-                    const prev = await readFile(marker, "utf8").catch(() => "");
-                    await writeFile(marker, `${prev}${lines}\n`, "utf8");
+                    await writeNeedsReviewEntries(
+                      dir,
+                      batch.map((f) => ({ name: path.basename(f), reason }))
+                    );
+                    for (const file of batch) retrySuppressedNames.add(path.basename(file));
                   } catch {
                     /* ignore */
                   }
@@ -719,6 +871,7 @@ export async function triageDirectory(options) {
                   moveFiles(keep, keepDir, notes),
                   moveFiles(aside, asideDir, notes),
                 ]);
+                await clearNeedsReviewEntries(dir, [...keep, ...aside]);
                   if (unclassified.length && keep.length + aside.length > 0) {
                     queue.push(...unclassified);
                   }
@@ -729,9 +882,10 @@ export async function triageDirectory(options) {
                 if (keep.length + aside.length > 0) {
                   completedBatches++;
                   const elapsedSec = (Date.now() - levelStart) / 1000;
-                  const remaining = totalBatches - completedBatches;
+                  const remainingNow = (await listLevelState(dir, { retryNeedsReview })).eligibleImages.length;
+                  const remainingBatchesNow = Math.ceil(remainingNow / BATCH_SIZE);
                   const tps = completedBatches / elapsedSec;
-                  const etaSec = tps > 0 ? Math.ceil(remaining / tps) : Infinity;
+                  const etaSec = tps > 0 ? Math.ceil(remainingBatchesNow / tps) : Infinity;
                   log(
                     `${indent}⏳  ETA to finish level: ${formatDuration(etaSec * 1000)}`
                   );
@@ -754,11 +908,12 @@ export async function triageDirectory(options) {
                 ]);
                 if (safeFailureCodes.has(err?.code)) {
                   const reason = failureReason(err);
-                  const marker = path.join(dir, "NEEDS_REVIEW");
-                  const lines = batch.map((f) => `${path.basename(f)}	${reason}`).join("\n");
                   try {
-                    const prev = await readFile(marker, "utf8").catch(() => "");
-                    await writeFile(marker, `${prev}${lines}\n`, "utf8");
+                    await writeNeedsReviewEntries(
+                      dir,
+                      batch.map((f) => ({ name: path.basename(f), reason }))
+                    );
+                    for (const file of batch) retrySuppressedNames.add(path.basename(file));
                   } catch {
                     /* ignore */
                   }
@@ -784,9 +939,13 @@ export async function triageDirectory(options) {
       } finally {
         multibar.stop();
       }
-      const nextNeedsReview = await readNeedsReviewNames(dir);
-      const remaining = (await listImages(dir)).filter((file) => !nextNeedsReview.has(path.basename(file))).length;
+      const nextState = await listLevelState(dir, { retryNeedsReview });
+      const remaining = nextState.eligibleImages.filter(
+        (file) => !retrySuppressedNames.has(path.basename(file))
+      ).length;
       const remainingBatches = Math.ceil(remaining / BATCH_SIZE);
+      console.log(`${indent}🔎  level drain check: level=${depth + 1} source=${dir} eligible=${remaining}`);
+      if (remaining > 0) console.log(`${indent}🔁  level still has eligible files; repeating level=${depth + 1}`);
       if (completedBatches) {
         const elapsedSec = (Date.now() - levelStart) / 1000;
         const tps = completedBatches / elapsedSec;
@@ -844,4 +1003,5 @@ export async function triageDirectory(options) {
       console.log(`${indent}🎯  All images ${status} at this level; stopping recursion.`);
     }
   }
+  return { blocked: false, blockedCount: 0 };
 }

--- a/tests/archive/staging.integration.test.js
+++ b/tests/archive/staging.integration.test.js
@@ -67,4 +67,30 @@ describe("ensureArchiveLevel integration", () => {
     );
     expect(runData.cloned).toBeGreaterThanOrEqual(files.length);
   });
+
+  it("appends late files after .ok exists", async () => {
+    const first = await ensureArchiveLevel({
+      levelDir,
+      files,
+      update: true,
+      verbose: false,
+    });
+    expect(first.created).toBe(files.length);
+    await expect(fs.stat(path.join(levelDir, ".ok"))).resolves.toBeTruthy();
+
+    const late = path.join(tmpDir, "new.jpg");
+    await fs.writeFile(late, "new");
+    const second = await ensureArchiveLevel({
+      levelDir,
+      files: [late],
+      update: true,
+      verbose: false,
+    });
+
+    expect(second.created).toBe(1);
+    await expect(fs.stat(path.join(levelDir, "new.jpg"))).resolves.toBeTruthy();
+    const stagedLog = await fs.readFile(path.join(levelDir, ".staged.jsonl"), "utf8");
+    expect(stagedLog).toContain("new.jpg");
+  });
+
 });

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -318,3 +318,128 @@ describe("triageDirectory", () => {
   });
 
 });
+
+describe("cascade scheduler invariants", () => {
+  it("processes the shallowest eligible level before nested _keep work", async () => {
+    await fs.mkdir(path.join(tmpDir, "_keep"), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "_keep", "deep.jpg"), "deep");
+    const seen = [];
+    chatCompletion.mockImplementation(async ({ images }) => {
+      const names = images.map((f) => path.basename(f)).sort();
+      seen.push(names);
+      if (names.includes("1.jpg")) {
+        return JSON.stringify({ keep: [], aside: ["1.jpg", "2.jpg"] });
+      }
+      return JSON.stringify({ keep: [], aside: ["deep.jpg"] });
+    });
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: true,
+    });
+
+    expect(seen[0]).toEqual(["1.jpg", "2.jpg"]);
+    expect(seen[1]).toEqual(["deep.jpg"]);
+  });
+
+  it("returns to base for late-arriving files after a deeper level settles", async () => {
+    await fs.rm(path.join(tmpDir, "1.jpg"));
+    await fs.rm(path.join(tmpDir, "2.jpg"));
+    const keepDir = path.join(tmpDir, "_keep");
+    await fs.mkdir(keepDir, { recursive: true });
+    await fs.writeFile(path.join(keepDir, "deep.jpg"), "deep");
+    const seen = [];
+    chatCompletion.mockImplementation(async ({ images }) => {
+      const names = images.map((f) => path.basename(f)).sort();
+      seen.push(names);
+      if (names.includes("deep.jpg")) {
+        await fs.writeFile(path.join(tmpDir, "late.jpg"), "late");
+        return JSON.stringify({ keep: [], aside: ["deep.jpg"] });
+      }
+      return JSON.stringify({ keep: [], aside: ["late.jpg"] });
+    });
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: true,
+    });
+
+    expect(seen).toEqual([["deep.jpg"], ["late.jpg"]]);
+    await expect(fs.stat(path.join(tmpDir, "_aside", "late.jpg"))).resolves.toBeTruthy();
+  });
+
+  it("does not descend while current-level residue remains eligible", async () => {
+    await fs.mkdir(path.join(tmpDir, "_keep"), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "_keep", "deep.jpg"), "deep");
+    const seen = [];
+    chatCompletion
+      .mockImplementationOnce(async ({ images }) => {
+        seen.push(images.map((f) => path.basename(f)).sort());
+        return JSON.stringify({ keep: [], aside: ["1.jpg"] });
+      })
+      .mockImplementationOnce(async ({ images }) => {
+        seen.push(images.map((f) => path.basename(f)).sort());
+        return JSON.stringify({ keep: [], aside: ["2.jpg"] });
+      })
+      .mockImplementationOnce(async ({ images }) => {
+        seen.push(images.map((f) => path.basename(f)).sort());
+        return JSON.stringify({ keep: [], aside: ["deep.jpg"] });
+      })
+      .mockImplementation(async ({ images }) => {
+        seen.push(images.map((f) => path.basename(f)).sort());
+        return JSON.stringify({ keep: [], aside: images.map((f) => path.basename(f)) });
+      });
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: true,
+    });
+
+    expect(seen[0]).toEqual(["1.jpg", "2.jpg"]);
+    expect(seen[1]).toEqual(["2.jpg"]);
+    expect(seen[2]).toEqual(["deep.jpg"]);
+  });
+
+  it("reports NEEDS_REVIEW images and blocks descent by default", async () => {
+    await fs.mkdir(path.join(tmpDir, "_keep"), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "_keep", "deep.jpg"), "deep");
+    await fs.writeFile(path.join(tmpDir, "NEEDS_REVIEW"), "1.jpg\tfailed\n2.jpg\tfailed\n");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: true,
+    });
+
+    expect(chatCompletion).not.toHaveBeenCalled();
+    expect(warnSpy.mock.calls.some(([msg]) => msg.includes("Cascade blocked"))).toBe(true);
+    await expect(fs.stat(path.join(tmpDir, "_keep", "deep.jpg"))).resolves.toBeTruthy();
+  });
+
+  it("retry-needs-review re-includes held files and clears successful markers", async () => {
+    await fs.writeFile(path.join(tmpDir, "NEEDS_REVIEW"), "1.jpg\tfailed\n2.jpg\tfailed\n");
+    chatCompletion.mockResolvedValueOnce(
+      JSON.stringify({ keep: ["1.jpg"], aside: ["2.jpg"] })
+    );
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: false,
+      retryNeedsReview: true,
+    });
+
+    await expect(fs.stat(path.join(tmpDir, "_keep", "1.jpg"))).resolves.toBeTruthy();
+    const marker = await fs.readFile(path.join(tmpDir, "NEEDS_REVIEW"), "utf8");
+    expect(marker.trim()).toBe("");
+  });
+});


### PR DESCRIPTION
### Motivation
- The orchestrator was descending depth-first into nested `_keep` folders even when shallower source directories still had eligible image files, causing Finder to show stranded images while the CLI reported “Nothing to do”.
- We need a robust scheduler that always processes the shallowest non-empty source directory first, re-scans the live source directories after each settled level, and treats `_level-00N` archives as append-only audit stores rather than authoritative work queues.

### Description
- Added a shallowest-first cascade coordinator (`triageTree`, `findShallowestLevelWithEligibleImages`, `listLevelState`) that scans down the `_keep` chain and selects the first level with live eligible images, processes that level to settlement, then restarts the scan from the root before going deeper (changes in `src/orchestrator.js`).
- Reworked per-level processing so each pass stages the current live eligible files into the level archive via `ensureArchiveLevel` before model work, re-scans the same source directory after each worker pool, and repeats until the directory is settled; the function now returns explicit `blocked` status for NEEDS_REVIEW blocks (changes in `src/orchestrator.js`).
- Made archives append-friendly by loading manifest/tracker even when `.ok` exists and only skipping files already tracked with matching fingerprints, allowing late arrivals to be staged into the same `_level-00N` folder (changes in `src/archive/ensureArchiveLevel.js`).
- Introduced explicit NEEDS_REVIEW helpers: `writeNeedsReviewEntries` and `clearNeedsReviewEntries`, added `--retry-needs-review` CLI flag and `PHOTO_SELECT_RETRY_NEEDS_REVIEW` env support to re-include held files intentionally, and added logic to suppress repeated retry attempts for the same failing batch to avoid infinite cost loops (changes in `src/orchestrator.js` and `src/index.js`).
- Improved logging to report per-level drain checks, scheduler selections, NEEDS_REVIEW-held counts, and when the scheduler returns to shallower levels (changes in `src/orchestrator.js`).
- Tests added / extended to cover scheduler invariants and archive append behavior (changes in `tests/orchestrator.test.js` and `tests/archive/staging.integration.test.js`).

### Testing
- Ran targeted tests: `npm test -- --run tests/orchestrator.test.js tests/archive/staging.integration.test.js` which succeeded (all tests in those files passed).
- Performed basic static checks: `node --check src/orchestrator.js` and `node --check src/index.js` which reported no syntax errors.
- Notes on broader suite: while developing this change the full test suite produced an unrelated snapshot mismatch in an integration prompt test earlier in the run; the scheduler/archiving changes and the focused tests above are green and the snapshot mismatch did not originate from these orchestration changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd1daeeb1883308116f3de915be85e)