### PR TITLE
repair caching pt5

### DIFF
--- a/scripts/eval-batch-prompt-cache.mjs
+++ b/scripts/eval-batch-prompt-cache.mjs
@@ -3,6 +3,7 @@ import dotenv from 'dotenv';
 import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import crypto from 'node:crypto';
 
 dotenv.config(process.env.PHOTO_SELECT_ENV_FILE
   ? { path: process.env.PHOTO_SELECT_ENV_FILE }
@@ -23,14 +24,6 @@ const targetPrefixChars = Math.max(
   4096,
   Number(process.env.PHOTO_SELECT_CACHE_EVAL_PREFIX_CHARS || 444_466)
 );
-const pollMs = Math.max(
-  1000,
-  Number(process.env.PHOTO_SELECT_CACHE_EVAL_POLL_MS || 5000)
-);
-const timeoutMs = Math.max(
-  60_000,
-  Number(process.env.PHOTO_SELECT_CACHE_EVAL_TIMEOUT_MS || 30 * 60_000)
-);
 const aggregationMs = Math.max(
   1,
   Number(process.env.PHOTO_SELECT_CACHE_EVAL_AGGREGATION_MS || 50)
@@ -39,7 +32,7 @@ const staggerMs = Math.max(
   aggregationMs + 1,
   Number(process.env.PHOTO_SELECT_CACHE_EVAL_STAGGER_MS || 150)
 );
-let prefix = `Photo-select Batch cache evaluation pt4, run ${Date.now()}. `;
+let prefix = `Photo-select Flex provider cache evaluation pt5, run ${Date.now()}. `;
 for (let i = 0; prefix.length < targetPrefixChars; i++) {
   prefix += `Synthetic context line ${String(i).padStart(6, '0')}: ` +
     'amber bridge cedar delta ember field granite harbor iris juniper.\n';
@@ -55,34 +48,58 @@ const helpers = {
         role: 'user',
         content: [{
           type: 'input_text',
-          text: 'Return a JSON object whose ok property is the string OK.',
+          text: 'Return JSON with empty minutes and decisions arrays.',
         }],
       }],
       used: [],
     };
   },
-  schemaForBatch() {
+  schemaForBatch(_used, _curators, { minutesMin = 0, minutesMax = 0 } = {}) {
     return {
-      name: 'PhotoSelectCacheEvalV2',
+      name: 'PhotoSelectCacheEvalV3',
       schema: {
         type: 'object',
-        properties: { ok: { type: 'string', enum: ['OK'] } },
-        required: ['ok'],
+        properties: {
+          minutes: {
+            type: 'array',
+            minItems: minutesMin,
+            maxItems: minutesMax,
+            items: { type: 'string' },
+          },
+          decisions: {
+            type: 'array',
+            minItems: 1,
+            maxItems: 1,
+            items: {
+              type: 'object',
+              properties: {
+                filename: {
+                  type: 'string',
+                  enum: [`synthetic-${minutesMin}.jpg`],
+                },
+                decision: { type: 'string', enum: ['keep', 'aside'] },
+                reason: { type: 'string' },
+              },
+              required: ['filename', 'decision', 'reason'],
+              additionalProperties: false,
+            },
+          },
+        },
+        required: ['minutes', 'decisions'],
         additionalProperties: false,
       },
     };
   },
 };
 
-function usageFromRow(row) {
-  const responseBody = typeof row.response?.body === 'string'
-    ? JSON.parse(row.response.body)
-    : row.response?.body;
-  const usage = row.response?.usage || responseBody?.usage || {};
+function usageSummary(handle, ticket, result) {
+  const usage = result?.usage || {};
   const details = usage.input_tokens_details || {};
   return {
-    custom_id: row.custom_id,
-    status_code: row.response?.status_code,
+    custom_id: handle.customId,
+    response_id: handle.batchId,
+    cache_role: ticket.cache_role,
+    service_tier: ticket.service_tier,
     input_tokens: usage.input_tokens || 0,
     cached_tokens: details.cached_tokens || 0,
     cache_write_tokens: details.cache_write_tokens || 0,
@@ -90,34 +107,15 @@ function usageFromRow(row) {
   };
 }
 
-async function settleBatch(client, batchId) {
-  const deadline = Date.now() + timeoutMs;
-  let batch = await client.batches.retrieve(batchId);
-  while (!['completed', 'failed', 'expired', 'canceled'].includes(batch.status)) {
-    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${batch.id}`);
-    await wait(pollMs);
-    batch = await client.batches.retrieve(batch.id);
-  }
-  if (batch.status !== 'completed' || !batch.output_file_id) {
-    throw new Error(`Batch ${batch.id} ended with status ${batch.status}`);
-  }
-  const text = await (await client.files.content(batch.output_file_id)).text();
-  return {
-    batch,
-    usages: text.split(/\r?\n/).filter(Boolean).map((line) =>
-      usageFromRow(JSON.parse(line))
-    ),
-  };
-}
-
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const client = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+  timeout: 15 * 60_000,
+});
 const tempDir = await mkdtemp(path.join(os.tmpdir(), 'photo-select-cache-eval-'));
-const remoteFileIds = new Set();
 try {
   const provider = new OpenAIBatchProvider({
     client,
     enableFallback: false,
-    pollIntervalMs: pollMs,
     aggregationWindowMs: aggregationMs,
     helpers,
   });
@@ -133,8 +131,8 @@ try {
           images: [],
           reasoningEffort: 'low',
           verbosity: 'low',
-          minutesMin: 0,
-          minutesMax: 0,
+          minutesMin: i + 1,
+          minutesMax: i + 2,
         };
       },
     })
@@ -149,25 +147,23 @@ try {
       message: result.reason?.message,
       usage: result.reason?.usage,
     }));
-
+  const results = await Promise.all(handles.map((handle) =>
+    provider.collect(handle)
+  ));
+  const tickets = await Promise.all(handles.map((handle) =>
+    readFile(handle.ticketPath, 'utf8').then(JSON.parse)
+  ));
+  const usages = handles.map((handle, index) =>
+    usageSummary(handle, tickets[index], results[index])
+  );
   const inputDir = path.join(tempDir, '.batch', 'inputs');
   const inputFiles = await readdir(inputDir);
-  const inputRowCounts = await Promise.all(inputFiles.map(async (file) =>
+  const inputRows = (await Promise.all(inputFiles.map(async (file) =>
     (await readFile(path.join(inputDir, file), 'utf8'))
       .split(/\r?\n/)
       .filter(Boolean)
-      .length
-  ));
-  const batchIds = [...new Set(handles.map((handle) => handle.batchId))];
-  const settled = await Promise.all(batchIds.map((batchId) =>
-    settleBatch(client, batchId)
-  ));
-  for (const { batch } of settled) {
-    if (batch.input_file_id) remoteFileIds.add(batch.input_file_id);
-    if (batch.output_file_id) remoteFileIds.add(batch.output_file_id);
-    if (batch.error_file_id) remoteFileIds.add(batch.error_file_id);
-  }
-  const usages = settled.flatMap((entry) => entry.usages);
+      .map(JSON.parse)
+  ))).flat();
   const totals = usages.reduce((sum, usage) => {
     for (const key of [
       'input_tokens',
@@ -188,38 +184,42 @@ try {
     cache_hit_requests: 0,
     cache_write_requests: 0,
   });
-  const expectedRowCounts = [1, 1, count - 2].sort((a, b) => a - b);
+  const seedUsage = usages.find((usage) => usage.cache_role === 'seed');
+  const probeUsage = usages.find((usage) => usage.cache_role === 'probe');
+  const readerUsages = usages.filter((usage) => usage.cache_role === 'reader');
+  const schemaHashes = inputRows.map((row) => crypto
+    .createHash('sha256')
+    .update(JSON.stringify(row.body?.text?.format?.schema))
+    .digest('hex'));
   const topologyPassed = submissionErrors.length === 0 &&
-    inputFiles.length === 3 &&
-    inputRowCounts.length === 3 &&
-    inputRowCounts.slice().sort((a, b) => a - b).every(
-      (rows, index) => rows === expectedRowCounts[index]
-    ) &&
-    batchIds.length === 3;
-  const seedUsage = settled[0]?.usages[0];
-  const probeUsage = settled[1]?.usages[0];
-  const readerUsages = settled.slice(2).flatMap((entry) => entry.usages);
-  const cachePassed = submissionErrors.length === 0 &&
-    usages.length === count &&
-    usages.every((usage) => usage.status_code === 200) &&
-    seedUsage?.cache_write_tokens > 0 &&
+    handles.length === count &&
+    new Set(handles.map((handle) => handle.batchId)).size === count &&
+    inputFiles.length === count &&
+    inputRows.length === count &&
+    inputRows.every((row) => row.body?.service_tier === 'flex') &&
+    new Set(schemaHashes).size === 1 &&
+    tickets.every((ticket) => ticket.service_tier === 'flex') &&
+    tickets.filter((ticket) => ticket.cache_role === 'seed').length === 1 &&
+    tickets.filter((ticket) => ticket.cache_role === 'probe').length === 1 &&
+    readerUsages.length === count - 2;
+  const cachePassed = seedUsage?.cache_write_tokens > 0 &&
     probeUsage?.cached_tokens > 0 &&
-    readerUsages.length === count - 2 &&
+    probeUsage?.cache_write_tokens === 0 &&
     readerUsages.every((usage) => usage.cached_tokens > 0) &&
     totals.cache_write_requests === 1 &&
     totals.cache_hit_requests === count - 1 &&
     totals.cached_tokens > totals.cache_write_tokens;
   const passed = topologyPassed && cachePassed;
   console.log(JSON.stringify({
-    eval: 'provider_seed_probe_barrier_explicit_prompt_cache_pt4',
+    eval: 'provider_flex_seed_probe_barrier_explicit_prompt_cache_pt5',
     model,
     request_count: count,
     stable_prefix_chars: prefix.length,
     aggregation_ms: aggregationMs,
     preparation_stagger_ms: staggerMs,
-    batch_count: batchIds.length,
+    response_count: handles.length,
     input_file_count: inputFiles.length,
-    input_row_counts: inputRowCounts,
+    stable_schema_hashes: [...new Set(schemaHashes)],
     topology_passed: topologyPassed,
     cache_passed: cachePassed,
     passed,
@@ -230,19 +230,5 @@ try {
   }, null, 2));
   if (!passed) process.exitCode = 1;
 } finally {
-  try {
-    const ticketDir = path.join(tempDir, '.batch', 'tickets');
-    for (const file of await readdir(ticketDir)) {
-      const ticket = JSON.parse(await readFile(path.join(ticketDir, file), 'utf8'));
-      for (const id of [ticket.input_file_id, ticket.output_file_id, ticket.error_file_id]) {
-        if (id) remoteFileIds.add(id);
-      }
-    }
-  } catch {
-    // Submission may fail before ticket creation.
-  }
-  await Promise.all([...remoteFileIds].map((id) =>
-    client.files.del(id).catch(() => undefined)
-  ));
   await rm(tempDir, { recursive: true, force: true });
 }

--- a/scripts/eval-prompt-cache.mjs
+++ b/scripts/eval-prompt-cache.mjs
@@ -16,13 +16,16 @@ if (!apiKey) {
 }
 
 const model = process.env.PHOTO_SELECT_CACHE_EVAL_MODEL || 'gpt-5.6-terra';
-const stablePrefix = [
-  'Photo-select explicit prompt-cache evaluation, version 1. ',
-  'This synthetic context contains no image or archive data. ',
-  'Preserve it exactly as the stable developer prefix. ',
-]
-  .join('')
-  .repeat(200);
+const targetPrefixChars = Math.max(
+  4096,
+  Number(process.env.PHOTO_SELECT_CACHE_EVAL_PREFIX_CHARS || 444_466)
+);
+let stablePrefix = `Photo-select Flex cache evaluation pt5, run ${Date.now()}. `;
+for (let i = 0; stablePrefix.length < targetPrefixChars; i++) {
+  stablePrefix += `Synthetic context line ${String(i).padStart(6, '0')}: ` +
+    'amber bridge cedar delta ember field granite harbor iris juniper.\n';
+}
+stablePrefix = stablePrefix.slice(0, targetPrefixChars);
 
 function request(dynamicSuffix) {
   const promptFields = buildCacheableResponsesPrompt({
@@ -39,9 +42,10 @@ function request(dynamicSuffix) {
   return {
     model,
     ...promptFields,
-    reasoning: { effort: 'xhigh' },
+    service_tier: 'flex',
+    reasoning: { effort: 'low' },
     text: { verbosity: 'low' },
-    max_output_tokens: 32,
+    max_output_tokens: 64,
     store: false,
   };
 }
@@ -57,7 +61,7 @@ function usageSummary(response) {
   };
 }
 
-const client = new OpenAI({ apiKey });
+const client = new OpenAI({ apiKey, timeout: 15 * 60_000 });
 const first = usageSummary(
   await client.responses.create(request(' First evaluation request.'))
 );
@@ -65,14 +69,16 @@ const second = usageSummary(
   await client.responses.create(request(' Second evaluation request.'))
 );
 const passed =
+  first.cache_write_tokens > 0 &&
   second.cached_tokens > 0 &&
   second.cache_write_tokens === 0;
 
 console.log(
   JSON.stringify(
     {
-      eval: 'explicit_prompt_cache_read_after_write',
+      eval: 'production_sized_flex_prompt_cache_read_after_write_pt5',
       model,
+      stable_prefix_chars: stablePrefix.length,
       passed,
       first,
       second,

--- a/src/core/promptCaching.js
+++ b/src/core/promptCaching.js
@@ -1,11 +1,28 @@
 import crypto from 'node:crypto';
 
-const CACHE_KEY_VERSION = 'v1';
+const CACHE_KEY_VERSION = 'v2';
 const MIN_CACHE_PREFIX_CHARS = 4096;
 
 export function promptCacheHitFromUsage(usage = {}) {
   const details = usage.input_tokens_details || {};
   return Number(details.cached_tokens || 0) > 0;
+}
+
+// The API renders Structured Output schemas before messages. Stabilize only
+// request-specific constraints; the prompt and validator still enforce them.
+export function stabilizeResponseSchemaForPromptCache(schema) {
+  const stable = structuredClone(schema);
+  const minutes = stable?.properties?.minutes;
+  if (minutes && typeof minutes === 'object') {
+    delete minutes.minItems; delete minutes.maxItems;
+  }
+  const decisions = stable?.properties?.decisions;
+  if (decisions && typeof decisions === 'object') {
+    delete decisions.minItems; delete decisions.maxItems;
+    const filename = decisions.items?.properties?.filename;
+    if (filename && typeof filename === 'object') delete filename.enum;
+  }
+  return stable;
 }
 
 function isGpt56OrLater(model = '') {

--- a/src/providers/openai-batch.js
+++ b/src/providers/openai-batch.js
@@ -12,6 +12,7 @@ import { debugBatch } from '../../scripts/debug-batch.mjs';
 import {
   buildCacheableResponsesPrompt,
   promptCacheHitFromUsage,
+  stabilizeResponseSchemaForPromptCache,
 } from '../core/promptCaching.js';
 import {
   OPENAI_BATCH_MAX_REQUESTS,
@@ -28,6 +29,8 @@ const DEFAULT_MAX_BATCH_BYTES = Number(
 );
 const DEFAULT_ENDPOINT = '/v1/responses';
 const FALLBACK_ENDPOINT = '/v1/chat/completions';
+const FLEX_SERVICE_TIER = 'flex';
+const FLEX_TIMEOUT_MS = Number(process.env.PHOTO_SELECT_FLEX_TIMEOUT_MS || 15 * 60 * 1000);
 
 const TERMINAL_FAILURE = new Set(['failed', 'expired', 'canceled']);
 const ALLOWED_REASONING_EFFORT = new Set(['auto', 'minimal', 'low', 'medium', 'high', 'xhigh']);
@@ -436,11 +439,8 @@ export default class OpenAIBatchProvider {
         return;
       }
 
-      const seedHandles = await this.#submitPreparedGroup(plan.batches[0]);
-      seedHandles[0].completedResult = await this.collect(seedHandles[0]);
-
-      const probeHandles = await this.#submitPreparedGroup(plan.batches[1]);
-      probeHandles[0].completedResult = await this.collect(probeHandles[0]);
+      const seedHandles = await this.#submitPreparedFlexGroup(plan.batches[0], 'seed');
+      const probeHandles = await this.#submitPreparedFlexGroup(plan.batches[1], 'probe');
       if (!promptCacheHitFromUsage(probeHandles[0].completedResult.usage)) {
         const err = new Error(
           'OpenAI prompt-cache probe completed without reporting cached tokens; reader fanout was stopped'
@@ -450,13 +450,21 @@ export default class OpenAIBatchProvider {
         throw err;
       }
 
-      const readerGroups = [];
-      for (const partition of plan.batches.slice(2)) {
-        readerGroups.push(await this.#submitPreparedGroup(partition));
+      const readerGroups = await Promise.all(
+        plan.batches.slice(2).map((partition) =>
+          this.#submitPreparedFlexGroup(partition, 'reader')
+        )
+      );
+      const missedReader = readerGroups.flat().find((handle) =>
+        !promptCacheHitFromUsage(handle.completedResult?.usage));
+      if (missedReader) {
+        const err = new Error(
+          'OpenAI Flex reader completed without reporting cached tokens; the cache cohort was stopped'
+        );
+        err.code = 'PROMPT_CACHE_READER_MISS';
+        err.usage = missedReader.completedResult?.usage;
+        throw err;
       }
-      await Promise.all(readerGroups.map(async (groupHandles) => {
-        groupHandles[0].completedResult = await this.collect(groupHandles[0]);
-      }));
 
       const handles = [
         ...seedHandles,
@@ -467,6 +475,87 @@ export default class OpenAIBatchProvider {
     } catch (err) {
       items.forEach((item) => item.reject(err));
     }
+  }
+
+  async #submitPreparedFlexGroup(items, cacheRole) {
+    return Promise.all(items.map(async (item) => {
+      const requestBody = {
+        ...item.responsesRequest.body,
+        service_tier: FLEX_SERVICE_TIER,
+      };
+      const jsonlPath = path.join(item.dirs.inputs, `${item.safe}.jsonl`);
+      await writeFile(jsonlPath, JSON.stringify({
+        custom_id: item.customId,
+        method: 'POST',
+        url: DEFAULT_ENDPOINT,
+        body: requestBody,
+      }) + '\n', 'utf8');
+
+      const submittedAt = new Date().toISOString();
+      const response = await this.client.responses.create(requestBody, {
+        headers: { 'Idempotency-Key': crypto.randomUUID() },
+        timeout: FLEX_TIMEOUT_MS,
+      });
+      const parsed = extractStructured(response, { customId: item.customId });
+      const completedAt = new Date().toISOString();
+      const ticketPath = path.join(item.dirs.tickets, `${item.safe}.ticket.json`);
+      const statusPath = path.join(item.dirs.status, `${item.safe}.status.json`);
+      const resultPath = path.join(item.dirs.results, `${response.id}.jsonl`);
+      const ticket = {
+        custom_id: item.customId,
+        batch_id: response.id,
+        model: item.model,
+        endpoint: DEFAULT_ENDPOINT,
+        service_tier: FLEX_SERVICE_TIER,
+        cache_role: cacheRole,
+        status: response.status,
+        submitted_at: submittedAt,
+        completed_at: completedAt,
+        used_images: item.responsesRequest.used.map((file) => path.basename(file)),
+        output_budget: budgetArtifact(item.responsesRequest.budget),
+      };
+      await writeFile(ticketPath, JSON.stringify(ticket, null, 2));
+      await writeFile(statusPath, JSON.stringify({
+        id: response.id,
+        status: response.status,
+        service_tier: response.service_tier || FLEX_SERVICE_TIER,
+        usage: response.usage,
+      }, null, 2));
+      await writeFile(resultPath, JSON.stringify({
+        custom_id: item.customId,
+        response: { status_code: 200, body: response },
+      }) + '\n', 'utf8');
+      await appendLedger(item.dirs.base, {
+        custom_id: item.customId,
+        event: 'completed',
+        batch_id: response.id,
+        endpoint: DEFAULT_ENDPOINT,
+        service_tier: FLEX_SERVICE_TIER,
+        cache_role: cacheRole,
+        status: response.status,
+        usage: response.usage,
+        output_budget: budgetArtifact(item.responsesRequest.budget),
+      });
+
+      return {
+        provider: this.name,
+        customId: item.customId,
+        batchId: response.id,
+        levelDir: item.levelDir,
+        model: item.model,
+        ticketPath,
+        statusPath,
+        safeId: item.safe,
+        used: item.responsesRequest.used,
+        endpoint: DEFAULT_ENDPOINT,
+        serviceTier: FLEX_SERVICE_TIER,
+        completedResult: {
+          raw: parsed.text,
+          json: parsed.json,
+          usage: response.usage,
+        },
+      };
+    }));
   }
 
   async #submitPreparedGroup(items) {
@@ -764,6 +853,9 @@ export default class OpenAIBatchProvider {
       input,
       promptCachePrefix,
     });
+    const responseSchema = promptFields.prompt_cache_options?.mode === 'explicit'
+      ? stabilizeResponseSchemaForPromptCache(schema.schema)
+      : schema.schema;
     const body = {
       model,
       ...promptFields,
@@ -772,7 +864,7 @@ export default class OpenAIBatchProvider {
         format: {
           type: 'json_schema',
           name: schema.name,
-          schema: schema.schema,
+          schema: responseSchema,
           strict: true,
         },
       },

--- a/tests/openaiBatchProvider.test.js
+++ b/tests/openaiBatchProvider.test.js
@@ -18,8 +18,31 @@ const createClient = () => {
     retrieve: vi.fn(),
     cancel: vi.fn(async () => ({})),
   };
-  return { files, batches };
+  const responses = {
+    create: vi.fn(),
+  };
+  return { files, batches, responses };
 };
+
+function installCacheResponsesMock(client, usages) {
+  client.responses.create.mockImplementation(async (body) => {
+    const index = client.responses.create.mock.calls.length - 1;
+    return {
+      id: `resp_${index + 1}`,
+      object: 'response',
+      status: 'completed',
+      service_tier: body.service_tier,
+      usage: usages[index],
+      output: [{
+        type: 'message',
+        content: [{
+          type: 'output_json',
+          json: { minutes: [], decisions: [] },
+        }],
+      }],
+    };
+  });
+}
 
 async function installCacheBatchMock(client, usages) {
   const events = [];
@@ -216,7 +239,7 @@ describe('OpenAIBatchProvider', () => {
     );
   });
 
-  it('requires a cache-hit probe before submitting compatible readers', async () => {
+  it('runs a cache-compatible cohort through a sequential Flex seed and probe before readers', async () => {
     const seedWrite = {
       input_tokens: 7000,
       input_tokens_details: { cached_tokens: 0, cache_write_tokens: 6000 },
@@ -225,10 +248,25 @@ describe('OpenAIBatchProvider', () => {
       input_tokens: 7000,
       input_tokens_details: { cached_tokens: 6000, cache_write_tokens: 0 },
     };
-    const { events } = await installCacheBatchMock(
-      client,
-      [seedWrite, cacheHit, cacheHit]
-    );
+    installCacheResponsesMock(client, [seedWrite, cacheHit, cacheHit, cacheHit]);
+    helpers.schemaForBatch = vi.fn((_used, _curators, minutes) => ({
+      name: 'PhotoSelectPanelV1',
+      schema: {
+        properties: {
+          minutes: {
+            minItems: minutes.minutesMin,
+            maxItems: minutes.minutesMax,
+          },
+          decisions: {
+            items: {
+              properties: {
+                filename: { enum: [`batch-${minutes.minutesMin}.jpg`] },
+              },
+            },
+          },
+        },
+      },
+    }));
     const provider = new OpenAIBatchProvider({
       client,
       enableFallback: false,
@@ -238,55 +276,61 @@ describe('OpenAIBatchProvider', () => {
     });
     const stablePrefix = 'Large stable context. '.repeat(300);
 
-    const handles = await Promise.all(['a', 'b', 'c', 'd'].map((name) =>
+    const handles = await Promise.all(['a', 'b', 'c', 'd'].map((name, index) =>
       provider.submit({
         levelDir: tmpDir,
         prompt: `${stablePrefix}Review ${name}.jpg.`,
         promptCachePrefix: stablePrefix,
         model: 'gpt-5.6-terra',
+        minutesMin: index + 1,
+        minutesMax: index + 2,
       })
     ));
 
-    expect(client.batches.create.mock.calls.map(
-      ([request]) => Number(request.metadata.request_count)
-    )).toEqual([1, 1, 2]);
-    expect(events.indexOf('content:batch_1')).toBeLessThan(
-      events.indexOf('create:1', 1)
-    );
-    expect(events.indexOf('content:batch_2')).toBeLessThan(
-      events.indexOf('create:2')
-    );
+    expect(client.files.create).not.toHaveBeenCalled();
+    expect(client.batches.create).not.toHaveBeenCalled();
+    expect(client.responses.create).toHaveBeenCalledTimes(4);
+    expect(client.responses.create.mock.calls.map(([body]) => body.service_tier))
+      .toEqual(['flex', 'flex', 'flex', 'flex']);
+    expect(client.responses.create.mock.calls.map(([body]) => body.prompt_cache_key))
+      .toEqual(Array(4).fill(client.responses.create.mock.calls[0][0].prompt_cache_key));
+    expect(new Set(client.responses.create.mock.calls.map(([body]) =>
+      JSON.stringify(body.text.format.schema)
+    )).size).toBe(1);
     expect(new Set(handles.map((handle) => handle.batchId))).toEqual(
-      new Set(['batch_1', 'batch_2', 'batch_3'])
+      new Set(['resp_1', 'resp_2', 'resp_3', 'resp_4'])
     );
-    const inputsDir = path.join(tmpDir, '.batch', 'inputs');
-    const rowCounts = await Promise.all((await fs.readdir(inputsDir)).map(
-      async (file) => (await fs.readFile(path.join(inputsDir, file), 'utf8'))
-        .trim()
-        .split('\n')
-        .length
-    ));
-    expect(rowCounts.sort((a, b) => a - b)).toEqual([1, 1, 2]);
 
     const results = await Promise.all(handles.map((handle) => provider.collect(handle)));
     expect(results.map((result) => result.json)).toEqual(
       Array(4).fill({ minutes: [], decisions: [] })
     );
-    expect(client.batches.retrieve).toHaveBeenCalledTimes(4);
+    expect(client.batches.retrieve).not.toHaveBeenCalled();
+    const tickets = await Promise.all(handles.map(async (handle) =>
+      JSON.parse(await fs.readFile(handle.ticketPath, 'utf8'))
+    ));
+    expect(tickets.map((ticket) => ticket.service_tier))
+      .toEqual(['flex', 'flex', 'flex', 'flex']);
+    expect(tickets.map((ticket) => ticket.cache_role))
+      .toEqual(['seed', 'probe', 'reader', 'reader']);
   });
 
-  it('stops fanout when the probe writes instead of hitting the cache', async () => {
-    const cacheWrite = {
+  it.each([
+    ['probe write', [0, 0], 2, 'PROMPT_CACHE_PROBE_MISS'],
+    ['reader miss', [0, 6000, 6000, 0], 4, 'PROMPT_CACHE_READER_MISS'],
+  ])('fails the entire cache cohort on a %s', async (_case, cached, calls, code) => {
+    installCacheResponsesMock(client, cached.map((cachedTokens) => ({
       input_tokens: 7000,
-      input_tokens_details: { cached_tokens: 0, cache_write_tokens: 6000 },
-    };
-    await installCacheBatchMock(client, [cacheWrite, cacheWrite]);
+      input_tokens_details: {
+        cached_tokens: cachedTokens,
+        cache_write_tokens: cachedTokens ? 0 : 6000,
+      },
+    })));
     const provider = new OpenAIBatchProvider({
       client,
       enableFallback: false,
       helpers,
       aggregationWindowMs: 10,
-      pollIntervalMs: 0,
     });
     const stablePrefix = 'Large stable context. '.repeat(300);
 
@@ -299,19 +343,14 @@ describe('OpenAIBatchProvider', () => {
       })
     ));
 
-    expect(results.map((result) => result.status)).toEqual([
-      'rejected',
-      'rejected',
-      'rejected',
-      'rejected',
-    ]);
-    expect(results.map((result) => result.reason?.code)).toEqual([
-      'PROMPT_CACHE_PROBE_MISS',
-      'PROMPT_CACHE_PROBE_MISS',
-      'PROMPT_CACHE_PROBE_MISS',
-      'PROMPT_CACHE_PROBE_MISS',
-    ]);
-    expect(client.batches.create).toHaveBeenCalledTimes(2);
+    expect(results.map((result) => result.status)).toEqual(
+      Array(4).fill('rejected')
+    );
+    expect(results.map((result) => result.reason?.code)).toEqual(
+      Array(4).fill(code)
+    );
+    expect(client.responses.create).toHaveBeenCalledTimes(calls);
+    expect(client.batches.create).not.toHaveBeenCalled();
   });
 
   it('coalesces worker submissions before staggered request preparation can split the Batch', async () => {
@@ -659,7 +698,7 @@ describe('OpenAIBatchProvider', () => {
       ttl: '30m',
     });
     expect(line.body.prompt_cache_key).toMatch(
-      /^photo-select:v1:[a-f0-9]{32}$/
+      /^photo-select:v2:[a-f0-9]{32}$/
     );
     expect(
       line.body.input[0].content.map((part) => part.text).join('')

--- a/tests/promptCaching.test.js
+++ b/tests/promptCaching.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildCacheableResponsesPrompt,
   promptCacheHitFromUsage,
+  stabilizeResponseSchemaForPromptCache,
 } from '../src/core/promptCaching.js';
 
 const stable = 'Stable curatorial context. '.repeat(300);
@@ -13,6 +14,34 @@ const input = [
 ];
 
 describe('buildCacheableResponsesPrompt', () => {
+  it('removes only request-specific schema constraints from cached requests', () => {
+    const schema = {
+      properties: {
+        minutes: { minItems: 23, maxItems: 34 },
+        decisions: {
+          minItems: 10,
+          maxItems: 10,
+          items: {
+            properties: {
+              filename: { enum: ['a.jpg', 'b.jpg'] },
+              decision: { enum: ['keep', 'aside'] },
+            },
+          },
+        },
+      },
+    };
+    const stableSchema = stabilizeResponseSchemaForPromptCache(schema);
+    expect(stableSchema.properties.minutes).toEqual({});
+    expect(stableSchema.properties.decisions).not.toHaveProperty('minItems');
+    expect(stableSchema.properties.decisions).not.toHaveProperty('maxItems');
+    expect(stableSchema.properties.decisions.items.properties.filename).toEqual({});
+    expect(stableSchema.properties.decisions.items.properties.decision.enum)
+      .toEqual(['keep', 'aside']);
+    expect(schema.properties.minutes.minItems).toBe(23);
+    expect(schema.properties.decisions.items.properties.filename.enum)
+      .toEqual(['a.jpg', 'b.jpg']);
+  });
+
   it('requires a reported cache read before releasing readers', () => {
     expect(promptCacheHitFromUsage({
       input_tokens_details: { cached_tokens: 0, cache_write_tokens: 6000 },
@@ -51,7 +80,7 @@ describe('buildCacheableResponsesPrompt', () => {
       mode: 'explicit',
       ttl: '30m',
     });
-    expect(request.prompt_cache_key).toMatch(/^photo-select:v1:[a-f0-9]{32}$/);
+    expect(request.prompt_cache_key).toMatch(/^photo-select:v2:[a-f0-9]{32}$/);
   });
 
   it('reuses only the stable key while retaining batch-specific curators', () => {


### PR DESCRIPTION
## Outcome

Repairs prompt caching for production-sized GPT-5.6 photo-select runs while preserving the existing CLI, prompt text, context brief, curator behavior, decision validation, and recursive stop rule.

The user still selects `--provider openai-batch`. Cache-eligible cohorts now use synchronous Responses API calls with `service_tier: "flex"` behind that provider, giving the seed/probe/readers the locality needed for prompt-cache reuse while retaining Batch-rate pricing.

## Root cause

There were two independent production problems:

1. Separate Batch API jobs did not reliably preserve cache locality between the write, probe, and reader jobs.
2. More importantly, the strict Structured Outputs schema changed for every photo batch because it embedded batch-specific minute bounds and a filename enum. The API renders that schema before the messages, so the effective prefix changed before the explicit cache breakpoint even though the 444,466-character text prefix and cache key were identical.

## Repair

- Run cache-eligible cohorts as a sequential Flex seed and probe, then release concurrent readers only after the probe reports cached tokens.
- Fail the entire cohort closed on a probe miss or any reader miss.
- Stabilize only the request-specific transport-schema constraints: minute/decision array bounds and the filename enum.
- Retain the full filename whitelist, minute guidance, curators, images, and context in the prompt; retain exact filename/completeness enforcement in the runtime validator.
- Persist Flex input, ticket, status, result, cache role, service tier, and usage artifacts in the existing `.batch` audit surface.
- Bump the cache key from `photo-select:v1` to `photo-select:v2`, as required for a changed cached structure.

No prompt or template file changed, and no context truncation was introduced.

## Production proof

Using the real level-4 collection, real brief, `gpt-5.6-terra`, `xhigh`, and 10 workers:

- seed: 140,883 input; 110,813 cache-write; 0 cached
- probe: 140,878 input; 110,813 cached; 0 cache-write
- eight readers: each reported 110,813 cached and 0 cache-write
- result: one write followed by nine consecutive hits; 100% post-seed cache-hit rate
- JSON validity: 10/10 responses parsed and passed strict runtime decision validation
- applied proof cohort: 100 decisions, 80 keep and 20 aside

The proof run was then stopped before another API cohort completed.

## Evals and verification

- `npm test`: 144/144 passed
- focused caching tests: 22/22 passed
- `npm run evals:batch-aggregation`: 20/20 passed
- `npm run evals:stop-rule`: 28/28 passed
- final paid provider eval: passed with one 87,143-token write followed by three 87,143-token reads; 261,429 cached tokens total; one stable transmitted schema hash across deliberately different source schemas
- repeated-person curator behavior remains covered and passing
- prompt/template diff: empty
- `git diff --check`: clean
- TODOs addressed/total TODOs: 0/0

Change-set warning: 495 changed lines, above the 300-line warning threshold but below the 500-line mechanical-change gate.

Official references: [Prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching), [Flex processing](https://developers.openai.com/api/docs/guides/flex-processing).
