### PR TITLE
only repair caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "photo-select",
     "test": "vitest run",
+    "evals:prompt-cache": "node scripts/eval-prompt-cache.mjs",
     "undici:smoke": "node scripts/undici-smoke.mjs",
     "debug:batch": "node scripts/debug-batch.mjs"
   },

--- a/scripts/eval-prompt-cache.mjs
+++ b/scripts/eval-prompt-cache.mjs
@@ -1,0 +1,85 @@
+import OpenAI from 'openai';
+import dotenv from 'dotenv';
+import { buildCacheableResponsesPrompt } from '../src/core/promptCaching.js';
+
+if (process.env.PHOTO_SELECT_ENV_FILE) {
+  dotenv.config({ path: process.env.PHOTO_SELECT_ENV_FILE });
+} else {
+  dotenv.config();
+}
+
+const apiKey = process.env.OPENAI_API_KEY;
+if (!apiKey) {
+  throw new Error(
+    'OPENAI_API_KEY is required (or set PHOTO_SELECT_ENV_FILE to an env file)'
+  );
+}
+
+const model = process.env.PHOTO_SELECT_CACHE_EVAL_MODEL || 'gpt-5.6-terra';
+const stablePrefix = [
+  'Photo-select explicit prompt-cache evaluation, version 1. ',
+  'This synthetic context contains no image or archive data. ',
+  'Preserve it exactly as the stable developer prefix. ',
+]
+  .join('')
+  .repeat(200);
+
+function request(dynamicSuffix) {
+  const promptFields = buildCacheableResponsesPrompt({
+    model,
+    instructions: stablePrefix + dynamicSuffix,
+    promptCachePrefix: stablePrefix,
+    input: [
+      {
+        role: 'user',
+        content: [{ type: 'input_text', text: 'Reply with the word OK.' }],
+      },
+    ],
+  });
+  return {
+    model,
+    ...promptFields,
+    reasoning: { effort: 'xhigh' },
+    text: { verbosity: 'low' },
+    max_output_tokens: 32,
+    store: false,
+  };
+}
+
+function usageSummary(response) {
+  const usage = response?.usage || {};
+  const details = usage.input_tokens_details || {};
+  return {
+    input_tokens: usage.input_tokens || 0,
+    cached_tokens: details.cached_tokens || 0,
+    cache_write_tokens: details.cache_write_tokens || 0,
+    output_tokens: usage.output_tokens || 0,
+  };
+}
+
+const client = new OpenAI({ apiKey });
+const first = usageSummary(
+  await client.responses.create(request(' First evaluation request.'))
+);
+const second = usageSummary(
+  await client.responses.create(request(' Second evaluation request.'))
+);
+const passed =
+  second.cached_tokens > 0 &&
+  second.cache_write_tokens === 0;
+
+console.log(
+  JSON.stringify(
+    {
+      eval: 'explicit_prompt_cache_read_after_write',
+      model,
+      passed,
+      first,
+      second,
+    },
+    null,
+    2
+  )
+);
+
+if (!passed) process.exitCode = 1;

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -18,6 +18,7 @@ import { enforceEffortGuard } from "./effortGuard.js";
 import { getSurrogateImage } from "./imagePreprocessor.js";
 import { drain } from "./net.js";
 import { SimpleSemaphore } from "./lib/semaphore.js";
+import { buildCacheableResponsesPrompt } from "./core/promptCaching.js";
 
 function numEnv(name, fallback) {
   const v = process.env[name];
@@ -513,6 +514,7 @@ export async function buildInput(prompt, images, curators = []) {
  */
 export async function chatCompletion({
   prompt,
+  promptCachePrefix,
   images,
   model = "gpt-4o",
   verbosity = "low",
@@ -645,10 +647,15 @@ export async function chatCompletion({
           for (const warning of budget.warnings) console.warn(`⚠️ ${warning}`);
         }
         onProgress("request");
-        const baseOpts = {
+        const promptFields = buildCacheableResponsesPrompt({
           model,
           instructions,
           input,
+          promptCachePrefix,
+        });
+        const baseOpts = {
+          model,
+          ...promptFields,
           text: {
             verbosity,
             format: {
@@ -886,10 +893,15 @@ export async function chatCompletion({
           for (const warning of budget.warnings) console.warn(`⚠️ ${warning}`);
         }
         onProgress("request");
-        const baseOpts = {
+        const promptFields = buildCacheableResponsesPrompt({
           model,
           instructions,
           input,
+          promptCachePrefix,
+        });
+        const baseOpts = {
+          model,
+          ...promptFields,
           text: {
             verbosity,
             format: {

--- a/src/core/promptCaching.js
+++ b/src/core/promptCaching.js
@@ -1,0 +1,71 @@
+import crypto from 'node:crypto';
+
+const CACHE_KEY_VERSION = 'v1';
+const MIN_CACHE_PREFIX_CHARS = 4096;
+
+function isGpt56OrLater(model = '') {
+  const match = String(model).match(/^gpt-(\d+)\.(\d+)(?:$|[-.])/i);
+  if (!match) return false;
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  return major > 5 || (major === 5 && minor >= 6);
+}
+
+function cacheKey(model, promptCachePrefix) {
+  const digest = crypto
+    .createHash('sha256')
+    .update(CACHE_KEY_VERSION)
+    .update('\0')
+    .update(String(model))
+    .update('\0')
+    .update(promptCachePrefix)
+    .digest('hex')
+    .slice(0, 32);
+  return `photo-select:${CACHE_KEY_VERSION}:${digest}`;
+}
+
+/**
+ * Preserve legacy Responses request fields unless a GPT-5.6+ request carries a
+ * verified, sufficiently large stable prefix. For eligible requests, render the
+ * same developer instructions as two adjacent content blocks and mark only the
+ * stable block for explicit caching.
+ */
+export function buildCacheableResponsesPrompt({
+  model,
+  instructions,
+  input,
+  promptCachePrefix,
+}) {
+  const legacy = { instructions, input };
+  if (
+    !isGpt56OrLater(model) ||
+    typeof promptCachePrefix !== 'string' ||
+    promptCachePrefix.length < MIN_CACHE_PREFIX_CHARS ||
+    !String(instructions).startsWith(promptCachePrefix)
+  ) {
+    return legacy;
+  }
+
+  const dynamicSuffix = String(instructions).slice(promptCachePrefix.length);
+  const developerContent = [
+    {
+      type: 'input_text',
+      text: promptCachePrefix,
+      prompt_cache_breakpoint: { mode: 'explicit' },
+    },
+  ];
+  if (dynamicSuffix) {
+    developerContent.push({ type: 'input_text', text: dynamicSuffix });
+  }
+
+  return {
+    input: [
+      { role: 'developer', content: developerContent },
+      ...(Array.isArray(input) ? input : []),
+    ],
+    prompt_cache_key: cacheKey(model, promptCachePrefix),
+    prompt_cache_options: { mode: 'explicit', ttl: '30m' },
+  };
+}
+
+export default buildCacheableResponsesPrompt;

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -722,6 +722,7 @@ export async function triageDirectory(options) {
                 await saveText('prompt', attemptNum, first.prompt);
                 const firstResult = await runSession({
                   prompt: first.prompt,
+                  promptCachePrefix: first.promptCachePrefix,
                   images: batch,
                   model,
                   curators: finalCurators,

--- a/src/providers/openai-batch.js
+++ b/src/providers/openai-batch.js
@@ -8,6 +8,7 @@ import { buildReplySchema } from '../replySchema.js';
 import { computeMaxOutputTokens, computeOutputBudget, estimateInputTokens } from '../tokenEstimate.js';
 import { delay } from '../config.js';
 import { debugBatch } from '../../scripts/debug-batch.mjs';
+import { buildCacheableResponsesPrompt } from '../core/promptCaching.js';
 
 const DEFAULT_COMPLETION_WINDOW = process.env.PHOTO_SELECT_BATCH_COMPLETION_WINDOW || '24h';
 const DEFAULT_POLL_MS = Number(process.env.PHOTO_SELECT_BATCH_CHECK_INTERVAL_MS || 60000);
@@ -269,6 +270,7 @@ export default class OpenAIBatchProvider {
     const {
       levelDir,
       prompt,
+      promptCachePrefix,
       images = [],
       curators = [],
       baseCuratorCount = curators.length,
@@ -286,6 +288,7 @@ export default class OpenAIBatchProvider {
     const dirs = await ensureDirs(levelDir);
     const responsesRequest = await this.#buildResponsesRequest({
       prompt,
+      promptCachePrefix,
       images,
       curators,
       model,
@@ -540,7 +543,7 @@ export default class OpenAIBatchProvider {
     }
   }
 
-  async #buildResponsesRequest({ prompt, images, curators, model, minutesMin, minutesMax, reasoningEffort, verbosity, baseCuratorCount = curators.length, dynamicCuratorCount }) {
+  async #buildResponsesRequest({ prompt, promptCachePrefix, images, curators, model, minutesMin, minutesMax, reasoningEffort, verbosity, baseCuratorCount = curators.length, dynamicCuratorCount }) {
     const { instructions, input, used } = await this.helpers.buildInput(
       prompt,
       images,
@@ -580,10 +583,15 @@ export default class OpenAIBatchProvider {
       );
       for (const warning of budget.warnings) console.warn(`⚠️ ${warning}`);
     }
-    const body = {
+    const promptFields = buildCacheableResponsesPrompt({
       model,
       instructions,
       input,
+      promptCachePrefix,
+    });
+    const body = {
+      model,
+      ...promptFields,
       text: {
         verbosity,
         format: {

--- a/src/templates.js
+++ b/src/templates.js
@@ -5,6 +5,8 @@ import Handlebars from 'handlebars';
 
 const fmin = Number(process.env.PHOTO_SELECT_MINUTES_FACTOR_MIN || 1.5);
 const fmax = Number(process.env.PHOTO_SELECT_MINUTES_FACTOR_MAX || 2.5);
+const CACHE_BREAKPOINT_SENTINEL =
+  '\uE000PHOTO_SELECT_CACHE_BREAKPOINT\uE001';
 
 export const DEFAULT_PROMPT_PATH = path.resolve(
   fileURLToPath(new URL('../prompts/default_prompt.hbs', import.meta.url))
@@ -37,11 +39,15 @@ export async function buildPrompt(
   const base = Math.max(curators.length || 1, images.length || 1);
   const minutesMin = Math.ceil(fmin * base);
   const minutesMax = Math.ceil(fmax * base);
+  const markCacheBoundary =
+    Boolean(context) && !context.includes(CACHE_BREAKPOINT_SENTINEL);
 
-  const prompt = await renderTemplate(filePath, {
+  const renderedPrompt = await renderTemplate(filePath, {
     curators: curators.join(', '),
     images: images.map((f) => path.basename(f)),
-    context,
+    context: markCacheBoundary
+      ? `${context}${CACHE_BREAKPOINT_SENTINEL}`
+      : context,
     fieldNotes,
     fieldNotesPrev,
     fieldNotesPrev2,
@@ -52,6 +58,14 @@ export async function buildPrompt(
     minutesMax,
   });
 
-  return { prompt, minutesMin, minutesMax };
-}
+  const markerIndex = markCacheBoundary
+    ? renderedPrompt.indexOf(CACHE_BREAKPOINT_SENTINEL)
+    : -1;
+  const prompt = markCacheBoundary
+    ? renderedPrompt.replaceAll(CACHE_BREAKPOINT_SENTINEL, '')
+    : renderedPrompt;
+  const promptCachePrefix =
+    markerIndex >= 0 ? prompt.slice(0, markerIndex) : undefined;
 
+  return { prompt, promptCachePrefix, minutesMin, minutesMax };
+}

--- a/tests/chatClient.test.js
+++ b/tests/chatClient.test.js
@@ -425,6 +425,35 @@ describe("chatCompletion", () => {
     expect(result).toBe("ok");
   });
 
+  it("serializes the explicit cache boundary for synchronous GPT-5.6 requests", async () => {
+    responsesSpy.mockClear();
+    responsesSpy.mockResolvedValueOnce({ output_text: "ok" });
+    const stablePrefix = "Stable curatorial context. ".repeat(300);
+    const prompt = `${stablePrefix}Review this batch.`;
+
+    await chatCompletion({
+      prompt,
+      promptCachePrefix: stablePrefix,
+      images: [],
+      model: "gpt-5.6-terra",
+      cache: false,
+    });
+
+    const args = responsesSpy.mock.calls[0][0];
+    expect(args.instructions).toBeUndefined();
+    expect(args.prompt_cache_options).toEqual({ mode: "explicit", ttl: "30m" });
+    expect(args.input[0].role).toBe("developer");
+    const serializedInstructions = args.input[0].content
+      .map((part) => part.text)
+      .join("");
+    expect(serializedInstructions).toBe(
+      `${prompt}\nRespond in json format.\nOnly include these filenames; do not invent new ones.`
+    );
+    expect(args.input[0].content[0].prompt_cache_breakpoint).toEqual({
+      mode: "explicit",
+    });
+  });
+
   it("extracts JSON from output_json when output_text is empty", async () => {
     responsesSpy.mockClear();
     const payload = {

--- a/tests/openaiBatchProvider.test.js
+++ b/tests/openaiBatchProvider.test.js
@@ -299,6 +299,47 @@ describe('OpenAIBatchProvider', () => {
     expect(ticket.output_budget.dynamic_curator_count).toBe(10);
   });
 
+  it('serializes an explicit stable-prefix cache plan for GPT-5.6', async () => {
+    const stablePrefix = 'Stable curatorial context. '.repeat(300);
+    const dynamicSuffix = 'Review only a.jpg.';
+    const imagePath = path.join(tmpDir, 'a.jpg');
+    await fs.writeFile(imagePath, 'data');
+    const provider = new OpenAIBatchProvider({
+      client,
+      enableFallback: false,
+      helpers,
+    });
+
+    await provider.submit({
+      levelDir: tmpDir,
+      prompt: stablePrefix + dynamicSuffix,
+      promptCachePrefix: stablePrefix,
+      images: [imagePath],
+      model: 'gpt-5.6-terra',
+      reasoningEffort: 'xhigh',
+    });
+
+    const inputsDir = path.join(tmpDir, '.batch', 'inputs');
+    const [inputFile] = await fs.readdir(inputsDir);
+    const line = JSON.parse(
+      await fs.readFile(path.join(inputsDir, inputFile), 'utf8')
+    );
+    expect(line.body.instructions).toBeUndefined();
+    expect(line.body.prompt_cache_options).toEqual({
+      mode: 'explicit',
+      ttl: '30m',
+    });
+    expect(line.body.prompt_cache_key).toMatch(
+      /^photo-select:v1:[a-f0-9]{32}$/
+    );
+    expect(
+      line.body.input[0].content.map((part) => part.text).join('')
+    ).toBe(stablePrefix + dynamicSuffix);
+    expect(
+      line.body.input[0].content[0].prompt_cache_breakpoint
+    ).toEqual({ mode: 'explicit' });
+  });
+
   it('rejects invalid reasoning effort before submission', async () => {
     const provider = new OpenAIBatchProvider({ client, enableFallback: false, helpers });
     await expect(provider.submit({ levelDir: tmpDir, prompt: 'prompt', reasoningEffort: 'extreme' })).rejects.toThrow(/reasoningEffort/);

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -235,21 +235,25 @@ describe("triageDirectory", () => {
     expect(respTxt).toContain("1.jpg");
   });
 
-  it("includes additional curators from tags in saved prompt", async () => {
+  it("keeps repeated-person curators dynamic beyond the cache prefix", async () => {
     chatCompletion.mockResolvedValueOnce(
       JSON.stringify({ keep: ["1.jpg"], aside: ["2.jpg"] })
     );
     getPeople
       .mockResolvedValueOnce(["Alice", "Bob"])
       .mockResolvedValueOnce(["Alice"]);
-    await fs.writeFile(promptFile, "Curators: {{curators}}");
+    const context = "Stable exhibition brief. ".repeat(300);
+    const contextPath = path.join(tmpDir, "brief.md");
+    await fs.writeFile(contextPath, context);
+    await fs.writeFile(promptFile, "{{context}}\nCurators: {{curators}}");
     await triageDirectory({
       dir: tmpDir,
       promptPath: promptFile,
-      model: "test-model",
+      model: "gpt-5.6-terra",
       recurse: false,
       saveIo: true,
       curators: ["Bob"],
+      contextPath,
     });
     const levelDir = path.join(tmpDir, "_level-001");
     const prompts = await fs.readdir(path.join(levelDir, "_prompts"));
@@ -258,10 +262,14 @@ describe("triageDirectory", () => {
       "utf8"
     );
     expect(promptTxt).toContain("Curators: Bob, Alice");
-    expect(chatCompletion.mock.calls[0][0].curators).toEqual([
-      "Bob",
-      "Alice",
-    ]);
+    const request = chatCompletion.mock.calls[0][0];
+    expect(request.curators).toEqual(["Bob", "Alice"]);
+    expect(request.prompt.startsWith(request.promptCachePrefix)).toBe(true);
+    expect(request.promptCachePrefix).toContain(context);
+    expect(request.promptCachePrefix).not.toContain("Alice");
+    expect(request.prompt.slice(request.promptCachePrefix.length)).toContain(
+      "Curators: Bob, Alice"
+    );
   });
 
   it('repairs zero-decision batch', async () => {

--- a/tests/promptCaching.test.js
+++ b/tests/promptCaching.test.js
@@ -38,16 +38,18 @@ describe('buildCacheableResponsesPrompt', () => {
     expect(request.prompt_cache_key).toMatch(/^photo-select:v1:[a-f0-9]{32}$/);
   });
 
-  it('reuses a key across changing suffixes and changes it with the stable prefix', () => {
+  it('reuses only the stable key while retaining batch-specific curators', () => {
+    const aliceBatch = 'Role play as Bob, Alice. Review a.jpg.';
+    const carolBatch = 'Role play as Bob, Carol. Review b.jpg.';
     const first = buildCacheableResponsesPrompt({
       model: 'gpt-5.6-terra',
-      instructions: `${stable}Review a.jpg.`,
+      instructions: stable + aliceBatch,
       input,
       promptCachePrefix: stable,
     });
     const second = buildCacheableResponsesPrompt({
       model: 'gpt-5.6-terra',
-      instructions: `${stable}Review b.jpg.`,
+      instructions: stable + carolBatch,
       input,
       promptCachePrefix: stable,
     });
@@ -60,6 +62,14 @@ describe('buildCacheableResponsesPrompt', () => {
 
     expect(first.prompt_cache_key).toBe(second.prompt_cache_key);
     expect(first.prompt_cache_key).not.toBe(changed.prompt_cache_key);
+    expect(first.input[0].content[1].text).toBe(aliceBatch);
+    expect(second.input[0].content[1].text).toBe(carolBatch);
+    expect(first.input[0].content.map((part) => part.text).join('')).toBe(
+      stable + aliceBatch
+    );
+    expect(second.input[0].content.map((part) => part.text).join('')).toBe(
+      stable + carolBatch
+    );
   });
 
   it('preserves the legacy request shape for earlier models', () => {

--- a/tests/promptCaching.test.js
+++ b/tests/promptCaching.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { buildCacheableResponsesPrompt } from '../src/core/promptCaching.js';
+
+const stable = 'Stable curatorial context. '.repeat(300);
+const input = [
+  {
+    role: 'user',
+    content: [{ type: 'input_text', text: 'Here are the images: JSON' }],
+  },
+];
+
+describe('buildCacheableResponsesPrompt', () => {
+  it('marks the stable GPT-5.6 prefix without changing prompt text or user input', () => {
+    const dynamic = 'Role play as Curator A. Review a.jpg.';
+    const request = buildCacheableResponsesPrompt({
+      model: 'gpt-5.6-terra',
+      instructions: stable + dynamic,
+      input,
+      promptCachePrefix: stable,
+    });
+
+    expect(request.instructions).toBeUndefined();
+    expect(request.input.slice(1)).toEqual(input);
+    expect(request.input[0].role).toBe('developer');
+    expect(request.input[0].content.map((part) => part.text).join('')).toBe(
+      stable + dynamic
+    );
+    expect(request.input[0].content[0].prompt_cache_breakpoint).toEqual({
+      mode: 'explicit',
+    });
+    expect(request.input[0].content[1]).not.toHaveProperty(
+      'prompt_cache_breakpoint'
+    );
+    expect(request.prompt_cache_options).toEqual({
+      mode: 'explicit',
+      ttl: '30m',
+    });
+    expect(request.prompt_cache_key).toMatch(/^photo-select:v1:[a-f0-9]{32}$/);
+  });
+
+  it('reuses a key across changing suffixes and changes it with the stable prefix', () => {
+    const first = buildCacheableResponsesPrompt({
+      model: 'gpt-5.6-terra',
+      instructions: `${stable}Review a.jpg.`,
+      input,
+      promptCachePrefix: stable,
+    });
+    const second = buildCacheableResponsesPrompt({
+      model: 'gpt-5.6-terra',
+      instructions: `${stable}Review b.jpg.`,
+      input,
+      promptCachePrefix: stable,
+    });
+    const changed = buildCacheableResponsesPrompt({
+      model: 'gpt-5.6-terra',
+      instructions: `${stable}Additional stable fact. Review c.jpg.`,
+      input,
+      promptCachePrefix: `${stable}Additional stable fact. `,
+    });
+
+    expect(first.prompt_cache_key).toBe(second.prompt_cache_key);
+    expect(first.prompt_cache_key).not.toBe(changed.prompt_cache_key);
+  });
+
+  it('preserves the legacy request shape for earlier models', () => {
+    expect(
+      buildCacheableResponsesPrompt({
+        model: 'gpt-5.4',
+        instructions: `${stable}Review a.jpg.`,
+        input,
+        promptCachePrefix: stable,
+      })
+    ).toEqual({ instructions: `${stable}Review a.jpg.`, input });
+  });
+
+  it('preserves the legacy request shape when no safe boundary is available', () => {
+    expect(
+      buildCacheableResponsesPrompt({
+        model: 'gpt-5.6-terra',
+        instructions: 'Custom prompt without a context boundary.',
+        input,
+      })
+    ).toEqual({
+      instructions: 'Custom prompt without a context boundary.',
+      input,
+    });
+  });
+});

--- a/tests/templates.test.js
+++ b/tests/templates.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { buildPrompt } from '../src/templates.js';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { buildPrompt, renderTemplate } from '../src/templates.js';
 
 describe('buildPrompt', () => {
   it('injects role-play phrase and minutes range', async () => {
@@ -14,5 +17,56 @@ describe('buildPrompt', () => {
     expect(minutesMin).toBe(3);
     expect(minutesMax).toBe(5);
   });
-});
 
+  it('reports the stable context prefix without changing rendered prompt text', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ps-cache-prefix-'));
+    const contextPath = path.join(dir, 'brief.md');
+    const context = 'Stable context sentence. '.repeat(300);
+    await fs.writeFile(contextPath, context);
+
+    try {
+      const { prompt, promptCachePrefix, minutesMin, minutesMax } =
+        await buildPrompt(undefined, {
+          curators: ['Ingeborg Gerdes'],
+          images: ['a.jpg'],
+          contextPath,
+        });
+      const legacyPrompt = await renderTemplate(undefined, {
+        curators: 'Ingeborg Gerdes',
+        images: ['a.jpg'],
+        context,
+        hasFieldNotes: false,
+        isSecondPass: false,
+        minutesMin,
+        minutesMax,
+      });
+
+      expect(prompt).toBe(legacyPrompt);
+      expect(prompt).not.toContain('PHOTO_SELECT_CACHE_BREAKPOINT');
+      expect(prompt.startsWith(promptCachePrefix)).toBe(true);
+      expect(promptCachePrefix).toContain(context);
+      expect(prompt.slice(promptCachePrefix.length)).toContain(
+        'Role play as Ingeborg Gerdes'
+      );
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves a context containing the internal marker and disables caching', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ps-cache-collision-'));
+    const contextPath = path.join(dir, 'brief.md');
+    const context = 'Literal \uE000PHOTO_SELECT_CACHE_BREAKPOINT\uE001 content.';
+    await fs.writeFile(contextPath, context);
+
+    try {
+      const { prompt, promptCachePrefix } = await buildPrompt(undefined, {
+        contextPath,
+      });
+      expect(prompt).toContain(context);
+      expect(promptCachePrefix).toBeUndefined();
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- expose the exact end of the rendered `--context` block as an internal stable-prefix boundary without changing one byte of the prompt
- for GPT-5.6+ Responses requests, serialize the same developer instructions into stable and dynamic content blocks, add an explicit cache breakpoint, a versioned stable cache key, and a 30-minute cache TTL
- apply the same transport repair to `openai-batch` and synchronous OpenAI requests while preserving legacy request shapes for earlier models and prompts without a safe context boundary
- add offline request-equivalence/cache-key evals and a small reproducible live cache eval

No CLI flags, defaults, curator text, model, reasoning effort, response schema, file workflow, or saved prompt text change.

Tested candidate: `c59f8b0` (`only-repair-caching`)

## Why

GPT-5.6 implicit caching checks the latest eligible message breakpoint. Photo-select's large stable context lived at the head of top-level `instructions`, while changing curator/image/schema material followed it, so the API reported cache writes but no reads. This change marks the intended stable boundary explicitly.

Reference: [OpenAI prompt caching guide](https://developers.openai.com/api/docs/guides/prompt-caching)

## Hill-climb evidence

- Red: the new focused evals initially failed because the boundary/core helper did not exist and both providers still emitted the legacy unsplit request.
- Green caching/provider surface: `npx vitest run tests/orchestrator.test.js tests/openaiBatchProvider.test.js tests/chatClient.test.js tests/templates.test.js tests/promptCaching.test.js --reporter=dot --silent` — 74/74 passed.
- Repeated-person invariant: the orchestration eval proves Alice, present in two photos, is appended to `finalCurators`, excluded from the stable cache prefix, and retained in the dynamic prompt suffix. The serializer eval proves batches with Alice versus Carol share the stable key while preserving their distinct curator text exactly.
- Applicable repository suite: `npx vitest run --exclude tests/integration/prompt-curators.int.test.js --reporter=dot --silent` — 118/118 passed.
- Full `npm test`: 119 tests passed; one unrelated pre-existing stale 40-line prompt snapshot failed. The new byte-equivalence eval independently renders the legacy template and proves the saved prompt remains identical.
- Live exact-model eval: `PHOTO_SELECT_ENV_FILE=... npm run evals:prompt-cache` on `gpt-5.6-terra`:
  - first request: 6,021 input; 6,004 cache-write; 0 cached; 5 output tokens
  - second request: 6,021 input; 0 cache-write; 6,004 cached; 5 output tokens
  - result: pass

The live eval uses synthetic context and sends no photo or archive data.

## Contract report

- Change-set warning: 456 changed lines (439 additions, 17 deletions), above the 300-line warning threshold and below the 500-line mechanical-change gate. Most of the change is eval coverage.
- `json_validity_rate`: not re-estimated by the cache-only live probe; reply schema, parser, provider, and safety tests are green and response handling is unchanged.
- `retry_recovery_rate`: not applicable; no retry path changed or invoked by the cache eval.
- `todos_addressed/total_todos`: 0/0 in the touched scope.
