### PR TITLE
repair caching pt4

### DIFF
--- a/scripts/eval-batch-prompt-cache.mjs
+++ b/scripts/eval-batch-prompt-cache.mjs
@@ -16,12 +16,12 @@ const { default: OpenAIBatchProvider } = await import(
 
 const model = process.env.PHOTO_SELECT_CACHE_EVAL_MODEL || 'gpt-5.6-terra';
 const count = Math.min(15, Math.max(
-  2,
+  3,
   Number(process.env.PHOTO_SELECT_CACHE_EVAL_REQUESTS || 4)
 ));
-const prefixRepetitions = Math.max(
-  300,
-  Number(process.env.PHOTO_SELECT_CACHE_EVAL_PREFIX_REPETITIONS || 2700)
+const targetPrefixChars = Math.max(
+  4096,
+  Number(process.env.PHOTO_SELECT_CACHE_EVAL_PREFIX_CHARS || 444_466)
 );
 const pollMs = Math.max(
   1000,
@@ -39,11 +39,12 @@ const staggerMs = Math.max(
   aggregationMs + 1,
   Number(process.env.PHOTO_SELECT_CACHE_EVAL_STAGGER_MS || 150)
 );
-const prefix = (
-  'Photo-select provider Batch prompt-cache evaluation, version 3. ' +
-  'This synthetic context contains no image or archive data. ' +
-  'Preserve it exactly as the stable developer prefix. '
-).repeat(prefixRepetitions) + ` Run ${Date.now()}.`;
+let prefix = `Photo-select Batch cache evaluation pt4, run ${Date.now()}. `;
+for (let i = 0; prefix.length < targetPrefixChars; i++) {
+  prefix += `Synthetic context line ${String(i).padStart(6, '0')}: ` +
+    'amber bridge cedar delta ember field granite harbor iris juniper.\n';
+}
+prefix = prefix.slice(0, targetPrefixChars);
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const helpers = {
@@ -120,7 +121,7 @@ try {
     aggregationWindowMs: aggregationMs,
     helpers,
   });
-  const handles = await Promise.all(Array.from({ length: count }, (_, i) =>
+  const submissions = await Promise.allSettled(Array.from({ length: count }, (_, i) =>
     provider.submit({
       levelDir: tempDir,
       model,
@@ -138,6 +139,16 @@ try {
       },
     })
   ));
+  const handles = submissions
+    .filter((result) => result.status === 'fulfilled')
+    .map((result) => result.value);
+  const submissionErrors = submissions
+    .filter((result) => result.status === 'rejected')
+    .map((result) => ({
+      code: result.reason?.code,
+      message: result.reason?.message,
+      usage: result.reason?.usage,
+    }));
 
   const inputDir = path.join(tempDir, '.batch', 'inputs');
   const inputFiles = await readdir(inputDir);
@@ -177,21 +188,30 @@ try {
     cache_hit_requests: 0,
     cache_write_requests: 0,
   });
-  const expectedRowCounts = [1, count - 1].sort((a, b) => a - b);
-  const topologyPassed = inputFiles.length === 2 &&
-    inputRowCounts.length === 2 &&
+  const expectedRowCounts = [1, 1, count - 2].sort((a, b) => a - b);
+  const topologyPassed = submissionErrors.length === 0 &&
+    inputFiles.length === 3 &&
+    inputRowCounts.length === 3 &&
     inputRowCounts.slice().sort((a, b) => a - b).every(
       (rows, index) => rows === expectedRowCounts[index]
     ) &&
-    batchIds.length === 2;
-  const cachePassed = usages.length === count &&
+    batchIds.length === 3;
+  const seedUsage = settled[0]?.usages[0];
+  const probeUsage = settled[1]?.usages[0];
+  const readerUsages = settled.slice(2).flatMap((entry) => entry.usages);
+  const cachePassed = submissionErrors.length === 0 &&
+    usages.length === count &&
     usages.every((usage) => usage.status_code === 200) &&
+    seedUsage?.cache_write_tokens > 0 &&
+    probeUsage?.cached_tokens > 0 &&
+    readerUsages.length === count - 2 &&
+    readerUsages.every((usage) => usage.cached_tokens > 0) &&
     totals.cache_write_requests === 1 &&
     totals.cache_hit_requests === count - 1 &&
     totals.cached_tokens > totals.cache_write_tokens;
   const passed = topologyPassed && cachePassed;
   console.log(JSON.stringify({
-    eval: 'provider_seeded_deferred_preparation_explicit_prompt_cache',
+    eval: 'provider_seed_probe_barrier_explicit_prompt_cache_pt4',
     model,
     request_count: count,
     stable_prefix_chars: prefix.length,
@@ -205,10 +225,22 @@ try {
     passed,
     totals,
     cache_hit_rate: totals.cache_hit_requests / count,
+    submission_errors: submissionErrors,
     usages,
   }, null, 2));
   if (!passed) process.exitCode = 1;
 } finally {
+  try {
+    const ticketDir = path.join(tempDir, '.batch', 'tickets');
+    for (const file of await readdir(ticketDir)) {
+      const ticket = JSON.parse(await readFile(path.join(ticketDir, file), 'utf8'));
+      for (const id of [ticket.input_file_id, ticket.output_file_id, ticket.error_file_id]) {
+        if (id) remoteFileIds.add(id);
+      }
+    }
+  } catch {
+    // Submission may fail before ticket creation.
+  }
   await Promise.all([...remoteFileIds].map((id) =>
     client.files.del(id).catch(() => undefined)
   ));

--- a/src/core/batchAggregation.js
+++ b/src/core/batchAggregation.js
@@ -39,7 +39,7 @@ export function partitionBatchItems(
 
 export function planCacheSeededBatches(items, options = {}) {
   const unseeded = partitionBatchItems(items, options);
-  if (items.length < 2) return { seeded: false, batches: unseeded };
+  if (items.length < 3) return { seeded: false, batches: unseeded };
 
   const promptCacheKey = items[0].promptCacheKey;
   if (
@@ -49,9 +49,9 @@ export function planCacheSeededBatches(items, options = {}) {
     return { seeded: false, batches: unseeded };
   }
 
-  const [seed, ...readers] = items;
+  const [seed, probe, ...readers] = items;
   return {
     seeded: true,
-    batches: [[seed], ...partitionBatchItems(readers, options)],
+    batches: [[seed], [probe], ...partitionBatchItems(readers, options)],
   };
 }

--- a/src/core/promptCaching.js
+++ b/src/core/promptCaching.js
@@ -3,10 +3,9 @@ import crypto from 'node:crypto';
 const CACHE_KEY_VERSION = 'v1';
 const MIN_CACHE_PREFIX_CHARS = 4096;
 
-export function promptCacheReadyFromUsage(usage = {}) {
+export function promptCacheHitFromUsage(usage = {}) {
   const details = usage.input_tokens_details || {};
-  return Number(details.cached_tokens || 0) > 0 ||
-    Number(details.cache_write_tokens || 0) > 0;
+  return Number(details.cached_tokens || 0) > 0;
 }
 
 function isGpt56OrLater(model = '') {

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -529,6 +529,10 @@ export async function triageDirectory(options) {
     return wrapped;
   }
 
+  function isPromptCacheSafetyError(err) {
+    return err?.code === "PROMPT_CACHE_PROBE_MISS";
+  }
+
   let dynamicWorkers = workers;
   let consecutiveGatewayErrors = 0;
   function isGatewayError(e) {
@@ -949,6 +953,15 @@ export async function triageDirectory(options) {
                   }
                   log(`${indent}⚠️  Files left unmoved and added to NEEDS_REVIEW (${reason}).`);
                   return;
+                }
+                if (isPromptCacheSafetyError(err)) {
+                  const alreadyAborting = abortProcessing;
+                  abortProcessing = true;
+                  queue.length = 0;
+                  if (!alreadyAborting) {
+                    log(`${indent}🛑  Prompt-cache probe missed; stopping remaining batches to prevent uncached fanout.`);
+                  }
+                  throw err;
                 }
                 if (isBillingLimitError(err) && !abortProcessing) {
                   abortProcessing = true;

--- a/src/providers/openai-batch.js
+++ b/src/providers/openai-batch.js
@@ -11,7 +11,7 @@ import { delay } from '../config.js';
 import { debugBatch } from '../../scripts/debug-batch.mjs';
 import {
   buildCacheableResponsesPrompt,
-  promptCacheReadyFromUsage,
+  promptCacheHitFromUsage,
 } from '../core/promptCaching.js';
 import {
   OPENAI_BATCH_MAX_REQUESTS,
@@ -427,23 +427,42 @@ export default class OpenAIBatchProvider {
         maxRequests: this.maxBatchRequests,
         maxBytes: this.maxBatchInputBytes,
       });
-      const handles = [];
-      for (const [index, partition] of plan.batches.entries()) {
-        const submitted = await this.#submitPreparedGroup(partition);
-        if (plan.seeded && index === 0) {
-          const completedResult = await this.collect(submitted[0]);
-          if (!promptCacheReadyFromUsage(completedResult.usage)) {
-            const err = new Error(
-              'OpenAI completed the prompt-cache seed without reporting a cache read or write'
-            );
-            err.code = 'PROMPT_CACHE_SEED_NOT_READY';
-            err.usage = completedResult.usage;
-            throw err;
-          }
-          submitted[0].completedResult = completedResult;
+      if (!plan.seeded) {
+        const handles = [];
+        for (const partition of plan.batches) {
+          handles.push(...await this.#submitPreparedGroup(partition));
         }
-        handles.push(...submitted);
+        items.forEach((item, index) => item.resolve(handles[index]));
+        return;
       }
+
+      const seedHandles = await this.#submitPreparedGroup(plan.batches[0]);
+      seedHandles[0].completedResult = await this.collect(seedHandles[0]);
+
+      const probeHandles = await this.#submitPreparedGroup(plan.batches[1]);
+      probeHandles[0].completedResult = await this.collect(probeHandles[0]);
+      if (!promptCacheHitFromUsage(probeHandles[0].completedResult.usage)) {
+        const err = new Error(
+          'OpenAI prompt-cache probe completed without reporting cached tokens; reader fanout was stopped'
+        );
+        err.code = 'PROMPT_CACHE_PROBE_MISS';
+        err.usage = probeHandles[0].completedResult.usage;
+        throw err;
+      }
+
+      const readerGroups = [];
+      for (const partition of plan.batches.slice(2)) {
+        readerGroups.push(await this.#submitPreparedGroup(partition));
+      }
+      await Promise.all(readerGroups.map(async (groupHandles) => {
+        groupHandles[0].completedResult = await this.collect(groupHandles[0]);
+      }));
+
+      const handles = [
+        ...seedHandles,
+        ...probeHandles,
+        ...readerGroups.flat(),
+      ];
       items.forEach((item, index) => item.resolve(handles[index]));
     } catch (err) {
       items.forEach((item) => item.reject(err));

--- a/tests/batchAggregation.test.js
+++ b/tests/batchAggregation.test.js
@@ -18,11 +18,12 @@ describe('partitionBatchItems', () => {
     ).toEqual([['a', 'b'], ['c']]);
   });
 
-  it('places one compatible cache seed before partitioned readers', () => {
+  it('places a compatible cache seed and probe before partitioned readers', () => {
     const items = [
       { id: 'a', jsonl: 'aaaa\n', promptCacheKey: 'shared' },
       { id: 'b', jsonl: 'bbbb\n', promptCacheKey: 'shared' },
       { id: 'c', jsonl: 'cccc\n', promptCacheKey: 'shared' },
+      { id: 'd', jsonl: 'dddd\n', promptCacheKey: 'shared' },
     ];
 
     const plan = planCacheSeededBatches(items, {
@@ -33,7 +34,7 @@ describe('partitionBatchItems', () => {
     expect(plan.seeded).toBe(true);
     expect(
       plan.batches.map((partition) => partition.map((item) => item.id))
-    ).toEqual([['a'], ['b', 'c']]);
+    ).toEqual([['a'], ['b'], ['c', 'd']]);
   });
 
   it('does not seed a cohort containing different cache keys', () => {

--- a/tests/openaiBatchProvider.test.js
+++ b/tests/openaiBatchProvider.test.js
@@ -21,6 +21,68 @@ const createClient = () => {
   return { files, batches };
 };
 
+async function installCacheBatchMock(client, usages) {
+  const events = [];
+  const customIdsByFile = new Map();
+  const customIdsByBatch = new Map();
+  let fileSequence = 0;
+  let batchSequence = 0;
+
+  client.files.create.mockImplementation(async ({ file }) => {
+    const fileId = `file_${++fileSequence}`;
+    const rows = (await fs.readFile(file.path, 'utf8'))
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    customIdsByFile.set(fileId, rows.map((row) => row.custom_id));
+    return { id: fileId };
+  });
+  client.batches.create.mockImplementation(async ({ input_file_id, metadata }) => {
+    const batchId = `batch_${++batchSequence}`;
+    customIdsByBatch.set(batchId, customIdsByFile.get(input_file_id));
+    events.push(`create:${metadata.request_count}`);
+    return { id: batchId, status: 'validating' };
+  });
+  client.batches.retrieve.mockImplementation(async (batchId) => {
+    events.push(`retrieve:${batchId}`);
+    return {
+      id: batchId,
+      status: 'completed',
+      output_file_id: `out_${batchId}`,
+    };
+  });
+  client.files.content.mockImplementation(async (outputFileId) => {
+    const batchId = outputFileId.slice('out_'.length);
+    const usage = usages[Number(batchId.slice('batch_'.length)) - 1];
+    events.push(`content:${batchId}`);
+    return {
+      text: async () => customIdsByBatch.get(batchId).map((customId) =>
+        JSON.stringify({
+          custom_id: customId,
+          response: {
+            status_code: 200,
+            body: {
+              id: `resp_${customId}`,
+              object: 'response',
+              status: 'completed',
+              usage,
+              output: [{
+                type: 'message',
+                content: [{
+                  type: 'output_json',
+                  json: { minutes: [], decisions: [] },
+                }],
+              }],
+            },
+          },
+        })
+      ).join('\n') + '\n',
+    };
+  });
+
+  return { events };
+}
+
 describe('OpenAIBatchProvider', () => {
   let tmpDir;
   let client;
@@ -154,58 +216,19 @@ describe('OpenAIBatchProvider', () => {
     );
   });
 
-  it('completes one cold-cache seed before submitting compatible readers', async () => {
-    const events = [];
-    let fileSequence = 0;
-    let batchSequence = 0;
-    let seedCustomId;
-    client.files.create.mockImplementation(async () => ({
-      id: `file_${++fileSequence}`,
-    }));
-    client.batches.create.mockImplementation(async ({ metadata }) => {
-      const requestCount = Number(metadata.request_count);
-      events.push(`create:${requestCount}`);
-      if (requestCount === 1) seedCustomId = metadata.custom_id;
-      return { id: `batch_${++batchSequence}`, status: 'validating' };
-    });
-    client.batches.retrieve.mockImplementation(async (batchId) => {
-      events.push(`retrieve:${batchId}`);
-      return {
-        id: batchId,
-        status: 'completed',
-        output_file_id: `out_${batchId}`,
-      };
-    });
-    client.files.content.mockImplementation(async (outputFileId) => {
-      events.push(`content:${outputFileId}`);
-      return {
-        text: async () => JSON.stringify({
-          custom_id: seedCustomId,
-          response: {
-            status_code: 200,
-            body: {
-              id: 'resp_seed',
-              object: 'response',
-              status: 'completed',
-              usage: {
-                input_tokens: 7000,
-                input_tokens_details: {
-                  cached_tokens: 0,
-                  cache_write_tokens: 6000,
-                },
-              },
-              output: [{
-                type: 'message',
-                content: [{
-                  type: 'output_json',
-                  json: { minutes: [], decisions: [] },
-                }],
-              }],
-            },
-          },
-        }) + '\n',
-      };
-    });
+  it('requires a cache-hit probe before submitting compatible readers', async () => {
+    const seedWrite = {
+      input_tokens: 7000,
+      input_tokens_details: { cached_tokens: 0, cache_write_tokens: 6000 },
+    };
+    const cacheHit = {
+      input_tokens: 7000,
+      input_tokens_details: { cached_tokens: 6000, cache_write_tokens: 0 },
+    };
+    const { events } = await installCacheBatchMock(
+      client,
+      [seedWrite, cacheHit, cacheHit]
+    );
     const provider = new OpenAIBatchProvider({
       client,
       enableFallback: false,
@@ -215,7 +238,7 @@ describe('OpenAIBatchProvider', () => {
     });
     const stablePrefix = 'Large stable context. '.repeat(300);
 
-    const handles = await Promise.all(['a', 'b', 'c'].map((name) =>
+    const handles = await Promise.all(['a', 'b', 'c', 'd'].map((name) =>
       provider.submit({
         levelDir: tmpDir,
         prompt: `${stablePrefix}Review ${name}.jpg.`,
@@ -226,12 +249,15 @@ describe('OpenAIBatchProvider', () => {
 
     expect(client.batches.create.mock.calls.map(
       ([request]) => Number(request.metadata.request_count)
-    )).toEqual([1, 2]);
-    expect(events.indexOf('content:out_batch_1')).toBeLessThan(
+    )).toEqual([1, 1, 2]);
+    expect(events.indexOf('content:batch_1')).toBeLessThan(
+      events.indexOf('create:1', 1)
+    );
+    expect(events.indexOf('content:batch_2')).toBeLessThan(
       events.indexOf('create:2')
     );
     expect(new Set(handles.map((handle) => handle.batchId))).toEqual(
-      new Set(['batch_1', 'batch_2'])
+      new Set(['batch_1', 'batch_2', 'batch_3'])
     );
     const inputsDir = path.join(tmpDir, '.batch', 'inputs');
     const rowCounts = await Promise.all((await fs.readdir(inputsDir)).map(
@@ -240,53 +266,21 @@ describe('OpenAIBatchProvider', () => {
         .split('\n')
         .length
     ));
-    expect(rowCounts.sort((a, b) => a - b)).toEqual([1, 2]);
+    expect(rowCounts.sort((a, b) => a - b)).toEqual([1, 1, 2]);
 
-    const seedResult = await provider.collect(handles[0]);
-    expect(seedResult.json).toEqual({ minutes: [], decisions: [] });
-    expect(client.batches.retrieve).toHaveBeenCalledTimes(1);
+    const results = await Promise.all(handles.map((handle) => provider.collect(handle)));
+    expect(results.map((result) => result.json)).toEqual(
+      Array(4).fill({ minutes: [], decisions: [] })
+    );
+    expect(client.batches.retrieve).toHaveBeenCalledTimes(4);
   });
 
-  it('does not release readers when the seed reports no cache read or write', async () => {
-    let batchSequence = 0;
-    let seedCustomId;
-    client.files.create.mockImplementation(async () => ({ id: 'file_seed' }));
-    client.batches.create.mockImplementation(async ({ metadata }) => {
-      if (metadata.request_count === '1') seedCustomId = metadata.custom_id;
-      return { id: `batch_${++batchSequence}`, status: 'validating' };
-    });
-    client.batches.retrieve.mockImplementation(async (batchId) => ({
-      id: batchId,
-      status: 'completed',
-      output_file_id: `out_${batchId}`,
-    }));
-    client.files.content.mockImplementation(async () => ({
-      text: async () => JSON.stringify({
-        custom_id: seedCustomId,
-        response: {
-          status_code: 200,
-          body: {
-            id: 'resp_without_cache',
-            object: 'response',
-            status: 'completed',
-            usage: {
-              input_tokens: 7000,
-              input_tokens_details: {
-                cached_tokens: 0,
-                cache_write_tokens: 0,
-              },
-            },
-            output: [{
-              type: 'message',
-              content: [{
-                type: 'output_json',
-                json: { minutes: [], decisions: [] },
-              }],
-            }],
-          },
-        },
-      }) + '\n',
-    }));
+  it('stops fanout when the probe writes instead of hitting the cache', async () => {
+    const cacheWrite = {
+      input_tokens: 7000,
+      input_tokens_details: { cached_tokens: 0, cache_write_tokens: 6000 },
+    };
+    await installCacheBatchMock(client, [cacheWrite, cacheWrite]);
     const provider = new OpenAIBatchProvider({
       client,
       enableFallback: false,
@@ -296,7 +290,7 @@ describe('OpenAIBatchProvider', () => {
     });
     const stablePrefix = 'Large stable context. '.repeat(300);
 
-    const results = await Promise.allSettled(['a', 'b'].map((name) =>
+    const results = await Promise.allSettled(['a', 'b', 'c', 'd'].map((name) =>
       provider.submit({
         levelDir: tmpDir,
         prompt: `${stablePrefix}Review ${name}.jpg.`,
@@ -308,8 +302,16 @@ describe('OpenAIBatchProvider', () => {
     expect(results.map((result) => result.status)).toEqual([
       'rejected',
       'rejected',
+      'rejected',
+      'rejected',
     ]);
-    expect(client.batches.create).toHaveBeenCalledTimes(1);
+    expect(results.map((result) => result.reason?.code)).toEqual([
+      'PROMPT_CACHE_PROBE_MISS',
+      'PROMPT_CACHE_PROBE_MISS',
+      'PROMPT_CACHE_PROBE_MISS',
+      'PROMPT_CACHE_PROBE_MISS',
+    ]);
+    expect(client.batches.create).toHaveBeenCalledTimes(2);
   });
 
   it('coalesces worker submissions before staggered request preparation can split the Batch', async () => {

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -429,6 +429,39 @@ describe("triageDirectory", () => {
     await expect(fs.stat(path.join(tmpDir, "2.jpg"))).resolves.toBeTruthy();
   });
 
+  it("stops processing when a prompt-cache probe misses", async () => {
+    let calls = 0;
+    const provider = {
+      submit: vi.fn(async () => {
+        calls++;
+        if (calls === 1) {
+          const err = new Error("Prompt-cache probe did not report cached tokens");
+          err.code = "PROMPT_CACHE_PROBE_MISS";
+          throw err;
+        }
+        throw new Error("Billing hard limit has been reached");
+      }),
+      collect: vi.fn(),
+    };
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await expect(
+        triageDirectory({
+          dir: tmpDir,
+          promptPath: promptFile,
+          model: "test-model",
+          recurse: false,
+          provider,
+        })
+      ).rejects.toMatchObject({ code: "PROMPT_CACHE_PROBE_MISS" });
+    } finally {
+      logSpy.mockRestore();
+    }
+    expect(provider.submit).toHaveBeenCalledTimes(1);
+    await expect(fs.stat(path.join(tmpDir, "1.jpg"))).resolves.toBeTruthy();
+    await expect(fs.stat(path.join(tmpDir, "2.jpg"))).resolves.toBeTruthy();
+  });
+
 });
 
 describe("cascade scheduler invariants", () => {

--- a/tests/promptCaching.test.js
+++ b/tests/promptCaching.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildCacheableResponsesPrompt,
-  promptCacheReadyFromUsage,
+  promptCacheHitFromUsage,
 } from '../src/core/promptCaching.js';
 
 const stable = 'Stable curatorial context. '.repeat(300);
@@ -13,17 +13,17 @@ const input = [
 ];
 
 describe('buildCacheableResponsesPrompt', () => {
-  it('requires a reported cache read or write before releasing readers', () => {
-    expect(promptCacheReadyFromUsage({
+  it('requires a reported cache read before releasing readers', () => {
+    expect(promptCacheHitFromUsage({
       input_tokens_details: { cached_tokens: 0, cache_write_tokens: 6000 },
-    })).toBe(true);
-    expect(promptCacheReadyFromUsage({
+    })).toBe(false);
+    expect(promptCacheHitFromUsage({
       input_tokens_details: { cached_tokens: 6000, cache_write_tokens: 0 },
     })).toBe(true);
-    expect(promptCacheReadyFromUsage({
+    expect(promptCacheHitFromUsage({
       input_tokens_details: { cached_tokens: 0, cache_write_tokens: 0 },
     })).toBe(false);
-    expect(promptCacheReadyFromUsage()).toBe(false);
+    expect(promptCacheHitFromUsage()).toBe(false);
   });
 
   it('marks the stable GPT-5.6 prefix without changing prompt text or user input', () => {


### PR DESCRIPTION
## Outcome

Repairs the pt3 cache-fanout bug without changing prompt text, context length, curator selection, CLI inputs, decision handling, or the unanimous-level stop rule.

## Root cause

The paid production trace showed identical 444,466-character prefixes, cache keys, explicit breakpoints, and cache options across ten Batch requests, but reported zero cached tokens and ten cache writes. Pt3 treated any cache write as proof that the cache was ready, so it released reader fanout even when every reader was still missing. It also released completed workers before the rest of the cohort was terminal, allowing extra singleton cohorts to start.

## Repair

- Require an actual positive cached token count from a distinct probe before reader fanout.
- Plan compatible cohorts as one seed, one probe, then partitioned readers.
- Stop atomically after the seed and probe if the probe writes instead of reading; no readers are submitted and the cohort leaves photos unmoved.
- Hold worker handles until every reader Batch is terminal, preventing completed workers from starting skewed singleton cohorts.
- Propagate the cache-safety error through the orchestrator instead of silently retrying it.
- Upgrade the live Batch eval to a 444,466-character synthetic prefix and seed/probe/readers topology.

## Verification

- Red phase reproduced five distinct pt3 failures: write accepted as hit, old topology, fanout after probe miss, swallowed safety stop, and no cohort barrier.
- `npm test`: 22 files, 142 tests passed.
- `npm run evals:batch-aggregation`: 3 files, 19 tests passed.
- `npm run evals:stop-rule`: 2 files, 28 tests passed.
- `git diff --check`: clean.
- Existing eval coverage confirms repeated people are still added as dynamic curators beyond the stable cache prefix.

## Live evidence boundary

The production-scale paid canary has not been launched from this branch because the prior 10-worker collection process is still active on the same account and was continuing to create Batch tickets during verification. This PR fixes and tests the code defect and fails closed after two requests; a fresh live hit-rate measurement should run only after that older process stops.

## Change-set note

397 changed lines, above the 300-line warning threshold and below the 500-line mechanical-change gate. Most churn replaces the Batch boundary mocks with seed/probe/reader usage-aware eval scaffolding.
