### PR TITLE
only repair caching: restore Batch cache locality

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "photo-select",
     "test": "vitest run",
     "evals:prompt-cache": "node scripts/eval-prompt-cache.mjs",
+    "evals:batch-prompt-cache": "node scripts/eval-batch-prompt-cache.mjs",
     "evals:stop-rule": "vitest run tests/evaluateLevelOutcome.test.js tests/orchestrator.test.js",
     "undici:smoke": "node scripts/undici-smoke.mjs",
     "debug:batch": "node scripts/debug-batch.mjs"

--- a/scripts/eval-batch-prompt-cache.mjs
+++ b/scripts/eval-batch-prompt-cache.mjs
@@ -1,0 +1,108 @@
+import OpenAI from 'openai';
+import dotenv from 'dotenv';
+import { createReadStream } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { buildCacheableResponsesPrompt } from '../src/core/promptCaching.js';
+dotenv.config(process.env.PHOTO_SELECT_ENV_FILE
+  ? { path: process.env.PHOTO_SELECT_ENV_FILE }
+  : undefined);
+if (!process.env.OPENAI_API_KEY) {
+  throw new Error('OPENAI_API_KEY is required (or set PHOTO_SELECT_ENV_FILE)');
+}
+const model = process.env.PHOTO_SELECT_CACHE_EVAL_MODEL || 'gpt-5.6-terra';
+const count = Math.min(20, Math.max(2, Number(process.env.PHOTO_SELECT_CACHE_EVAL_REQUESTS || 6)));
+const pollMs = Math.max(1000, Number(process.env.PHOTO_SELECT_CACHE_EVAL_POLL_MS || 5000));
+const timeoutMs = Math.max(60_000, Number(process.env.PHOTO_SELECT_CACHE_EVAL_TIMEOUT_MS || 30 * 60_000));
+const prefix = (
+  'Photo-select grouped Batch prompt-cache evaluation, version 1. ' +
+  'This synthetic context contains no image or archive data. ' +
+  'Preserve it exactly as the stable developer prefix. '
+).repeat(200) + ` Run ${Date.now()}.`;
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+function body(index) {
+  return {
+    model,
+    ...buildCacheableResponsesPrompt({
+      model,
+      instructions: `${prefix} Synthetic request ${index}.`,
+      promptCachePrefix: prefix,
+      input: [{
+        role: 'user',
+        content: [{ type: 'input_text', text: 'Reply with the word OK.' }],
+      }],
+    }),
+    reasoning: { effort: 'low' },
+    text: { verbosity: 'low' },
+    max_output_tokens: 64,
+    store: false,
+  };
+}
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const tempDir = await mkdtemp(path.join(os.tmpdir(), 'photo-select-cache-eval-'));
+try {
+  const inputPath = path.join(tempDir, 'requests.jsonl');
+  const jsonl = Array.from({ length: count }, (_, i) => JSON.stringify({
+    custom_id: `cache-eval-${i + 1}`,
+    method: 'POST',
+    url: '/v1/responses',
+    body: body(i + 1),
+  })).join('\n') + '\n';
+  await writeFile(inputPath, jsonl, 'utf8');
+  const input = await client.files.create({
+    file: createReadStream(inputPath),
+    purpose: 'batch',
+  });
+  let batch = await client.batches.create({
+    input_file_id: input.id,
+    endpoint: '/v1/responses',
+    completion_window: '24h',
+    metadata: { eval: 'photo-select-batch-cache', request_count: String(count) },
+  });
+  const deadline = Date.now() + timeoutMs;
+  while (!['completed', 'failed', 'expired', 'canceled'].includes(batch.status)) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${batch.id}`);
+    await wait(pollMs);
+    batch = await client.batches.retrieve(batch.id);
+  }
+  if (batch.status !== 'completed' || !batch.output_file_id) {
+    throw new Error(`Batch ${batch.id} ended with status ${batch.status}`);
+  }
+  const text = await (await client.files.content(batch.output_file_id)).text();
+  const usages = text.split(/\r?\n/).filter(Boolean).map((line) => {
+    const row = JSON.parse(line);
+    const responseBody = typeof row.response?.body === 'string'
+      ? JSON.parse(row.response.body)
+      : row.response?.body;
+    const usage = responseBody?.usage || {};
+    const details = usage.input_tokens_details || {};
+    return {
+      custom_id: row.custom_id,
+      status_code: row.response?.status_code,
+      input_tokens: usage.input_tokens || 0,
+      cached_tokens: details.cached_tokens || 0,
+      cache_write_tokens: details.cache_write_tokens || 0,
+      output_tokens: usage.output_tokens || 0,
+    };
+  });
+  const totals = usages.reduce((sum, usage) => {
+    for (const key of ['input_tokens', 'cached_tokens', 'cache_write_tokens', 'output_tokens']) {
+      sum[key] += usage[key];
+    }
+    sum.cache_hit_requests += Number(usage.cached_tokens > 0);
+    sum.cache_write_requests += Number(usage.cache_write_tokens > 0);
+    return sum;
+  }, { input_tokens: 0, cached_tokens: 0, cache_write_tokens: 0,
+    output_tokens: 0, cache_hit_requests: 0, cache_write_requests: 0 });
+  const passed = usages.length === count &&
+    usages.every((usage) => usage.status_code === 200) &&
+    totals.cache_write_requests === 1 && totals.cache_hit_requests === count - 1 &&
+    totals.cached_tokens > totals.cache_write_tokens;
+  console.log(JSON.stringify({ eval: 'grouped_batch_explicit_prompt_cache', model,
+    batch_id: batch.id, request_count: count, passed, totals,
+    cache_hit_rate: totals.cache_hit_requests / count, usages }, null, 2));
+  if (!passed) process.exitCode = 1;
+} finally {
+  await rm(tempDir, { recursive: true, force: true });
+}

--- a/src/core/batchAggregation.js
+++ b/src/core/batchAggregation.js
@@ -1,0 +1,38 @@
+export const OPENAI_BATCH_MAX_REQUESTS = 50_000;
+export const OPENAI_BATCH_MAX_BYTES = 200 * 1024 * 1024;
+
+export function partitionBatchItems(
+  items,
+  {
+    maxRequests = OPENAI_BATCH_MAX_REQUESTS,
+    maxBytes = OPENAI_BATCH_MAX_BYTES,
+  } = {}
+) {
+  const partitions = [];
+  let current = [];
+  let currentBytes = 0;
+
+  for (const item of items) {
+    const itemBytes = Buffer.byteLength(item.jsonl, 'utf8');
+    if (itemBytes > maxBytes) {
+      const err = new Error(
+        `Batch item ${item.id || '<unknown>'} exceeds the ${maxBytes}-byte input limit`
+      );
+      err.code = 'BATCH_ITEM_TOO_LARGE';
+      throw err;
+    }
+    if (
+      current.length > 0 &&
+      (current.length >= maxRequests || currentBytes + itemBytes > maxBytes)
+    ) {
+      partitions.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+    current.push(item);
+    currentBytes += itemBytes;
+  }
+
+  if (current.length > 0) partitions.push(current);
+  return partitions;
+}

--- a/src/providers/openai-batch.js
+++ b/src/providers/openai-batch.js
@@ -9,9 +9,19 @@ import { computeMaxOutputTokens, computeOutputBudget, estimateInputTokens } from
 import { delay } from '../config.js';
 import { debugBatch } from '../../scripts/debug-batch.mjs';
 import { buildCacheableResponsesPrompt } from '../core/promptCaching.js';
+import {
+  OPENAI_BATCH_MAX_REQUESTS,
+  partitionBatchItems,
+} from '../core/batchAggregation.js';
 
 const DEFAULT_COMPLETION_WINDOW = process.env.PHOTO_SELECT_BATCH_COMPLETION_WINDOW || '24h';
 const DEFAULT_POLL_MS = Number(process.env.PHOTO_SELECT_BATCH_CHECK_INTERVAL_MS || 60000);
+const DEFAULT_AGGREGATION_MS = Number(
+  process.env.PHOTO_SELECT_BATCH_AGGREGATION_MS || 1000
+);
+const DEFAULT_MAX_BATCH_BYTES = Number(
+  process.env.PHOTO_SELECT_BATCH_MAX_INPUT_BYTES || 190 * 1024 * 1024
+);
 const DEFAULT_ENDPOINT = '/v1/responses';
 const FALLBACK_ENDPOINT = '/v1/chat/completions';
 
@@ -250,13 +260,20 @@ export default class OpenAIBatchProvider {
     client,
     pollIntervalMs = DEFAULT_POLL_MS,
     completionWindow = DEFAULT_COMPLETION_WINDOW,
+    aggregationWindowMs = DEFAULT_AGGREGATION_MS,
+    maxBatchInputBytes = DEFAULT_MAX_BATCH_BYTES,
+    maxBatchRequests = OPENAI_BATCH_MAX_REQUESTS,
     enableFallback = true,
     helpers = {},
   } = {}) {
     this.client = client || new OpenAI();
     this.pollIntervalMs = pollIntervalMs;
     this.completionWindow = completionWindow;
+    this.aggregationWindowMs = Math.max(0, Number(aggregationWindowMs) || 0);
+    this.maxBatchInputBytes = Math.max(1, Number(maxBatchInputBytes) || 1);
+    this.maxBatchRequests = Math.max(1, Number(maxBatchRequests) || 1);
     this.enableFallback = enableFallback;
+    this.pendingSubmissionGroups = new Map();
     this.helpers = {
       buildInput,
       buildMessages,
@@ -312,37 +329,115 @@ export default class OpenAIBatchProvider {
     });
     const safe = safeId(customId);
 
-    const attempts = [
-      { endpoint: DEFAULT_ENDPOINT, request: responsesRequest },
-    ];
-    if (this.enableFallback) {
-      attempts.push({ endpoint: FALLBACK_ENDPOINT, request: null });
+    return this.#enqueueSubmission({
+      dirs,
+      customId,
+      safe,
+      levelDir,
+      prompt,
+      images,
+      curators,
+      model,
+      minutesMin,
+      minutesMax,
+      verbosity,
+      responsesRequest,
+    });
+  }
+
+  #enqueueSubmission(item) {
+    const groupKey = JSON.stringify([
+      path.resolve(item.levelDir),
+      item.model,
+      this.completionWindow,
+    ]);
+    let group = this.pendingSubmissionGroups.get(groupKey);
+    if (!group) {
+      group = { items: [], timer: null };
+      this.pendingSubmissionGroups.set(groupKey, group);
     }
 
+    return new Promise((resolve, reject) => {
+      group.items.push({ ...item, resolve, reject });
+      if (!group.timer) {
+        group.timer = setTimeout(() => {
+          void this.#flushSubmissionGroup(groupKey);
+        }, this.aggregationWindowMs);
+      }
+    });
+  }
+
+  async #flushSubmissionGroup(groupKey) {
+    const group = this.pendingSubmissionGroups.get(groupKey);
+    if (!group) return;
+    this.pendingSubmissionGroups.delete(groupKey);
+    try {
+      const prepared = group.items.map((item) => ({
+        ...item,
+        id: item.customId,
+        jsonl: JSON.stringify({
+          custom_id: item.customId,
+          method: 'POST',
+          url: DEFAULT_ENDPOINT,
+          body: item.responsesRequest.body,
+        }) + '\n',
+      }));
+      const partitions = partitionBatchItems(prepared, {
+        maxRequests: this.maxBatchRequests,
+        maxBytes: this.maxBatchInputBytes,
+      });
+      const handles = [];
+      for (const partition of partitions) {
+        handles.push(...await this.#submitPreparedGroup(partition));
+      }
+      group.items.forEach((item, index) => item.resolve(handles[index]));
+    } catch (err) {
+      group.items.forEach((item) => item.reject(err));
+    }
+  }
+
+  async #submitPreparedGroup(items) {
+    const first = items[0];
+    const groupDigest = crypto
+      .createHash('sha256')
+      .update(items.map((item) => item.customId).join('\0'))
+      .digest('hex')
+      .slice(0, 24);
+    const jsonlPath = path.join(
+      first.dirs.inputs,
+      items.length === 1 ? `${first.safe}.jsonl` : `batch-${groupDigest}.jsonl`
+    );
+    const endpoints = this.enableFallback
+      ? [DEFAULT_ENDPOINT, FALLBACK_ENDPOINT]
+      : [DEFAULT_ENDPOINT];
     let batch;
-    let lastErr;
     let inputFile;
     let endpointUsed = DEFAULT_ENDPOINT;
-    for (const attempt of attempts) {
-      const endpoint = attempt.endpoint;
-      const request = attempt.request ||
-        (await this.#buildChatCompletionsRequest({
-          prompt,
-          images,
-          curators,
-          model,
-          minutesMin,
-          minutesMax,
-          verbosity,
-        }, responsesRequest.used));
-      const jsonlLine = {
-        custom_id: customId,
-        method: 'POST',
-        url: endpoint,
-        body: request.body,
-      };
-      const jsonlPath = path.join(dirs.inputs, `${safe}.jsonl`);
-      await writeFile(jsonlPath, JSON.stringify(jsonlLine) + '\n', 'utf8');
+    let lastErr;
+
+    for (const endpoint of endpoints) {
+      const requests = endpoint === DEFAULT_ENDPOINT
+        ? items.map((item) => item.responsesRequest)
+        : await Promise.all(
+          items.map((item) => this.#buildChatCompletionsRequest({
+            prompt: item.prompt,
+            images: item.images,
+            curators: item.curators,
+            model: item.model,
+            minutesMin: item.minutesMin,
+            minutesMax: item.minutesMax,
+            verbosity: item.verbosity,
+          }, item.responsesRequest.used))
+        );
+      const jsonl = items
+        .map((item, index) => JSON.stringify({
+          custom_id: item.customId,
+          method: 'POST',
+          url: endpoint,
+          body: requests[index].body,
+        }))
+        .join('\n') + '\n';
+      await writeFile(jsonlPath, jsonl, 'utf8');
       try {
         inputFile = await this.client.files.create({
           file: createReadStream(jsonlPath),
@@ -353,70 +448,76 @@ export default class OpenAIBatchProvider {
           endpoint,
           completion_window: this.completionWindow,
           metadata: {
-            custom_id: customId,
-            model,
-            level: levelKey(levelDir),
+            custom_id: items.length === 1
+              ? first.customId
+              : `ps-group:${groupDigest}`,
+            request_count: String(items.length),
+            model: first.model,
+            level: levelKey(first.levelDir),
           },
         });
         endpointUsed = endpoint;
         break;
       } catch (err) {
         lastErr = err;
-        await appendLedger(dirs.base, {
-          custom_id: customId,
+        await Promise.all(items.map((item) => appendLedger(item.dirs.base, {
+          custom_id: item.customId,
           event: 'submit_error',
           endpoint,
           message: err?.message,
-        });
-        if (!this.enableFallback || endpoint === FALLBACK_ENDPOINT) {
-          throw err;
-        }
+        })));
+        if (!this.enableFallback || endpoint === FALLBACK_ENDPOINT) throw err;
       }
     }
 
-    if (!batch) {
-      throw lastErr || new Error('Failed to create batch job');
-    }
+    if (!batch) throw lastErr || new Error('Failed to create batch job');
 
-    const ticketPath = path.join(dirs.tickets, `${safe}.ticket.json`);
     const submittedAt = new Date().toISOString();
-    const ticket = {
-      custom_id: customId,
-      batch_id: batch.id,
-      model,
-      endpoint: endpointUsed,
-      status: batch.status,
-      input_file_id: inputFile.id,
-      submitted_at: submittedAt,
-      completion_window: this.completionWindow,
-      used_images: responsesRequest.used.map((file) => path.basename(file)),
-      output_budget: budgetArtifact(responsesRequest.budget),
-    };
-    await writeFile(ticketPath, JSON.stringify(ticket, null, 2));
-    await appendLedger(dirs.base, {
-      custom_id: customId,
-      event: 'submitted',
-      batch_id: batch.id,
-      endpoint: endpointUsed,
-      status: batch.status,
-      output_budget: budgetArtifact(responsesRequest.budget),
-    });
+    return Promise.all(items.map(async (item) => {
+      const ticketPath = path.join(
+        item.dirs.tickets,
+        `${item.safe}.ticket.json`
+      );
+      const statusPath = path.join(
+        item.dirs.status,
+        `${item.safe}.status.json`
+      );
+      const ticket = {
+        custom_id: item.customId,
+        batch_id: batch.id,
+        model: item.model,
+        endpoint: endpointUsed,
+        status: batch.status,
+        input_file_id: inputFile.id,
+        submitted_at: submittedAt,
+        completion_window: this.completionWindow,
+        used_images: item.responsesRequest.used.map((file) => path.basename(file)),
+        output_budget: budgetArtifact(item.responsesRequest.budget),
+      };
+      await writeFile(ticketPath, JSON.stringify(ticket, null, 2));
+      await appendLedger(item.dirs.base, {
+        custom_id: item.customId,
+        event: 'submitted',
+        batch_id: batch.id,
+        endpoint: endpointUsed,
+        status: batch.status,
+        output_budget: budgetArtifact(item.responsesRequest.budget),
+      });
+      await writeFile(statusPath, JSON.stringify(batch, null, 2));
 
-    const statusPath = path.join(dirs.status, `${safe}.status.json`);
-    await writeFile(statusPath, JSON.stringify(batch, null, 2));
-
-    return {
-      provider: this.name,
-      customId,
-      batchId: batch.id,
-      levelDir,
-      model,
-      ticketPath,
-      statusPath,
-      safeId: safe,
-      used: responsesRequest.used,
-      endpoint: endpointUsed,
-    };
+      return {
+        provider: this.name,
+        customId: item.customId,
+        batchId: batch.id,
+        levelDir: item.levelDir,
+        model: item.model,
+        ticketPath,
+        statusPath,
+        safeId: item.safe,
+        used: item.responsesRequest.used,
+        endpoint: endpointUsed,
+      };
+    }));
   }
 
   async collect(handle) {

--- a/tests/batchAggregation.test.js
+++ b/tests/batchAggregation.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { partitionBatchItems } from '../src/core/batchAggregation.js';
+
+describe('partitionBatchItems', () => {
+  it('preserves order while enforcing request-count and byte limits', () => {
+    const items = [
+      { id: 'a', jsonl: 'aaaa\n' },
+      { id: 'b', jsonl: 'bbbb\n' },
+      { id: 'c', jsonl: 'cccc\n' },
+    ];
+
+    expect(
+      partitionBatchItems(items, { maxRequests: 2, maxBytes: 10 })
+        .map((partition) => partition.map((item) => item.id))
+    ).toEqual([['a', 'b'], ['c']]);
+  });
+});

--- a/tests/openaiBatchProvider.test.js
+++ b/tests/openaiBatchProvider.test.js
@@ -105,6 +105,89 @@ describe('OpenAIBatchProvider', () => {
     expect(ledger).toContain('output_budget');
   });
 
+  it('coalesces compatible concurrent submissions into one multi-line Batch job', async () => {
+    const provider = new OpenAIBatchProvider({
+      client,
+      enableFallback: false,
+      helpers,
+      aggregationWindowMs: 25,
+    });
+    const firstImage = path.join(tmpDir, '1.jpg');
+    const secondImage = path.join(tmpDir, '2.jpg');
+    await Promise.all([
+      fs.writeFile(firstImage, 'first'),
+      fs.writeFile(secondImage, 'second'),
+    ]);
+
+    const handles = await Promise.all([
+      provider.submit({
+        levelDir: tmpDir,
+        prompt: 'stable context\nreview 1.jpg',
+        images: [firstImage],
+        model: 'gpt-5.6-terra',
+      }),
+      provider.submit({
+        levelDir: tmpDir,
+        prompt: 'stable context\nreview 2.jpg',
+        images: [secondImage],
+        model: 'gpt-5.6-terra',
+      }),
+    ]);
+
+    expect(client.files.create).toHaveBeenCalledTimes(1);
+    expect(client.batches.create).toHaveBeenCalledTimes(1);
+    expect(new Set(handles.map((handle) => handle.customId)).size).toBe(2);
+    expect(new Set(handles.map((handle) => handle.batchId))).toEqual(
+      new Set(['batch_123'])
+    );
+
+    const inputsDir = path.join(tmpDir, '.batch', 'inputs');
+    const inputFiles = await fs.readdir(inputsDir);
+    expect(inputFiles).toHaveLength(1);
+    const lines = (await fs.readFile(path.join(inputsDir, inputFiles[0]), 'utf8'))
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(lines).toHaveLength(2);
+    expect(new Set(lines.map((line) => line.custom_id))).toEqual(
+      new Set(handles.map((handle) => handle.customId))
+    );
+  });
+
+  it('splits an aggregate before the configured Batch request limit', async () => {
+    const provider = new OpenAIBatchProvider({
+      client,
+      enableFallback: false,
+      helpers,
+      aggregationWindowMs: 25,
+      maxBatchRequests: 1,
+    });
+    const firstImage = path.join(tmpDir, '1.jpg');
+    const secondImage = path.join(tmpDir, '2.jpg');
+    await Promise.all([
+      fs.writeFile(firstImage, 'first'),
+      fs.writeFile(secondImage, 'second'),
+    ]);
+
+    await Promise.all([
+      provider.submit({
+        levelDir: tmpDir,
+        prompt: 'review 1.jpg',
+        images: [firstImage],
+        model: 'gpt-5.6-terra',
+      }),
+      provider.submit({
+        levelDir: tmpDir,
+        prompt: 'review 2.jpg',
+        images: [secondImage],
+        model: 'gpt-5.6-terra',
+      }),
+    ]);
+
+    expect(client.files.create).toHaveBeenCalledTimes(2);
+    expect(client.batches.create).toHaveBeenCalledTimes(2);
+  });
+
   it('limits safeId length for deeply nested level directories', async () => {
     const provider = new OpenAIBatchProvider({ client, enableFallback: false, helpers });
     let longDir = tmpDir;


### PR DESCRIPTION
## Summary

Follow-up to merged PR #220. The prompt template and explicit cache fields were already correct; the remaining defect was Batch topology: the CLI uploaded one JSONL line and created one OpenAI Batch job per worker submission, preventing same-job cache locality.

This PR only repairs caching:

- coalesces compatible concurrent `openai-batch` submissions for the same level/model into one multi-line JSONL file and one Batch job;
- retains a distinct `custom_id`, handle, ticket, status file, result, curator list, image list, and output budget for every original submission;
- retains the Responses-to-Chat-Completions fallback;
- partitions aggregates before OpenAI's request-count and input-byte limits; and
- adds a cold-prefix paid eval that requires one cache write followed by cache reads in the same Batch.

No CLI flags, prompt text, reply schema, recursive selection behavior, or stop-rule behavior changes. The existing repeated-person curator promotion remains dynamic beyond the stable cache prefix.

## Root cause and evidence

- Direct Responses cache eval: passed; the stable prefix was cached.
- Existing production-style audit: one JSONL line per Batch job and zero cache-hit requests despite correct explicit cache fields.
- Final cold-prefix grouped Batch eval (`batch_6a729ce298ac819091033c315047a8a6`):
  - 6/6 successful JSONL response rows;
  - 1 cache-write request / 5 cache-hit requests;
  - 6,212 cache-write tokens / 31,060 cached tokens;
  - 83.3% request cache-hit rate.

This matches OpenAI's Batch guidance to place many requests in one JSONL input file while preserving one line per request.

## Verification

- `npm test -- --reporter=dot` — 21 files, 133/133 tests passed
- `npm run evals:stop-rule -- --reporter=dot` — 27/27 tests passed
- `npm run evals:prompt-cache` — passed, 6,004 cached tokens on the verified read
- `npm run evals:batch-prompt-cache` — passed with the cold-prefix metrics above
- repeated-person curator and stable-prefix integration tests — 6/6 passed
- `node --check` for changed runtime/eval files — passed
- `git diff --check` — passed
- changed-file TODOs: 0/0
- retry recovery: not exercised; no parse retry occurred

## Review note

The change is exactly 500 added/deleted lines, so it crosses the contract's 300-line warning threshold but not the greater-than-500 `--mechanical` threshold. The active photo run was not interrupted or restarted and will continue using the code already loaded in that process.
