### PR TITLE
stop rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ to ignore existing manifests. Filesystem concurrency defaults to 12 (from
 `PHOTO_SELECT_FS_CONCURRENCY`); override it with `PHOTO_SELECT_STAGE_CONCURRENCY`
 or the `--stage-concurrency` flag when staging needs to be throttled.
 
+Recursive runs settle every photo in the current level before deciding what happens
+next. If the completed level is unanimous—every photo is in `_keep`, or every photo
+is in `_aside`—the run stops. A mixed level descends into `_keep` and continues.
+
 ### Concurrency: `--workers` (recommended)
 
 Use `--workers N` to process batches concurrently. The old `--parallel` flag is deprecated and is automatically mapped to `--workers`. A deprecation warning is printed if you use it.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "photo-select",
     "test": "vitest run",
     "evals:prompt-cache": "node scripts/eval-prompt-cache.mjs",
+    "evals:stop-rule": "vitest run tests/evaluateLevelOutcome.test.js tests/orchestrator.test.js",
     "undici:smoke": "node scripts/undici-smoke.mjs",
     "debug:batch": "node scripts/debug-batch.mjs"
   },

--- a/src/core/evaluateLevelOutcome.js
+++ b/src/core/evaluateLevelOutcome.js
@@ -1,0 +1,32 @@
+/**
+ * Decide whether a completed level is terminal.
+ *
+ * Bucket presence is used instead of direct image counts because a prior
+ * mixed level's kept photos may already have moved deeper into its `_keep`
+ * subtree when a run resumes.
+ */
+export function evaluateLevelOutcome({
+  complete,
+  hasKeep,
+  hasAside,
+}) {
+  if (!complete) {
+    return { state: "incomplete", shouldStop: false };
+  }
+
+  if (hasKeep && hasAside) {
+    return { state: "mixed", shouldStop: false };
+  }
+
+  if (hasKeep) {
+    return { state: "unanimous_keep", shouldStop: true };
+  }
+
+  if (hasAside) {
+    return { state: "unanimous_aside", shouldStop: true };
+  }
+
+  return { state: "empty", shouldStop: false };
+}
+
+export default evaluateLevelOutcome;

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -12,6 +12,7 @@ import FieldNotesWriter from "./fieldNotesWriter.js";
 import { MultiBar, Presets } from "cli-progress";
 import { sanitizePeople } from "./lib/people.js";
 import { finalizeCurators } from "./core/finalizeCurators.js";
+import { evaluateLevelOutcome } from "./core/evaluateLevelOutcome.js";
 
 const exec = promisify(execFile);
 
@@ -281,6 +282,18 @@ export async function findShallowestLevelWithEligibleImages(rootDir, options = {
       }
       console.log(`${"  ".repeat(depth)}↘️  no eligible work at level ${level}; checking _keep`);
     }
+    const [hasKeep, hasAside] = await Promise.all([
+      dirExists(path.join(current, "_keep")),
+      dirExists(path.join(current, "_aside")),
+    ]);
+    const outcome = evaluateLevelOutcome({
+      complete: state.needsReviewImages.length === 0,
+      hasKeep,
+      hasAside,
+    });
+    if (outcome.shouldStop) {
+      return { dir: current, depth, level, state, stopped: true, outcome };
+    }
     const next = path.join(current, "_keep");
     if (!(await dirExists(next))) return null;
     current = next;
@@ -297,6 +310,13 @@ export async function triageTree(options) {
     const work = await findShallowestLevelWithEligibleImages(rootDir, options);
     if (!work) {
       console.log("✅  No pending image files found in cascade.");
+      break;
+    }
+    if (work.stopped) {
+      const bucket = work.outcome.state === "unanimous_keep" ? "kept" : "set aside";
+      console.log(
+        `${"  ".repeat(work.depth)}🎯  All images ${bucket} at completed level ${work.level}; stopping recursion.`
+      );
       break;
     }
     if (work.blocked) {
@@ -957,7 +977,7 @@ export async function triageDirectory(options) {
       }
 }
 
-  // Step 5 – recurse into keepDir if both keep and aside exist
+  // Step 5 – recurse into keepDir only after a mixed completed level
   if (recurse) {
     const keepDir = path.join(dir, "_keep");
     const asideDir = path.join(dir, "_aside");
@@ -971,14 +991,23 @@ export async function triageDirectory(options) {
       }
     };
 
-    const [keepCount, asideCount, hasDeeperKeep] = await Promise.all([
+    const [keepCount, hasDeeperKeep, hasKeep, hasAside] = await Promise.all([
       countImages(keepDir),
-      countImages(asideDir),
       dirExists(path.join(keepDir, "_keep")),
+      dirExists(keepDir),
+      dirExists(asideDir),
     ]);
 
+    const outcome = evaluateLevelOutcome({
+      complete: true,
+      hasKeep,
+      hasAside,
+    });
     const keepHasWork = keepCount > 0 || hasDeeperKeep;
-    if (keepHasWork) {
+    if (outcome.shouldStop) {
+      const bucket = outcome.state === "unanimous_keep" ? "kept" : "set aside";
+      console.log(`${indent}🎯  All images ${bucket} at this level; stopping recursion.`);
+    } else if (outcome.state === "mixed" && keepHasWork) {
       await triageDirectory({
         dir: keepDir,
         promptPath,
@@ -999,9 +1028,6 @@ export async function triageDirectory(options) {
         forceRebuild,
         stageConcurrency,
       });
-    } else if (keepCount || asideCount) {
-      const status = keepCount ? "kept" : "set aside";
-      console.log(`${indent}🎯  All images ${status} at this level; stopping recursion.`);
     }
   }
   return { blocked: false, blockedCount: 0 };

--- a/tests/evaluateLevelOutcome.test.js
+++ b/tests/evaluateLevelOutcome.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { evaluateLevelOutcome } from "../src/core/evaluateLevelOutcome.js";
+
+describe("evaluateLevelOutcome", () => {
+  it.each([
+    {
+      name: "stops after unanimous keep",
+      input: { complete: true, hasKeep: true, hasAside: false },
+      expected: { state: "unanimous_keep", shouldStop: true },
+    },
+    {
+      name: "stops after unanimous aside",
+      input: { complete: true, hasKeep: false, hasAside: true },
+      expected: { state: "unanimous_aside", shouldStop: true },
+    },
+    {
+      name: "continues after a mixed decision",
+      input: { complete: true, hasKeep: true, hasAside: true },
+      expected: { state: "mixed", shouldStop: false },
+    },
+    {
+      name: "does not stop an incomplete level",
+      input: { complete: false, hasKeep: true, hasAside: false },
+      expected: { state: "incomplete", shouldStop: false },
+    },
+    {
+      name: "does not call an empty directory unanimous",
+      input: { complete: true, hasKeep: false, hasAside: false },
+      expected: { state: "empty", shouldStop: false },
+    },
+  ])("$name", ({ input, expected }) => {
+    expect(evaluateLevelOutcome(input)).toEqual(expected);
+  });
+});

--- a/tests/integration/__snapshots__/prompt-curators.int.test.js.snap
+++ b/tests/integration/__snapshots__/prompt-curators.int.test.js.snap
@@ -4,6 +4,7 @@ exports[`finalizeCurators integration > appends repeated names verbatim and orde
 "
 You are moderating a collaborative curatorial session among a real-world group making photo selection choices for an exhibition.
 
+
 Role play as Beata, Ellen Lev, Beata (Kendell + Mandy cabin neighbor):
  - Indicate who is speaking
  - Say what you think

--- a/tests/integration/prompt-curators.int.test.js
+++ b/tests/integration/prompt-curators.int.test.js
@@ -34,7 +34,12 @@ describe('finalizeCurators integration', () => {
       'Ellen Lev',
       'Beata (Kendell + Mandy cabin neighbor)',
     ]);
-    const header = prompt.split('\n').slice(0, 40).join('\n');
+    const lines = prompt.split('\n');
+    const finalConstraint = lines.findIndex((line) =>
+      line.includes('include **every** filename from the list **exactly once**')
+    );
+    expect(finalConstraint).toBeGreaterThan(-1);
+    const header = lines.slice(0, finalConstraint + 1).join('\n');
     expect(header).toMatchSnapshot();
   });
 
@@ -53,4 +58,3 @@ describe('finalizeCurators integration', () => {
     expect(names).toEqual(['Curator A']);
   });
 });
-

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -71,32 +71,136 @@ describe("triageDirectory", () => {
     await expect(fs.stat(level2)).resolves.toBeTruthy();
   });
 
-  it("recurses even when all images kept", async () => {
-    chatCompletion
-      .mockResolvedValueOnce(
-        JSON.stringify({ keep: ["1.jpg", "2.jpg"], aside: [] })
-      )
-      .mockResolvedValueOnce(
-        JSON.stringify({ keep: [], aside: ["1.jpg", "2.jpg"] })
-      );
+  it("stops when all images at the completed level are kept", async () => {
+    chatCompletion.mockResolvedValueOnce(
+      JSON.stringify({ keep: ["1.jpg", "2.jpg"], aside: [] })
+    );
     await triageDirectory({
       dir: tmpDir,
       promptPath: promptFile,
       model: "test-model",
       recurse: true,
     });
-    expect(chatCompletion).toHaveBeenCalledTimes(2);
-    const aside2 = path.join(tmpDir, "_keep", "_aside", "2.jpg");
-    await expect(fs.stat(aside2)).resolves.toBeTruthy();
+    expect(chatCompletion).toHaveBeenCalledTimes(1);
+    await expect(fs.stat(path.join(tmpDir, "_keep", "1.jpg"))).resolves.toBeTruthy();
+    await expect(fs.stat(path.join(tmpDir, "_keep", "2.jpg"))).resolves.toBeTruthy();
   });
 
-  it("resumes into deepest _keep when parent has no images", async () => {
+  it("stops when all images at the completed level are set aside", async () => {
+    chatCompletion.mockResolvedValueOnce(
+      JSON.stringify({ keep: [], aside: ["1.jpg", "2.jpg"] })
+    );
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: true,
+    });
+
+    expect(chatCompletion).toHaveBeenCalledTimes(1);
+    await expect(fs.stat(path.join(tmpDir, "_aside", "1.jpg"))).resolves.toBeTruthy();
+    await expect(fs.stat(path.join(tmpDir, "_aside", "2.jpg"))).resolves.toBeTruthy();
+  });
+
+  it("evaluates unanimity after the entire level, not after each batch", async () => {
+    for (let i = 3; i <= 11; i++) {
+      await fs.writeFile(path.join(tmpDir, `${i}.jpg`), String(i));
+    }
+    chatCompletion.mockImplementation(async ({ images }) =>
+      JSON.stringify({
+        keep: images.map((file) => path.basename(file)),
+        aside: [],
+      })
+    );
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: true,
+      workers: 2,
+    });
+
+    expect(chatCompletion).toHaveBeenCalledTimes(2);
+    expect(await fs.readdir(path.join(tmpDir, "_keep"))).toHaveLength(11);
+  });
+
+  it("recurses when separately unanimous batches make a mixed level", async () => {
+    for (let i = 3; i <= 11; i++) {
+      await fs.writeFile(path.join(tmpDir, `${i}.jpg`), String(i));
+    }
+    let rootBatch = 0;
+    chatCompletion.mockImplementation(async ({ images }) => {
+      const names = images.map((file) => path.basename(file));
+      if (images[0].startsWith(tmpDir + path.sep) && rootBatch++ === 0) {
+        return JSON.stringify({ keep: names, aside: [] });
+      }
+      return JSON.stringify({ keep: [], aside: names });
+    });
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: true,
+      workers: 1,
+    });
+
+    expect(chatCompletion).toHaveBeenCalledTimes(3);
+    await expect(
+      fs.stat(path.join(tmpDir, "_keep", "_aside"))
+    ).resolves.toBeTruthy();
+  });
+
+  it("does not restart a previously completed unanimous-keep level", async () => {
+    await fs.rm(path.join(tmpDir, "1.jpg"));
+    await fs.rm(path.join(tmpDir, "2.jpg"));
+    await fs.mkdir(path.join(tmpDir, "_keep"));
+    await fs.writeFile(path.join(tmpDir, "_keep", "1.jpg"), "a");
+    await fs.writeFile(path.join(tmpDir, "_keep", "2.jpg"), "b");
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: true,
+    });
+
+    expect(chatCompletion).not.toHaveBeenCalled();
+  });
+
+  it("does not restart a previously completed unanimous-aside level", async () => {
+    await fs.rm(path.join(tmpDir, "1.jpg"));
+    await fs.rm(path.join(tmpDir, "2.jpg"));
+    await fs.mkdir(path.join(tmpDir, "_aside"));
+    await fs.writeFile(path.join(tmpDir, "_aside", "1.jpg"), "a");
+    await fs.writeFile(path.join(tmpDir, "_aside", "2.jpg"), "b");
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: true,
+    });
+
+    expect(chatCompletion).not.toHaveBeenCalled();
+  });
+
+  it("resumes into deepest _keep across completed mixed parent levels", async () => {
     await fs.rm(path.join(tmpDir, "1.jpg"));
     await fs.rm(path.join(tmpDir, "2.jpg"));
     const deep = path.join(tmpDir, "_keep", "_keep");
     await fs.mkdir(deep, { recursive: true });
     await fs.writeFile(path.join(deep, "1.jpg"), "a");
     await fs.writeFile(path.join(deep, "2.jpg"), "b");
+    await fs.mkdir(path.join(tmpDir, "_aside"));
+    await fs.writeFile(path.join(tmpDir, "_aside", "root-aside.jpg"), "aside");
+    await fs.mkdir(path.join(tmpDir, "_keep", "_aside"));
+    await fs.writeFile(
+      path.join(tmpDir, "_keep", "_aside", "middle-aside.jpg"),
+      "aside"
+    );
 
     chatCompletion
       .mockResolvedValueOnce(
@@ -328,9 +432,7 @@ describe("triageDirectory", () => {
 });
 
 describe("cascade scheduler invariants", () => {
-  it("processes the shallowest eligible level before nested _keep work", async () => {
-    await fs.mkdir(path.join(tmpDir, "_keep"), { recursive: true });
-    await fs.writeFile(path.join(tmpDir, "_keep", "deep.jpg"), "deep");
+  it("does not descend after unanimous aside", async () => {
     const seen = [];
     chatCompletion.mockImplementation(async ({ images }) => {
       const names = images.map((f) => path.basename(f)).sort();
@@ -349,7 +451,7 @@ describe("cascade scheduler invariants", () => {
     });
 
     expect(seen[0]).toEqual(["1.jpg", "2.jpg"]);
-    expect(seen[1]).toEqual(["deep.jpg"]);
+    expect(seen).toEqual([["1.jpg", "2.jpg"]]);
   });
 
   it("returns to base for late-arriving files after a deeper level settles", async () => {
@@ -358,6 +460,9 @@ describe("cascade scheduler invariants", () => {
     const keepDir = path.join(tmpDir, "_keep");
     await fs.mkdir(keepDir, { recursive: true });
     await fs.writeFile(path.join(keepDir, "deep.jpg"), "deep");
+    const asideDir = path.join(tmpDir, "_aside");
+    await fs.mkdir(asideDir, { recursive: true });
+    await fs.writeFile(path.join(asideDir, "earlier.jpg"), "aside");
     const seen = [];
     chatCompletion.mockImplementation(async ({ images }) => {
       const names = images.map((f) => path.basename(f)).sort();
@@ -380,9 +485,7 @@ describe("cascade scheduler invariants", () => {
     await expect(fs.stat(path.join(tmpDir, "_aside", "late.jpg"))).resolves.toBeTruthy();
   });
 
-  it("does not descend while current-level residue remains eligible", async () => {
-    await fs.mkdir(path.join(tmpDir, "_keep"), { recursive: true });
-    await fs.writeFile(path.join(tmpDir, "_keep", "deep.jpg"), "deep");
+  it("settles current-level residue before applying the unanimous stop", async () => {
     const seen = [];
     chatCompletion
       .mockImplementationOnce(async ({ images }) => {
@@ -392,10 +495,6 @@ describe("cascade scheduler invariants", () => {
       .mockImplementationOnce(async ({ images }) => {
         seen.push(images.map((f) => path.basename(f)).sort());
         return JSON.stringify({ keep: [], aside: ["2.jpg"] });
-      })
-      .mockImplementationOnce(async ({ images }) => {
-        seen.push(images.map((f) => path.basename(f)).sort());
-        return JSON.stringify({ keep: [], aside: ["deep.jpg"] });
       })
       .mockImplementation(async ({ images }) => {
         seen.push(images.map((f) => path.basename(f)).sort());
@@ -411,7 +510,7 @@ describe("cascade scheduler invariants", () => {
 
     expect(seen[0]).toEqual(["1.jpg", "2.jpg"]);
     expect(seen[1]).toEqual(["2.jpg"]);
-    expect(seen[2]).toEqual(["deep.jpg"]);
+    expect(seen).toHaveLength(2);
   });
 
   it("reports NEEDS_REVIEW images and blocks descent by default", async () => {


### PR DESCRIPTION
## Summary

- stop the recursive cascade after a completed level is unanimous: all `_keep` or all `_aside`
- continue into `_keep` only when both classification buckets are present
- preserve level completion and `NEEDS_REVIEW` as barriers before the stop rule is evaluated
- preserve terminal behavior across restarts without adding a new CLI flag
- document the rule and add a focused `evals:stop-rule` command
- strengthen the inherited curator-prompt snapshot so it locates the filename-completeness constraint semantically

## Root cause

The cascade scheduler descended whenever it found work under `_keep`. That made a completed all-keep level recurse even though the curatorial result was unanimous. The stop decision was not represented as an explicit level outcome shared by fresh runs and resumes.

## User impact

CLI invocation, prompts, providers, curators, batching, archive layout, and output schemas remain unchanged. A completed level now behaves as follows:

| Level result | Behavior |
| --- | --- |
| all keep | stop |
| all aside | stop |
| mixed keep and aside | recurse into keep |
| incomplete or NEEDS_REVIEW | do not evaluate unanimity |

## Evaluation

- `npm run evals:stop-rule` — 27/27 passed
- `npm test -- --reporter=dot --silent` — 130/130 passed
- `npm run evals:prompt-cache` — live regression passed; first request wrote 6,004 tokens and second request read 6,004 cached tokens
- `git diff --check` — passed
- concurrent multi-batch unanimity, mixed batches, terminal resumes, incomplete levels, and late-arriving shallower work are covered

## Contract metrics

- `json_validity_rate`: production prompt/schema unchanged; existing parsing and safety evals pass
- `retry_recovery_rate`: retry policy unchanged; repair eval remains green
- `todos_addressed/total_todos`: 0/0 in touched files
