### PR TITLE
repair caching pt3

### DIFF
--- a/scripts/eval-batch-prompt-cache.mjs
+++ b/scripts/eval-batch-prompt-cache.mjs
@@ -17,8 +17,12 @@ const { default: OpenAIBatchProvider } = await import(
 const model = process.env.PHOTO_SELECT_CACHE_EVAL_MODEL || 'gpt-5.6-terra';
 const count = Math.min(15, Math.max(
   2,
-  Number(process.env.PHOTO_SELECT_CACHE_EVAL_REQUESTS || 6)
+  Number(process.env.PHOTO_SELECT_CACHE_EVAL_REQUESTS || 4)
 ));
+const prefixRepetitions = Math.max(
+  300,
+  Number(process.env.PHOTO_SELECT_CACHE_EVAL_PREFIX_REPETITIONS || 2700)
+);
 const pollMs = Math.max(
   1000,
   Number(process.env.PHOTO_SELECT_CACHE_EVAL_POLL_MS || 5000)
@@ -36,10 +40,10 @@ const staggerMs = Math.max(
   Number(process.env.PHOTO_SELECT_CACHE_EVAL_STAGGER_MS || 150)
 );
 const prefix = (
-  'Photo-select provider Batch prompt-cache evaluation, version 2. ' +
+  'Photo-select provider Batch prompt-cache evaluation, version 3. ' +
   'This synthetic context contains no image or archive data. ' +
   'Preserve it exactly as the stable developer prefix. '
-).repeat(200) + ` Run ${Date.now()}.`;
+).repeat(prefixRepetitions) + ` Run ${Date.now()}.`;
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const helpers = {
@@ -173,9 +177,13 @@ try {
     cache_hit_requests: 0,
     cache_write_requests: 0,
   });
-  const topologyPassed = inputFiles.length === 1 &&
-    inputRowCounts.length === 1 && inputRowCounts[0] === count &&
-    batchIds.length === 1;
+  const expectedRowCounts = [1, count - 1].sort((a, b) => a - b);
+  const topologyPassed = inputFiles.length === 2 &&
+    inputRowCounts.length === 2 &&
+    inputRowCounts.slice().sort((a, b) => a - b).every(
+      (rows, index) => rows === expectedRowCounts[index]
+    ) &&
+    batchIds.length === 2;
   const cachePassed = usages.length === count &&
     usages.every((usage) => usage.status_code === 200) &&
     totals.cache_write_requests === 1 &&
@@ -183,9 +191,10 @@ try {
     totals.cached_tokens > totals.cache_write_tokens;
   const passed = topologyPassed && cachePassed;
   console.log(JSON.stringify({
-    eval: 'provider_deferred_preparation_grouped_batch_explicit_prompt_cache',
+    eval: 'provider_seeded_deferred_preparation_explicit_prompt_cache',
     model,
     request_count: count,
+    stable_prefix_chars: prefix.length,
     aggregation_ms: aggregationMs,
     preparation_stagger_ms: staggerMs,
     batch_count: batchIds.length,

--- a/src/core/batchAggregation.js
+++ b/src/core/batchAggregation.js
@@ -36,3 +36,22 @@ export function partitionBatchItems(
   if (current.length > 0) partitions.push(current);
   return partitions;
 }
+
+export function planCacheSeededBatches(items, options = {}) {
+  const unseeded = partitionBatchItems(items, options);
+  if (items.length < 2) return { seeded: false, batches: unseeded };
+
+  const promptCacheKey = items[0].promptCacheKey;
+  if (
+    !promptCacheKey ||
+    items.some((item) => item.promptCacheKey !== promptCacheKey)
+  ) {
+    return { seeded: false, batches: unseeded };
+  }
+
+  const [seed, ...readers] = items;
+  return {
+    seeded: true,
+    batches: [[seed], ...partitionBatchItems(readers, options)],
+  };
+}

--- a/src/core/promptCaching.js
+++ b/src/core/promptCaching.js
@@ -3,6 +3,12 @@ import crypto from 'node:crypto';
 const CACHE_KEY_VERSION = 'v1';
 const MIN_CACHE_PREFIX_CHARS = 4096;
 
+export function promptCacheReadyFromUsage(usage = {}) {
+  const details = usage.input_tokens_details || {};
+  return Number(details.cached_tokens || 0) > 0 ||
+    Number(details.cache_write_tokens || 0) > 0;
+}
+
 function isGpt56OrLater(model = '') {
   const match = String(model).match(/^gpt-(\d+)\.(\d+)(?:$|[-.])/i);
   if (!match) return false;

--- a/src/providers/openai-batch.js
+++ b/src/providers/openai-batch.js
@@ -9,10 +9,13 @@ import { buildReplySchema } from '../replySchema.js';
 import { computeMaxOutputTokens, computeOutputBudget, estimateInputTokens } from '../tokenEstimate.js';
 import { delay } from '../config.js';
 import { debugBatch } from '../../scripts/debug-batch.mjs';
-import { buildCacheableResponsesPrompt } from '../core/promptCaching.js';
+import {
+  buildCacheableResponsesPrompt,
+  promptCacheReadyFromUsage,
+} from '../core/promptCaching.js';
 import {
   OPENAI_BATCH_MAX_REQUESTS,
-  partitionBatchItems,
+  planCacheSeededBatches,
 } from '../core/batchAggregation.js';
 
 const DEFAULT_COMPLETION_WINDOW = process.env.PHOTO_SELECT_BATCH_COMPLETION_WINDOW || '24h';
@@ -410,6 +413,9 @@ export default class OpenAIBatchProvider {
       const partitionable = items.map((item) => ({
         ...item,
         id: item.customId,
+        promptCacheKey: item.responsesRequest.body.prompt_cache_options?.mode === 'explicit'
+          ? item.responsesRequest.body.prompt_cache_key
+          : undefined,
         jsonl: JSON.stringify({
           custom_id: item.customId,
           method: 'POST',
@@ -417,13 +423,26 @@ export default class OpenAIBatchProvider {
           body: item.responsesRequest.body,
         }) + '\n',
       }));
-      const partitions = partitionBatchItems(partitionable, {
+      const plan = planCacheSeededBatches(partitionable, {
         maxRequests: this.maxBatchRequests,
         maxBytes: this.maxBatchInputBytes,
       });
       const handles = [];
-      for (const partition of partitions) {
-        handles.push(...await this.#submitPreparedGroup(partition));
+      for (const [index, partition] of plan.batches.entries()) {
+        const submitted = await this.#submitPreparedGroup(partition);
+        if (plan.seeded && index === 0) {
+          const completedResult = await this.collect(submitted[0]);
+          if (!promptCacheReadyFromUsage(completedResult.usage)) {
+            const err = new Error(
+              'OpenAI completed the prompt-cache seed without reporting a cache read or write'
+            );
+            err.code = 'PROMPT_CACHE_SEED_NOT_READY';
+            err.usage = completedResult.usage;
+            throw err;
+          }
+          submitted[0].completedResult = completedResult;
+        }
+        handles.push(...submitted);
       }
       items.forEach((item, index) => item.resolve(handles[index]));
     } catch (err) {
@@ -556,6 +575,7 @@ export default class OpenAIBatchProvider {
   }
 
   async collect(handle) {
+    if (handle.completedResult) return handle.completedResult;
     let lastStatus = null;
     const dirs = await ensureDirs(handle.levelDir);
     const ticketPath = path.join(dirs.tickets, `${handle.safeId}.ticket.json`);

--- a/tests/batchAggregation.test.js
+++ b/tests/batchAggregation.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { partitionBatchItems } from '../src/core/batchAggregation.js';
+import {
+  partitionBatchItems,
+  planCacheSeededBatches,
+} from '../src/core/batchAggregation.js';
 
 describe('partitionBatchItems', () => {
   it('preserves order while enforcing request-count and byte limits', () => {
@@ -13,5 +16,35 @@ describe('partitionBatchItems', () => {
       partitionBatchItems(items, { maxRequests: 2, maxBytes: 10 })
         .map((partition) => partition.map((item) => item.id))
     ).toEqual([['a', 'b'], ['c']]);
+  });
+
+  it('places one compatible cache seed before partitioned readers', () => {
+    const items = [
+      { id: 'a', jsonl: 'aaaa\n', promptCacheKey: 'shared' },
+      { id: 'b', jsonl: 'bbbb\n', promptCacheKey: 'shared' },
+      { id: 'c', jsonl: 'cccc\n', promptCacheKey: 'shared' },
+    ];
+
+    const plan = planCacheSeededBatches(items, {
+      maxRequests: 2,
+      maxBytes: 10,
+    });
+
+    expect(plan.seeded).toBe(true);
+    expect(
+      plan.batches.map((partition) => partition.map((item) => item.id))
+    ).toEqual([['a'], ['b', 'c']]);
+  });
+
+  it('does not seed a cohort containing different cache keys', () => {
+    const plan = planCacheSeededBatches([
+      { id: 'a', jsonl: 'aaaa\n', promptCacheKey: 'first' },
+      { id: 'b', jsonl: 'bbbb\n', promptCacheKey: 'second' },
+    ], { maxRequests: 2, maxBytes: 10 });
+
+    expect(plan.seeded).toBe(false);
+    expect(
+      plan.batches.map((partition) => partition.map((item) => item.id))
+    ).toEqual([['a', 'b']]);
   });
 });

--- a/tests/openaiBatchProvider.test.js
+++ b/tests/openaiBatchProvider.test.js
@@ -154,6 +154,164 @@ describe('OpenAIBatchProvider', () => {
     );
   });
 
+  it('completes one cold-cache seed before submitting compatible readers', async () => {
+    const events = [];
+    let fileSequence = 0;
+    let batchSequence = 0;
+    let seedCustomId;
+    client.files.create.mockImplementation(async () => ({
+      id: `file_${++fileSequence}`,
+    }));
+    client.batches.create.mockImplementation(async ({ metadata }) => {
+      const requestCount = Number(metadata.request_count);
+      events.push(`create:${requestCount}`);
+      if (requestCount === 1) seedCustomId = metadata.custom_id;
+      return { id: `batch_${++batchSequence}`, status: 'validating' };
+    });
+    client.batches.retrieve.mockImplementation(async (batchId) => {
+      events.push(`retrieve:${batchId}`);
+      return {
+        id: batchId,
+        status: 'completed',
+        output_file_id: `out_${batchId}`,
+      };
+    });
+    client.files.content.mockImplementation(async (outputFileId) => {
+      events.push(`content:${outputFileId}`);
+      return {
+        text: async () => JSON.stringify({
+          custom_id: seedCustomId,
+          response: {
+            status_code: 200,
+            body: {
+              id: 'resp_seed',
+              object: 'response',
+              status: 'completed',
+              usage: {
+                input_tokens: 7000,
+                input_tokens_details: {
+                  cached_tokens: 0,
+                  cache_write_tokens: 6000,
+                },
+              },
+              output: [{
+                type: 'message',
+                content: [{
+                  type: 'output_json',
+                  json: { minutes: [], decisions: [] },
+                }],
+              }],
+            },
+          },
+        }) + '\n',
+      };
+    });
+    const provider = new OpenAIBatchProvider({
+      client,
+      enableFallback: false,
+      helpers,
+      aggregationWindowMs: 10,
+      pollIntervalMs: 0,
+    });
+    const stablePrefix = 'Large stable context. '.repeat(300);
+
+    const handles = await Promise.all(['a', 'b', 'c'].map((name) =>
+      provider.submit({
+        levelDir: tmpDir,
+        prompt: `${stablePrefix}Review ${name}.jpg.`,
+        promptCachePrefix: stablePrefix,
+        model: 'gpt-5.6-terra',
+      })
+    ));
+
+    expect(client.batches.create.mock.calls.map(
+      ([request]) => Number(request.metadata.request_count)
+    )).toEqual([1, 2]);
+    expect(events.indexOf('content:out_batch_1')).toBeLessThan(
+      events.indexOf('create:2')
+    );
+    expect(new Set(handles.map((handle) => handle.batchId))).toEqual(
+      new Set(['batch_1', 'batch_2'])
+    );
+    const inputsDir = path.join(tmpDir, '.batch', 'inputs');
+    const rowCounts = await Promise.all((await fs.readdir(inputsDir)).map(
+      async (file) => (await fs.readFile(path.join(inputsDir, file), 'utf8'))
+        .trim()
+        .split('\n')
+        .length
+    ));
+    expect(rowCounts.sort((a, b) => a - b)).toEqual([1, 2]);
+
+    const seedResult = await provider.collect(handles[0]);
+    expect(seedResult.json).toEqual({ minutes: [], decisions: [] });
+    expect(client.batches.retrieve).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not release readers when the seed reports no cache read or write', async () => {
+    let batchSequence = 0;
+    let seedCustomId;
+    client.files.create.mockImplementation(async () => ({ id: 'file_seed' }));
+    client.batches.create.mockImplementation(async ({ metadata }) => {
+      if (metadata.request_count === '1') seedCustomId = metadata.custom_id;
+      return { id: `batch_${++batchSequence}`, status: 'validating' };
+    });
+    client.batches.retrieve.mockImplementation(async (batchId) => ({
+      id: batchId,
+      status: 'completed',
+      output_file_id: `out_${batchId}`,
+    }));
+    client.files.content.mockImplementation(async () => ({
+      text: async () => JSON.stringify({
+        custom_id: seedCustomId,
+        response: {
+          status_code: 200,
+          body: {
+            id: 'resp_without_cache',
+            object: 'response',
+            status: 'completed',
+            usage: {
+              input_tokens: 7000,
+              input_tokens_details: {
+                cached_tokens: 0,
+                cache_write_tokens: 0,
+              },
+            },
+            output: [{
+              type: 'message',
+              content: [{
+                type: 'output_json',
+                json: { minutes: [], decisions: [] },
+              }],
+            }],
+          },
+        },
+      }) + '\n',
+    }));
+    const provider = new OpenAIBatchProvider({
+      client,
+      enableFallback: false,
+      helpers,
+      aggregationWindowMs: 10,
+      pollIntervalMs: 0,
+    });
+    const stablePrefix = 'Large stable context. '.repeat(300);
+
+    const results = await Promise.allSettled(['a', 'b'].map((name) =>
+      provider.submit({
+        levelDir: tmpDir,
+        prompt: `${stablePrefix}Review ${name}.jpg.`,
+        promptCachePrefix: stablePrefix,
+        model: 'gpt-5.6-terra',
+      })
+    ));
+
+    expect(results.map((result) => result.status)).toEqual([
+      'rejected',
+      'rejected',
+    ]);
+    expect(client.batches.create).toHaveBeenCalledTimes(1);
+  });
+
   it('coalesces worker submissions before staggered request preparation can split the Batch', async () => {
     const immediateBuildInput = helpers.buildInput;
     helpers.buildInput = vi.fn(async (prompt, images, curators) => {

--- a/tests/promptCaching.test.js
+++ b/tests/promptCaching.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { buildCacheableResponsesPrompt } from '../src/core/promptCaching.js';
+import {
+  buildCacheableResponsesPrompt,
+  promptCacheReadyFromUsage,
+} from '../src/core/promptCaching.js';
 
 const stable = 'Stable curatorial context. '.repeat(300);
 const input = [
@@ -10,6 +13,19 @@ const input = [
 ];
 
 describe('buildCacheableResponsesPrompt', () => {
+  it('requires a reported cache read or write before releasing readers', () => {
+    expect(promptCacheReadyFromUsage({
+      input_tokens_details: { cached_tokens: 0, cache_write_tokens: 6000 },
+    })).toBe(true);
+    expect(promptCacheReadyFromUsage({
+      input_tokens_details: { cached_tokens: 6000, cache_write_tokens: 0 },
+    })).toBe(true);
+    expect(promptCacheReadyFromUsage({
+      input_tokens_details: { cached_tokens: 0, cache_write_tokens: 0 },
+    })).toBe(false);
+    expect(promptCacheReadyFromUsage()).toBe(false);
+  });
+
   it('marks the stable GPT-5.6 prefix without changing prompt text or user input', () => {
     const dynamic = 'Role play as Curator A. Review a.jpg.';
     const request = buildCacheableResponsesPrompt({


### PR DESCRIPTION
## Summary

Repair the remaining prompt-cache cold-fill race without changing the CLI, prompt text, context handling, schemas, curator behavior, or recursive stop rule.

Compatible Batch requests now use a verified seed-before-readers schedule:

1. submit one cache-compatible request as a one-row Batch;
2. await its completed response;
3. require OpenAI usage to report either `cache_write_tokens > 0` or `cached_tokens > 0`;
4. only then submit the remaining compatible reader rows;
5. fail closed with `PROMPT_CACHE_SEED_NOT_READY` if the seed reports no cache activity.

The total number of model requests is unchanged. The seed result is retained on its handle so collection does not download or parse it twice.

## Root cause and production evidence

The pt2 production run proved that aggregation and the prompt shape were correct, but all compatible rows were released together:

- 13 successful Batch rows
- 0 cached tokens
- 1,442,575 cache-write tokens
- identical `prompt_cache_key`
- identical explicit retention mode and TTL
- identical 444,466-character prefix hash
- dynamic image content after the cache breakpoint

That pattern is consistent with a cold-cache fill race: the approximately 111k-token prefix took long enough to write that every concurrent row began before the first write was available.

## Evals added and hill-climbed

Red-to-green regressions cover:

- a cold cohort is submitted as `[1, N-1]`, never `[N]`;
- reader submission occurs only after the seed output has been collected;
- the seed result is reused rather than collected twice;
- no readers are released when the seed usage reports neither a read nor a write;
- mixed or absent cache keys retain ordinary aggregation;
- pure cache-readiness classification covers reads, writes, zeros, and missing usage;
- the paid Batch cache eval now uses a production-sized stable prefix and asserts one seed Batch plus one reader Batch.

## Verification

Local, final post-canary run:

- `npm test -- --reporter=dot`: 22 files, 141 tests passed
- `npm run evals:stop-rule -- --reporter=dot`: 2 files, 27 tests passed
- `npm run evals:batch-aggregation -- --reporter=dot`: 3 files, 19 tests passed
- prompt/curator compatibility checks: 3 files, 8 tests passed
- `git diff --check`: passed
- syntax checks for all modified source/eval files: passed
- TODO audit of modified files: no TODOs
- change size: 275 insertions, 14 deletions (289 modified lines; below the contract warning threshold)

Bounded live OpenAI Batch canary, synthetic data only:

- model: `gpt-5.6-terra`
- stable prefix: 469,819 characters
- topology: one-row seed Batch, then three-row reader Batch
- all 4 responses: HTTP 200
- writer: 83,743 cache-write tokens
- readers: 3 × 83,743 cached tokens
- total cached tokens: 251,229
- reader cache writes: 0
- cache hit rate: 75% overall / 100% of eligible readers
- result: passed

## Compatibility and contract notes

- No prompt text is changed or truncated.
- No context brief is changed or truncated.
- No CLI flags or defaults change.
- Curators discovered from people appearing across photos continue to be added.
- The unanimous completed-level stop rule is unchanged and its evals pass.
- No cache-key prefix bump is needed because the cached structure/content is unchanged; only request scheduling and usage verification changed.
- The original checkout's unrelated `README.md` modification was not touched.

OpenAI references: [Prompt caching](https://platform.openai.com/docs/guides/prompt-caching) · [Batch API](https://platform.openai.com/docs/guides/batch)
