### PR TITLE
repair caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "photo-select",
     "test": "vitest run",
     "evals:prompt-cache": "node scripts/eval-prompt-cache.mjs",
+    "evals:batch-aggregation": "vitest run tests/batchAggregation.test.js tests/openaiBatchProvider.test.js",
     "evals:batch-prompt-cache": "node scripts/eval-batch-prompt-cache.mjs",
     "evals:stop-rule": "vitest run tests/evaluateLevelOutcome.test.js tests/orchestrator.test.js",
     "undici:smoke": "node scripts/undici-smoke.mjs",

--- a/scripts/eval-batch-prompt-cache.mjs
+++ b/scripts/eval-batch-prompt-cache.mjs
@@ -1,66 +1,95 @@
 import OpenAI from 'openai';
 import dotenv from 'dotenv';
-import { createReadStream } from 'node:fs';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { buildCacheableResponsesPrompt } from '../src/core/promptCaching.js';
+
 dotenv.config(process.env.PHOTO_SELECT_ENV_FILE
   ? { path: process.env.PHOTO_SELECT_ENV_FILE }
   : undefined);
 if (!process.env.OPENAI_API_KEY) {
   throw new Error('OPENAI_API_KEY is required (or set PHOTO_SELECT_ENV_FILE)');
 }
+const { default: OpenAIBatchProvider } = await import(
+  '../src/providers/openai-batch.js'
+);
+
 const model = process.env.PHOTO_SELECT_CACHE_EVAL_MODEL || 'gpt-5.6-terra';
-const count = Math.min(20, Math.max(2, Number(process.env.PHOTO_SELECT_CACHE_EVAL_REQUESTS || 6)));
-const pollMs = Math.max(1000, Number(process.env.PHOTO_SELECT_CACHE_EVAL_POLL_MS || 5000));
-const timeoutMs = Math.max(60_000, Number(process.env.PHOTO_SELECT_CACHE_EVAL_TIMEOUT_MS || 30 * 60_000));
+const count = Math.min(15, Math.max(
+  2,
+  Number(process.env.PHOTO_SELECT_CACHE_EVAL_REQUESTS || 6)
+));
+const pollMs = Math.max(
+  1000,
+  Number(process.env.PHOTO_SELECT_CACHE_EVAL_POLL_MS || 5000)
+);
+const timeoutMs = Math.max(
+  60_000,
+  Number(process.env.PHOTO_SELECT_CACHE_EVAL_TIMEOUT_MS || 30 * 60_000)
+);
+const aggregationMs = Math.max(
+  1,
+  Number(process.env.PHOTO_SELECT_CACHE_EVAL_AGGREGATION_MS || 50)
+);
+const staggerMs = Math.max(
+  aggregationMs + 1,
+  Number(process.env.PHOTO_SELECT_CACHE_EVAL_STAGGER_MS || 150)
+);
 const prefix = (
-  'Photo-select grouped Batch prompt-cache evaluation, version 1. ' +
+  'Photo-select provider Batch prompt-cache evaluation, version 2. ' +
   'This synthetic context contains no image or archive data. ' +
   'Preserve it exactly as the stable developer prefix. '
 ).repeat(200) + ` Run ${Date.now()}.`;
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-function body(index) {
-  return {
-    model,
-    ...buildCacheableResponsesPrompt({
-      model,
-      instructions: `${prefix} Synthetic request ${index}.`,
-      promptCachePrefix: prefix,
+
+const helpers = {
+  async buildInput(prompt) {
+    const index = Number(prompt.match(/Synthetic request (\d+)/)?.[1] || 1);
+    await wait((index - 1) * staggerMs);
+    return {
+      instructions: prompt,
       input: [{
         role: 'user',
-        content: [{ type: 'input_text', text: 'Reply with the word OK.' }],
+        content: [{
+          type: 'input_text',
+          text: 'Return a JSON object whose ok property is the string OK.',
+        }],
       }],
-    }),
-    reasoning: { effort: 'low' },
-    text: { verbosity: 'low' },
-    max_output_tokens: 64,
-    store: false,
+      used: [],
+    };
+  },
+  schemaForBatch() {
+    return {
+      name: 'PhotoSelectCacheEvalV2',
+      schema: {
+        type: 'object',
+        properties: { ok: { type: 'string', enum: ['OK'] } },
+        required: ['ok'],
+        additionalProperties: false,
+      },
+    };
+  },
+};
+
+function usageFromRow(row) {
+  const responseBody = typeof row.response?.body === 'string'
+    ? JSON.parse(row.response.body)
+    : row.response?.body;
+  const usage = row.response?.usage || responseBody?.usage || {};
+  const details = usage.input_tokens_details || {};
+  return {
+    custom_id: row.custom_id,
+    status_code: row.response?.status_code,
+    input_tokens: usage.input_tokens || 0,
+    cached_tokens: details.cached_tokens || 0,
+    cache_write_tokens: details.cache_write_tokens || 0,
+    output_tokens: usage.output_tokens || 0,
   };
 }
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-const tempDir = await mkdtemp(path.join(os.tmpdir(), 'photo-select-cache-eval-'));
-try {
-  const inputPath = path.join(tempDir, 'requests.jsonl');
-  const jsonl = Array.from({ length: count }, (_, i) => JSON.stringify({
-    custom_id: `cache-eval-${i + 1}`,
-    method: 'POST',
-    url: '/v1/responses',
-    body: body(i + 1),
-  })).join('\n') + '\n';
-  await writeFile(inputPath, jsonl, 'utf8');
-  const input = await client.files.create({
-    file: createReadStream(inputPath),
-    purpose: 'batch',
-  });
-  let batch = await client.batches.create({
-    input_file_id: input.id,
-    endpoint: '/v1/responses',
-    completion_window: '24h',
-    metadata: { eval: 'photo-select-batch-cache', request_count: String(count) },
-  });
+
+async function settleBatch(client, batchId) {
   const deadline = Date.now() + timeoutMs;
+  let batch = await client.batches.retrieve(batchId);
   while (!['completed', 'failed', 'expired', 'canceled'].includes(batch.status)) {
     if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${batch.id}`);
     await wait(pollMs);
@@ -70,39 +99,106 @@ try {
     throw new Error(`Batch ${batch.id} ended with status ${batch.status}`);
   }
   const text = await (await client.files.content(batch.output_file_id)).text();
-  const usages = text.split(/\r?\n/).filter(Boolean).map((line) => {
-    const row = JSON.parse(line);
-    const responseBody = typeof row.response?.body === 'string'
-      ? JSON.parse(row.response.body)
-      : row.response?.body;
-    const usage = responseBody?.usage || {};
-    const details = usage.input_tokens_details || {};
-    return {
-      custom_id: row.custom_id,
-      status_code: row.response?.status_code,
-      input_tokens: usage.input_tokens || 0,
-      cached_tokens: details.cached_tokens || 0,
-      cache_write_tokens: details.cache_write_tokens || 0,
-      output_tokens: usage.output_tokens || 0,
-    };
+  return {
+    batch,
+    usages: text.split(/\r?\n/).filter(Boolean).map((line) =>
+      usageFromRow(JSON.parse(line))
+    ),
+  };
+}
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const tempDir = await mkdtemp(path.join(os.tmpdir(), 'photo-select-cache-eval-'));
+const remoteFileIds = new Set();
+try {
+  const provider = new OpenAIBatchProvider({
+    client,
+    enableFallback: false,
+    pollIntervalMs: pollMs,
+    aggregationWindowMs: aggregationMs,
+    helpers,
   });
+  const handles = await Promise.all(Array.from({ length: count }, (_, i) =>
+    provider.submit({
+      levelDir: tempDir,
+      prompt: `${prefix} Synthetic request ${i + 1}.`,
+      promptCachePrefix: prefix,
+      images: [],
+      model,
+      reasoningEffort: 'low',
+      verbosity: 'low',
+      minutesMin: 0,
+      minutesMax: 0,
+    })
+  ));
+
+  const inputDir = path.join(tempDir, '.batch', 'inputs');
+  const inputFiles = await readdir(inputDir);
+  const inputRowCounts = await Promise.all(inputFiles.map(async (file) =>
+    (await readFile(path.join(inputDir, file), 'utf8'))
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .length
+  ));
+  const batchIds = [...new Set(handles.map((handle) => handle.batchId))];
+  const settled = await Promise.all(batchIds.map((batchId) =>
+    settleBatch(client, batchId)
+  ));
+  for (const { batch } of settled) {
+    if (batch.input_file_id) remoteFileIds.add(batch.input_file_id);
+    if (batch.output_file_id) remoteFileIds.add(batch.output_file_id);
+    if (batch.error_file_id) remoteFileIds.add(batch.error_file_id);
+  }
+  const usages = settled.flatMap((entry) => entry.usages);
   const totals = usages.reduce((sum, usage) => {
-    for (const key of ['input_tokens', 'cached_tokens', 'cache_write_tokens', 'output_tokens']) {
+    for (const key of [
+      'input_tokens',
+      'cached_tokens',
+      'cache_write_tokens',
+      'output_tokens',
+    ]) {
       sum[key] += usage[key];
     }
     sum.cache_hit_requests += Number(usage.cached_tokens > 0);
     sum.cache_write_requests += Number(usage.cache_write_tokens > 0);
     return sum;
-  }, { input_tokens: 0, cached_tokens: 0, cache_write_tokens: 0,
-    output_tokens: 0, cache_hit_requests: 0, cache_write_requests: 0 });
-  const passed = usages.length === count &&
+  }, {
+    input_tokens: 0,
+    cached_tokens: 0,
+    cache_write_tokens: 0,
+    output_tokens: 0,
+    cache_hit_requests: 0,
+    cache_write_requests: 0,
+  });
+  const topologyPassed = inputFiles.length === 1 &&
+    inputRowCounts.length === 1 && inputRowCounts[0] === count &&
+    batchIds.length === 1;
+  const cachePassed = usages.length === count &&
     usages.every((usage) => usage.status_code === 200) &&
-    totals.cache_write_requests === 1 && totals.cache_hit_requests === count - 1 &&
+    totals.cache_write_requests === 1 &&
+    totals.cache_hit_requests === count - 1 &&
     totals.cached_tokens > totals.cache_write_tokens;
-  console.log(JSON.stringify({ eval: 'grouped_batch_explicit_prompt_cache', model,
-    batch_id: batch.id, request_count: count, passed, totals,
-    cache_hit_rate: totals.cache_hit_requests / count, usages }, null, 2));
+  const passed = topologyPassed && cachePassed;
+  console.log(JSON.stringify({
+    eval: 'provider_staggered_grouped_batch_explicit_prompt_cache',
+    model,
+    request_count: count,
+    aggregation_ms: aggregationMs,
+    preparation_stagger_ms: staggerMs,
+    batch_count: batchIds.length,
+    input_file_count: inputFiles.length,
+    input_row_counts: inputRowCounts,
+    topology_passed: topologyPassed,
+    cache_passed: cachePassed,
+    passed,
+    totals,
+    cache_hit_rate: totals.cache_hit_requests / count,
+    usages,
+  }, null, 2));
   if (!passed) process.exitCode = 1;
 } finally {
+  await Promise.all([...remoteFileIds].map((id) =>
+    client.files.del(id).catch(() => undefined)
+  ));
   await rm(tempDir, { recursive: true, force: true });
 }

--- a/src/providers/openai-batch.js
+++ b/src/providers/openai-batch.js
@@ -302,46 +302,50 @@ export default class OpenAIBatchProvider {
     if (reasoningEffort && !ALLOWED_REASONING_EFFORT.has(reasoningEffort)) {
       throw new Error(`invalid reasoningEffort: ${reasoningEffort}`);
     }
-    const dirs = await ensureDirs(levelDir);
-    const responsesRequest = await this.#buildResponsesRequest({
-      prompt,
-      promptCachePrefix,
-      images,
-      curators,
-      model,
-      minutesMin,
-      minutesMax,
-      reasoningEffort,
-      verbosity,
-      baseCuratorCount,
-      dynamicCuratorCount,
-    });
-    const customId = computeCustomId({
-      levelDir,
-      prompt,
-      model,
-      curators,
-      used: responsesRequest.used,
-      minutesMin,
-      minutesMax,
-      reasoningEffort,
-      verbosity,
-    });
-    const safe = safeId(customId);
-
     return this.#enqueueSubmission({
-      dirs,
-      customId,
-      safe,
       levelDir,
-      prompt,
-      images,
-      curators,
       model,
-      minutesMin,
-      minutesMax,
-      verbosity,
-      responsesRequest,
+      prepare: async () => {
+        const dirs = await ensureDirs(levelDir);
+        const responsesRequest = await this.#buildResponsesRequest({
+          prompt,
+          promptCachePrefix,
+          images,
+          curators,
+          model,
+          minutesMin,
+          minutesMax,
+          reasoningEffort,
+          verbosity,
+          baseCuratorCount,
+          dynamicCuratorCount,
+        });
+        const customId = computeCustomId({
+          levelDir,
+          prompt,
+          model,
+          curators,
+          used: responsesRequest.used,
+          minutesMin,
+          minutesMax,
+          reasoningEffort,
+          verbosity,
+        });
+        return {
+          dirs,
+          customId,
+          safe: safeId(customId),
+          levelDir,
+          prompt,
+          images,
+          curators,
+          model,
+          minutesMin,
+          minutesMax,
+          verbosity,
+          responsesRequest,
+        };
+      },
     });
   }
 
@@ -371,8 +375,22 @@ export default class OpenAIBatchProvider {
     const group = this.pendingSubmissionGroups.get(groupKey);
     if (!group) return;
     this.pendingSubmissionGroups.delete(groupKey);
+    let items = [];
     try {
-      const prepared = group.items.map((item) => ({
+      items = (await Promise.all(group.items.map(async (queued) => {
+        try {
+          return {
+            ...await queued.prepare(),
+            resolve: queued.resolve,
+            reject: queued.reject,
+          };
+        } catch (err) {
+          queued.reject(err);
+          return null;
+        }
+      }))).filter(Boolean);
+      if (items.length === 0) return;
+      const partitionable = items.map((item) => ({
         ...item,
         id: item.customId,
         jsonl: JSON.stringify({
@@ -382,7 +400,7 @@ export default class OpenAIBatchProvider {
           body: item.responsesRequest.body,
         }) + '\n',
       }));
-      const partitions = partitionBatchItems(prepared, {
+      const partitions = partitionBatchItems(partitionable, {
         maxRequests: this.maxBatchRequests,
         maxBytes: this.maxBatchInputBytes,
       });
@@ -390,9 +408,9 @@ export default class OpenAIBatchProvider {
       for (const partition of partitions) {
         handles.push(...await this.#submitPreparedGroup(partition));
       }
-      group.items.forEach((item, index) => item.resolve(handles[index]));
+      items.forEach((item, index) => item.resolve(handles[index]));
     } catch (err) {
-      group.items.forEach((item) => item.reject(err));
+      items.forEach((item) => item.reject(err));
     }
   }
 

--- a/tests/openaiBatchProvider.test.js
+++ b/tests/openaiBatchProvider.test.js
@@ -154,6 +154,92 @@ describe('OpenAIBatchProvider', () => {
     );
   });
 
+  it('coalesces worker submissions before staggered request preparation can split the Batch', async () => {
+    const immediateBuildInput = helpers.buildInput;
+    helpers.buildInput = vi.fn(async (prompt, images, curators) => {
+      if (path.basename(images[0]) === 'slow.jpg') {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      return immediateBuildInput(prompt, images, curators);
+    });
+    const provider = new OpenAIBatchProvider({
+      client,
+      enableFallback: false,
+      helpers,
+      aggregationWindowMs: 10,
+    });
+    const fastImage = path.join(tmpDir, 'fast.jpg');
+    const slowImage = path.join(tmpDir, 'slow.jpg');
+    await Promise.all([
+      fs.writeFile(fastImage, 'fast'),
+      fs.writeFile(slowImage, 'slow'),
+    ]);
+
+    await Promise.all([
+      provider.submit({
+        levelDir: tmpDir,
+        prompt: 'stable context\nreview fast.jpg',
+        images: [fastImage],
+        model: 'gpt-5.6-terra',
+      }),
+      provider.submit({
+        levelDir: tmpDir,
+        prompt: 'stable context\nreview slow.jpg',
+        images: [slowImage],
+        model: 'gpt-5.6-terra',
+      }),
+    ]);
+
+    const inputsDir = path.join(tmpDir, '.batch', 'inputs');
+    const inputFiles = await fs.readdir(inputsDir);
+    expect(inputFiles).toHaveLength(1);
+    const lines = (await fs.readFile(path.join(inputsDir, inputFiles[0]), 'utf8'))
+      .trim()
+      .split('\n');
+    expect(lines).toHaveLength(2);
+  });
+
+  it('keeps valid cohort members grouped when one request cannot be prepared', async () => {
+    const immediateBuildInput = helpers.buildInput;
+    helpers.buildInput = vi.fn(async (prompt, images, curators) => {
+      if (path.basename(images[0]) === 'broken.jpg') {
+        throw new Error('synthetic preparation failure');
+      }
+      return immediateBuildInput(prompt, images, curators);
+    });
+    const provider = new OpenAIBatchProvider({
+      client,
+      enableFallback: false,
+      helpers,
+      aggregationWindowMs: 10,
+    });
+    const imagePaths = ['first.jpg', 'broken.jpg', 'third.jpg']
+      .map((name) => path.join(tmpDir, name));
+    await Promise.all(imagePaths.map((file) => fs.writeFile(file, 'data')));
+
+    const results = await Promise.allSettled(imagePaths.map((file) =>
+      provider.submit({
+        levelDir: tmpDir,
+        prompt: `stable context\nreview ${path.basename(file)}`,
+        images: [file],
+        model: 'gpt-5.6-terra',
+      })
+    ));
+
+    expect(results.map((result) => result.status)).toEqual([
+      'fulfilled',
+      'rejected',
+      'fulfilled',
+    ]);
+    const inputsDir = path.join(tmpDir, '.batch', 'inputs');
+    const inputFiles = await fs.readdir(inputsDir);
+    expect(inputFiles).toHaveLength(1);
+    const lines = (await fs.readFile(path.join(inputsDir, inputFiles[0]), 'utf8'))
+      .trim()
+      .split('\n');
+    expect(lines).toHaveLength(2);
+  });
+
   it('splits an aggregate before the configured Batch request limit', async () => {
     const provider = new OpenAIBatchProvider({
       client,


### PR DESCRIPTION
## Summary

- enqueue compatible OpenAI Batch submissions before expensive per-request preparation begins
- prepare the captured cohort concurrently, while rejecting an individual preparation failure without dissolving the valid group
- make the paid prompt-cache eval traverse the real provider path with preparation staggered beyond the aggregation window
- add a dedicated `evals:batch-aggregation` command and two provider regressions

This does not change CLI flags, prompt text, context length, output schemas, the recursive stop rule, or repeated-person curator behavior.

## Root cause

The production executable at the prior base prepared each request before it entered the one-second aggregation queue. Image/request preparation completed at staggered times outside that window, so workers created separate one-line Batch input files.

Observed on the stopped collection run:

- 193 requests
- 193 one-line JSONL input files
- 0 grouped input files
- 186 completed requests
- 0 cache-hit requests
- 186 cache-write requests
- 20,619,581 cache-write tokens

The earlier paid eval manually assembled a six-row JSONL file. It proved the OpenAI platform could cache the prefix, but bypassed the provider code that was failing in production.

## TDD and hill climb

The first regression delayed one request's preparation beyond the aggregation window. Before the repair it observed two input files instead of one.

A second adversarial test injected one preparation failure into a three-request cohort. Before failure isolation, all three submissions rejected; after the repair, the two valid submissions remain grouped and only the invalid submission rejects.

## Verification

- `npm test -- --reporter=dot` — 21 files, 135 tests passed
- `npm run evals:batch-aggregation -- --reporter=dot` — 2 files, 14 tests passed
- `npm run evals:stop-rule -- --reporter=dot` — 2 files, 27 tests passed
- prompt cache, prompt curator, and repeated-person tests — 3 files, 7 tests passed
- syntax checks for the provider and paid eval passed
- `git diff --check` passed
- changed-file TODO scan found no TODOs

### Live synthetic OpenAI Batch canary

The repaired evaluator used six synthetic requests, no photos, no curator names, and no collection brief:

- 1 input file containing 6 rows
- 1 Batch job
- 6/6 HTTP 200 responses
- 1 cache-write request / 6,243 cache-write tokens
- 5 cache-hit requests / 31,215 cached tokens
- 83.3% cache-hit request rate
- evaluator result: `passed: true`

The evaluator deletes its remote input/output/error files after completion.

OpenAI documents that Batch inputs may contain multiple request rows and that prompt-cache metrics are reported as `cached_tokens` and `cache_write_tokens`: [Batch guide](https://developers.openai.com/api/docs/guides/batch), [Prompt caching guide](https://developers.openai.com/api/docs/guides/prompt-caching).

## Change-size warning

This change is 306 additions and 105 deletions (411 changed lines). That crosses the repository contract's 300-line warning threshold but remains below the >500-line `--mechanical` threshold.

## Operational gate

This PR does not resume or reconcile the stopped collection run. The repaired branch should be merged/deployed and the outstanding Batch jobs reconciled before the collection is resumed.
