### PR TITLE
repair caching pt2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "photo-select",
     "test": "vitest run",
     "evals:prompt-cache": "node scripts/eval-prompt-cache.mjs",
-    "evals:batch-aggregation": "vitest run tests/batchAggregation.test.js tests/openaiBatchProvider.test.js",
+    "evals:batch-aggregation": "vitest run tests/batchAggregation.test.js tests/openaiBatchProvider.test.js tests/orchestratorBatchAggregation.test.js",
     "evals:batch-prompt-cache": "node scripts/eval-batch-prompt-cache.mjs",
     "evals:stop-rule": "vitest run tests/evaluateLevelOutcome.test.js tests/orchestrator.test.js",
     "undici:smoke": "node scripts/undici-smoke.mjs",

--- a/scripts/eval-batch-prompt-cache.mjs
+++ b/scripts/eval-batch-prompt-cache.mjs
@@ -44,8 +44,6 @@ const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const helpers = {
   async buildInput(prompt) {
-    const index = Number(prompt.match(/Synthetic request (\d+)/)?.[1] || 1);
-    await wait((index - 1) * staggerMs);
     return {
       instructions: prompt,
       input: [{
@@ -121,14 +119,19 @@ try {
   const handles = await Promise.all(Array.from({ length: count }, (_, i) =>
     provider.submit({
       levelDir: tempDir,
-      prompt: `${prefix} Synthetic request ${i + 1}.`,
-      promptCachePrefix: prefix,
-      images: [],
       model,
-      reasoningEffort: 'low',
-      verbosity: 'low',
-      minutesMin: 0,
-      minutesMax: 0,
+      prepare: async () => {
+        await wait(i * staggerMs);
+        return {
+          prompt: `${prefix} Synthetic request ${i + 1}.`,
+          promptCachePrefix: prefix,
+          images: [],
+          reasoningEffort: 'low',
+          verbosity: 'low',
+          minutesMin: 0,
+          minutesMax: 0,
+        };
+      },
     })
   ));
 
@@ -180,7 +183,7 @@ try {
     totals.cached_tokens > totals.cache_write_tokens;
   const passed = topologyPassed && cachePassed;
   console.log(JSON.stringify({
-    eval: 'provider_staggered_grouped_batch_explicit_prompt_cache',
+    eval: 'provider_deferred_preparation_grouped_batch_explicit_prompt_cache',
     model,
     request_count: count,
     aggregation_ms: aggregationMs,

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -716,47 +716,56 @@ export async function triageDirectory(options) {
                   }
                 };
 
-                const names = batch.map((file) => path.basename(file));
-                const peopleLists = await Promise.all(
-                  names.map((name) => getPeople(name))
-                );
-                const photos = names.map((name, i) => ({
-                  file: name,
-                  people: sanitizePeople(peopleLists[i]),
-                }));
-                const { finalCurators, added } = finalizeCurators(curators, photos);
-                if (added.length) {
-                  log(
-                    `👥  Batch ${idx} additional curators from tags: ${added.join(', ')}`
-                  );
-                }
-                const first = await buildPrompt(promptPath, {
-                  curators: finalCurators,
-                  contextPath,
-                  images: batch,
-                  hasFieldNotes: false,
-                  isSecondPass: false,
-                });
                 const meta = { model, verbosity, reasoningEffort };
                 let attemptNum = 1;
-                await saveText('prompt', attemptNum, first.prompt);
-                const firstResult = await runSession({
-                  prompt: first.prompt,
-                  promptCachePrefix: first.promptCachePrefix,
-                  images: batch,
-                  model,
-                  curators: finalCurators,
-                  baseCuratorCount: curators.length,
-                  dynamicCuratorCount: added.length,
-                  verbosity,
-                  reasoningEffort,
-                  minutesMin: first.minutesMin,
-                  minutesMax: first.minutesMax,
-                  onProgress: (stage) => {
-                    bar.update(stageMap[stage] || 0, { stage });
-                  },
-                  stream: true,
-                });
+                let finalCurators = curators;
+                let added = [];
+                const prepareFirstRequest = async () => {
+                  const names = batch.map((file) => path.basename(file));
+                  const peopleLists = await Promise.all(
+                    names.map((name) => getPeople(name))
+                  );
+                  const photos = names.map((name, i) => ({
+                    file: name,
+                    people: sanitizePeople(peopleLists[i]),
+                  }));
+                  const finalized = finalizeCurators(curators, photos);
+                  finalCurators = finalized.finalCurators;
+                  added = finalized.added;
+                  if (added.length) {
+                    log(
+                      `👥  Batch ${idx} additional curators from tags: ${added.join(', ')}`
+                    );
+                  }
+                  const first = await buildPrompt(promptPath, {
+                    curators: finalCurators,
+                    contextPath,
+                    images: batch,
+                    hasFieldNotes: false,
+                    isSecondPass: false,
+                  });
+                  await saveText('prompt', attemptNum, first.prompt);
+                  return {
+                    prompt: first.prompt,
+                    promptCachePrefix: first.promptCachePrefix,
+                    images: batch,
+                    model,
+                    curators: finalCurators,
+                    baseCuratorCount: curators.length,
+                    dynamicCuratorCount: added.length,
+                    verbosity,
+                    reasoningEffort,
+                    minutesMin: first.minutesMin,
+                    minutesMax: first.minutesMax,
+                    onProgress: (stage) => {
+                      bar.update(stageMap[stage] || 0, { stage });
+                    },
+                    stream: true,
+                  };
+                };
+                const firstResult = provider.supportsDeferredPreparation
+                  ? await runSession({ model, prepare: prepareFirstRequest })
+                  : await runSession(await prepareFirstRequest());
                 reply = firstResult.raw;
                 await saveText('response', attemptNum, reply);
                 if (looksLikeOpenAIResponseEnvelope(reply)) {

--- a/src/providers/openai-batch.js
+++ b/src/providers/openai-batch.js
@@ -1,6 +1,7 @@
 import { OpenAI } from 'openai';
 import { mkdir, writeFile, appendFile, readFile } from 'node:fs/promises';
 import { createReadStream } from 'node:fs';
+import { AsyncResource } from 'node:async_hooks';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import { buildInput, buildMessages, schemaForBatch } from '../chatClient.js';
@@ -255,6 +256,7 @@ async function streamToText(resp) {
 export default class OpenAIBatchProvider {
   name = 'openai-batch';
   supportsAsync = true;
+  supportsDeferredPreparation = true;
 
   constructor({
     client,
@@ -286,67 +288,82 @@ export default class OpenAIBatchProvider {
   async submit(options = {}) {
     const {
       levelDir,
-      prompt,
-      promptCachePrefix,
-      images = [],
-      curators = [],
-      baseCuratorCount = curators.length,
-      dynamicCuratorCount,
       model = 'gpt-5',
-      minutesMin = 3,
-      minutesMax = 12,
       reasoningEffort,
-      verbosity = 'low',
     } = options;
     if (!levelDir) throw new Error('levelDir is required for openai-batch provider');
     if (reasoningEffort && !ALLOWED_REASONING_EFFORT.has(reasoningEffort)) {
       throw new Error(`invalid reasoningEffort: ${reasoningEffort}`);
     }
-    return this.#enqueueSubmission({
-      levelDir,
-      model,
-      prepare: async () => {
-        const dirs = await ensureDirs(levelDir);
-        const responsesRequest = await this.#buildResponsesRequest({
-          prompt,
-          promptCachePrefix,
-          images,
-          curators,
-          model,
-          minutesMin,
-          minutesMax,
-          reasoningEffort,
-          verbosity,
-          baseCuratorCount,
-          dynamicCuratorCount,
-        });
-        const customId = computeCustomId({
-          levelDir,
-          prompt,
-          model,
-          curators,
-          used: responsesRequest.used,
-          minutesMin,
-          minutesMax,
-          reasoningEffort,
-          verbosity,
-        });
-        return {
-          dirs,
-          customId,
-          safe: safeId(customId),
-          levelDir,
-          prompt,
-          images,
-          curators,
-          model,
-          minutesMin,
-          minutesMax,
-          verbosity,
-          responsesRequest,
-        };
-      },
+    const prepare = AsyncResource.bind(async () => {
+      const deferred = typeof options.prepare === 'function'
+        ? await options.prepare()
+        : {};
+      const preparedOptions = {
+        ...options,
+        ...(deferred || {}),
+        levelDir,
+        model,
+      };
+      const {
+        prompt,
+        promptCachePrefix,
+        images = [],
+        curators = [],
+        baseCuratorCount = curators.length,
+        dynamicCuratorCount,
+        minutesMin = 3,
+        minutesMax = 12,
+        reasoningEffort: preparedReasoningEffort,
+        verbosity = 'low',
+      } = preparedOptions;
+      if (
+        preparedReasoningEffort &&
+        !ALLOWED_REASONING_EFFORT.has(preparedReasoningEffort)
+      ) {
+        throw new Error(`invalid reasoningEffort: ${preparedReasoningEffort}`);
+      }
+      const dirs = await ensureDirs(levelDir);
+      const responsesRequest = await this.#buildResponsesRequest({
+        prompt,
+        promptCachePrefix,
+        images,
+        curators,
+        model,
+        minutesMin,
+        minutesMax,
+        reasoningEffort: preparedReasoningEffort,
+        verbosity,
+        baseCuratorCount,
+        dynamicCuratorCount,
+      });
+      const customId = computeCustomId({
+        levelDir,
+        prompt,
+        model,
+        curators,
+        used: responsesRequest.used,
+        minutesMin,
+        minutesMax,
+        reasoningEffort: preparedReasoningEffort,
+        verbosity,
+      });
+      return {
+        dirs,
+        customId,
+        safe: safeId(customId),
+        levelDir,
+        prompt,
+        images,
+        curators,
+        model,
+        minutesMin,
+        minutesMax,
+        verbosity,
+        responsesRequest,
+      };
     });
+    return this.#enqueueSubmission({ levelDir, model, prepare });
   }
 
   #enqueueSubmission(item) {

--- a/tests/orchestratorBatchAggregation.test.js
+++ b/tests/orchestratorBatchAggregation.test.js
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY = 'test';
+});
+
+vi.mock('../src/chatClient.js', async () => {
+  const actual = await vi.importActual('../src/chatClient.js');
+  return {
+    ...actual,
+    getPeople: vi.fn().mockResolvedValue([]),
+  };
+});
+
+import { getPeople } from '../src/chatClient.js';
+import { batchStore } from '../src/batchContext.js';
+import { triageDirectory } from '../src/orchestrator.js';
+import OpenAIBatchProvider from '../src/providers/openai-batch.js';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('orchestrator Batch aggregation', () => {
+  let tmpDir;
+  let promptFile;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ps-orchestrator-batch-'));
+    promptFile = path.join(tmpDir, 'prompt.txt');
+    await fs.writeFile(
+      promptFile,
+      'Curators: {{curators}}\nReview exactly these files:\n{{images}}'
+    );
+    await Promise.all(Array.from({ length: 11 }, (_, index) =>
+      fs.writeFile(path.join(tmpDir, `${index + 1}.jpg`), 'image')
+    ));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('coalesces active workers before delayed people lookup reaches the provider', async () => {
+    let peopleCall = 0;
+    getPeople.mockImplementation(async () => {
+      peopleCall += 1;
+      if (peopleCall === 1) await wait(100);
+      return ['Alice'];
+    });
+
+    let fileId = 0;
+    let batchId = 0;
+    const preparationContexts = [];
+    const client = {
+      files: {
+        create: vi.fn(async () => ({ id: `file_${++fileId}` })),
+      },
+      batches: {
+        create: vi.fn(async () => ({
+          id: `batch_${++batchId}`,
+          status: 'validating',
+        })),
+      },
+    };
+    const provider = new OpenAIBatchProvider({
+      client,
+      enableFallback: false,
+      aggregationWindowMs: 10,
+      helpers: {
+        buildInput: async (prompt, images) => {
+          preparationContexts.push(batchStore.getStore()?.batch);
+          return {
+            instructions: prompt,
+            input: [{ role: 'user', content: [] }],
+            used: images,
+          };
+        },
+        schemaForBatch: () => ({
+          name: 'PhotoSelectOrchestratorAggregation',
+          schema: { type: 'object', properties: {} },
+        }),
+      },
+    });
+    vi.spyOn(provider, 'collect').mockImplementation(async (handle) => {
+      const json = {
+        minutes: [],
+        decisions: handle.used.map((file) => ({
+          filename: path.basename(file),
+          decision: 'keep',
+          reason: '',
+        })),
+      };
+      return { raw: JSON.stringify(json), json };
+    });
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      provider,
+      model: 'gpt-5.6-terra',
+      workers: 2,
+      recurse: false,
+      curators: ['Base Curator'],
+    });
+
+    const inputDir = path.join(tmpDir, '_level-001', '.batch', 'inputs');
+    const inputFiles = await fs.readdir(inputDir);
+    expect(inputFiles).toHaveLength(1);
+    const rows = (await fs.readFile(path.join(inputDir, inputFiles[0]), 'utf8'))
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(rows).toHaveLength(2);
+    expect(preparationContexts.sort((a, b) => a - b)).toEqual([1, 2]);
+    expect(rows.some((row) =>
+      row.body.instructions?.includes('Curators: Base Curator, Alice')
+    )).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- enroll active OpenAI Batch workers before per-batch people lookup, prompt rendering, and image request preparation
- defer that preparation inside the provider's captured cohort while preserving each worker's async batch context
- extend the aggregation eval to cover the real orchestration boundary and update the paid synthetic cache canary

## Root cause

The first caching repair aggregated calls that had already reached `OpenAIBatchProvider.submit()`. In the real CLI path, each worker first awaited people-tag lookup and prompt construction. Production workers reached the provider roughly 20 seconds apart, outside the 1-second aggregation window, so every JSONL file contained one row.

A red integration regression reproduced this with two workers, eleven synthetic image names, a 100 ms first people lookup, and a 10 ms provider window:

- before: 2 input files with 1 row each
- expected: 1 input file with 2 rows

The repair lets the Batch provider advertise deferred preparation. Batch workers now join the cohort immediately; the provider then prepares their independent request rows concurrently. `AsyncResource.bind` retains the originating batch context for request-specific image/prompt preparation.

## User-visible behavior

Unchanged:

- CLI flags and command shape
- prompt template text and ordering
- context brief contents and length; no truncation was introduced
- output schema and decisions
- recursive unanimous keep/aside stopping rule
- repeated people-tag curator promotion
- non-Batch providers, which retain eager preparation

Only OpenAI Batch request scheduling changes.

## Verification

- `npm test -- --reporter=dot`: 22 files, 136/136 tests passed
- `npm run evals:batch-aggregation -- --reporter=dot`: 3 files, 15/15 tests passed
- syntax checks and `git diff --check`: passed
- live synthetic `gpt-5.6-terra` Batch canary:
  - 1 Batch
  - 1 JSONL input file
  - 6 request rows
  - 6 HTTP 200 responses
  - 1 cache writer / 5 cache readers
  - 6,243 cache-write tokens
  - 31,215 cached tokens
  - 83.3% request-level cache-hit rate
  - evaluator result: passed

The canary used synthetic text only—no photos, people, filenames, or collection brief.

This follows OpenAI's current [Batch JSONL guidance](https://developers.openai.com/api/docs/guides/batch) and [GPT-5.6 prompt caching guidance](https://developers.openai.com/api/docs/guides/prompt-caching).

## Production evidence

The real pre-pt2 restart generated one-row input files and reported cache writes without cache hits. At the last bounded trace, 11 completed requests had written 1,220,816 cache tokens and read 0 cached tokens.

The old real process was still running from the earlier checkout when this PR was prepared. This branch does not alter an already-running process; it must be merged and checked out before a new/resumed job can use the repair.

## Change-set contract

357 changed lines (254 additions, 103 deletions), triggering the repository's >=300-line warning. The largest addition is the 122-line orchestration regression; the remaining change moves existing preparation logic behind the deferred boundary.