### PR TITLE
Automatically recover unique semantic filename expansions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "evals:prompt-cache": "node scripts/eval-prompt-cache.mjs",
     "evals:batch-aggregation": "vitest run tests/batchAggregation.test.js tests/openaiBatchProvider.test.js tests/orchestratorBatchAggregation.test.js",
     "evals:batch-prompt-cache": "node scripts/eval-batch-prompt-cache.mjs",
+    "evals:filename-recovery": "vitest run tests/orchestratorSafety.test.js",
     "evals:stop-rule": "vitest run tests/evaluateLevelOutcome.test.js tests/orchestrator.test.js",
     "undici:smoke": "node scripts/undici-smoke.mjs",
     "debug:batch": "node scripts/debug-batch.mjs"

--- a/src/core/reconcileDecisionFilenames.js
+++ b/src/core/reconcileDecisionFilenames.js
@@ -1,0 +1,69 @@
+const SEMANTIC_TIMESTAMP = /^(\d{8}T\d{6})(\d+)Z(.*)$/;
+
+function isTrailingZeroExpansion(returnedName, canonicalName) {
+  const returned = returnedName.match(SEMANTIC_TIMESTAMP);
+  const canonical = canonicalName.match(SEMANTIC_TIMESTAMP);
+  if (!returned || !canonical) return false;
+
+  const [, returnedSecond, returnedFraction, returnedSuffix] = returned;
+  const [, canonicalSecond, canonicalFraction, canonicalSuffix] = canonical;
+  if (returnedSecond !== canonicalSecond || returnedSuffix !== canonicalSuffix) {
+    return false;
+  }
+  if (
+    returnedFraction.length <= canonicalFraction.length ||
+    !returnedFraction.startsWith(canonicalFraction)
+  ) {
+    return false;
+  }
+  return /^0+$/.test(returnedFraction.slice(canonicalFraction.length));
+}
+
+function parseJsonReply(rawReply) {
+  const original = String(rawReply);
+  const trimmed = original.trim();
+  const fenced = trimmed.match(/^```(\w*)\n([\s\S]*?)\n```$/);
+  const jsonText = fenced ? fenced[2] : trimmed;
+  try {
+    return {
+      value: JSON.parse(jsonText),
+      serialize(value) {
+        const json = JSON.stringify(value);
+        return fenced ? `\`\`\`${fenced[1]}\n${json}\n\`\`\`` : json;
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function reconcileDecisionFilenames(rawReply, allowedFilenames) {
+  const parsed = parseJsonReply(rawReply);
+  if (!parsed || !Array.isArray(parsed.value?.decisions)) {
+    return { reply: rawReply, repairs: [] };
+  }
+
+  const allowed = [...new Set(allowedFilenames.map(String))];
+  const allowedSet = new Set(allowed);
+  const repairs = [];
+  const decisions = parsed.value.decisions.map((decision) => {
+    if (!decision || typeof decision !== "object") return decision;
+    const returned = String(decision.filename || "").trim();
+    if (!returned || allowedSet.has(returned)) return decision;
+
+    const matches = allowed.filter((canonical) =>
+      isTrailingZeroExpansion(returned, canonical)
+    );
+    if (matches.length !== 1) return decision;
+
+    const canonical = matches[0];
+    repairs.push({ returned, canonical });
+    return { ...decision, filename: canonical };
+  });
+
+  if (!repairs.length) return { reply: rawReply, repairs };
+  return {
+    reply: parsed.serialize({ ...parsed.value, decisions }),
+    repairs,
+  };
+}

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -13,6 +13,7 @@ import { MultiBar, Presets } from "cli-progress";
 import { sanitizePeople } from "./lib/people.js";
 import { finalizeCurators } from "./core/finalizeCurators.js";
 import { evaluateLevelOutcome } from "./core/evaluateLevelOutcome.js";
+import { reconcileDecisionFilenames } from "./core/reconcileDecisionFilenames.js";
 
 const exec = promisify(execFile);
 
@@ -721,6 +722,18 @@ export async function triageDirectory(options) {
                 };
 
                 const meta = { model, verbosity, reasoningEffort };
+                const reconcileReply = (raw) => {
+                  const result = reconcileDecisionFilenames(
+                    raw,
+                    batch.map((file) => path.basename(file))
+                  );
+                  for (const repair of result.repairs) {
+                    log(
+                      `${indent}🔧  Reconciled response filename ${repair.returned} → ${repair.canonical}`
+                    );
+                  }
+                  return result.reply;
+                };
                 let attemptNum = 1;
                 let finalCurators = curators;
                 let added = [];
@@ -777,6 +790,7 @@ export async function triageDirectory(options) {
                   err.code = 'PROVIDER_ENVELOPE_NOT_DECISIONS';
                   throw err;
                 }
+                reply = reconcileReply(reply);
                 ({ keep, aside, unclassified, notes, minutes } = parseReply(
                   reply,
                   batch,
@@ -822,6 +836,7 @@ export async function triageDirectory(options) {
                       err.code = 'PROVIDER_ENVELOPE_NOT_DECISIONS';
                       throw err;
                     }
+                    reply = reconcileReply(reply);
                     ({ keep, aside, unclassified, notes } = parseReply(
                       reply,
                       batch,

--- a/tests/orchestratorSafety.test.js
+++ b/tests/orchestratorSafety.test.js
@@ -36,6 +36,104 @@ afterEach(async () => {
 });
 
 describe("triageDirectory safety validation", () => {
+  it("recovers a unique trailing-zero timestamp expansion without a restart", async () => {
+    const canonicalKeep = "20190219T003218580000Z-community-meeting-01.jpg";
+    const expandedKeep = "20190219T003218580000000Z-community-meeting-01.jpg";
+    const canonicalAside = "20190219T003219120000Z-community-meeting-02.jpg";
+    await fs.rename(path.join(tmpDir, "1.jpg"), path.join(tmpDir, canonicalKeep));
+    await fs.rename(path.join(tmpDir, "2.jpg"), path.join(tmpDir, canonicalAside));
+    chatCompletion.mockResolvedValueOnce(JSON.stringify({
+      minutes: [{
+        speaker: "Deborah Treisman",
+        text: "The first image carries the sequence; what should lead the next pass?",
+      }],
+      decisions: [
+        { filename: expandedKeep, decision: "keep", reason: "sequence anchor" },
+        { filename: canonicalAside, decision: "aside", reason: "repeats the beat" },
+      ],
+    }));
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: false,
+      saveIo: true,
+    });
+
+    await expect(fs.stat(path.join(tmpDir, "_keep", canonicalKeep))).resolves.toBeTruthy();
+    await expect(fs.stat(path.join(tmpDir, "_aside", canonicalAside))).resolves.toBeTruthy();
+    await expect(fs.stat(path.join(tmpDir, "NEEDS_REVIEW"))).rejects.toThrow();
+    const minutesName = (await fs.readdir(tmpDir)).find((name) => name.startsWith("minutes-"));
+    const minutes = JSON.parse(await fs.readFile(path.join(tmpDir, minutesName), "utf8"));
+    expect(minutes.decisions.map(({ filename }) => filename).sort()).toEqual([
+      canonicalKeep,
+      canonicalAside,
+    ].sort());
+    expect(JSON.stringify(minutes)).not.toContain(expandedKeep);
+    const responseDir = path.join(tmpDir, "_level-001", "_responses");
+    const responseName = (await fs.readdir(responseDir))[0];
+    const rawResponse = await fs.readFile(path.join(responseDir, responseName), "utf8");
+    expect(rawResponse).toContain(expandedKeep);
+  });
+
+  it("does not recover a filename whose semantic suffix changed", async () => {
+    const canonical = "20190219T003218580000Z-community-meeting-01.jpg";
+    const changedSuffix = "20190219T003218580000000Z-community-meeting-02.jpg";
+    await fs.rename(path.join(tmpDir, "1.jpg"), path.join(tmpDir, canonical));
+    chatCompletion.mockResolvedValueOnce(JSON.stringify({
+      minutes: [{
+        speaker: "Deborah Treisman",
+        text: "The returned name changes the subject; what evidence could resolve it?",
+      }],
+      decisions: [
+        { filename: changedSuffix, decision: "keep", reason: "unsafe mismatch" },
+        { filename: "2.jpg", decision: "aside", reason: "secondary" },
+      ],
+    }));
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: false,
+    });
+
+    await expect(fs.stat(path.join(tmpDir, canonical))).resolves.toBeTruthy();
+    const marker = await fs.readFile(path.join(tmpDir, "NEEDS_REVIEW"), "utf8");
+    expect(marker).toContain("INVALID_DECISIONS");
+  });
+
+  it("does not guess when a trailing-zero timestamp expansion is ambiguous", async () => {
+    const shorter = "20190219T00321858000Z-community-meeting.jpg";
+    const longer = "20190219T003218580000Z-community-meeting.jpg";
+    const expanded = "20190219T0032185800000Z-community-meeting.jpg";
+    await fs.rename(path.join(tmpDir, "1.jpg"), path.join(tmpDir, shorter));
+    await fs.rename(path.join(tmpDir, "2.jpg"), path.join(tmpDir, longer));
+    chatCompletion.mockResolvedValueOnce(JSON.stringify({
+      minutes: [{
+        speaker: "Deborah Treisman",
+        text: "Two originals fit this transcription; which one did the model mean?",
+      }],
+      decisions: [
+        { filename: expanded, decision: "keep", reason: "ambiguous timestamp" },
+        { filename: longer, decision: "aside", reason: "explicit second choice" },
+      ],
+    }));
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: false,
+    });
+
+    await expect(fs.stat(path.join(tmpDir, shorter))).resolves.toBeTruthy();
+    await expect(fs.stat(path.join(tmpDir, longer))).resolves.toBeTruthy();
+    const marker = await fs.readFile(path.join(tmpDir, "NEEDS_REVIEW"), "utf8");
+    expect(marker).toContain("INVALID_DECISIONS");
+  });
+
   it("leaves files unmoved and marks NEEDS_REVIEW for raw provider envelopes", async () => {
     chatCompletion.mockResolvedValueOnce(JSON.stringify({
       object: "response",


### PR DESCRIPTION
## What

- reconcile a model-returned semantic filename only when it is a unique trailing-zero expansion of one filename in the current batch whitelist
- keep the raw provider response unchanged in the response archive while using the canonical filename for parsing, minutes, and file moves
- log every deterministic reconciliation
- add a dedicated filename-recovery eval command and production-shaped orchestration cases

## Why

A recurring provider response expanded the fractional timestamp in names such as `20190219T003218580000Z-...` to `20190219T003218580000000Z-...`. The parser correctly rejected the unknown filename, marked the full batch `NEEDS_REVIEW`, and suppressed it for the remainder of the invocation. Restarting with `--retry-needs-review` merely reset that invocation-local suppression, so Jamie had to restart even though the batch whitelist made the intended file uniquely identifiable.

## User-visible impact

The CLI command, prompts, context brief, curator expansion, classification decisions, recursion, stop rule, caching topology, and semantic filenames are unchanged. In the observed extra-zero case, the batch now finishes in the same invocation and emits a visible reconciliation line instead of requiring a manual restart.

## Safety boundary

- exact names remain exact
- the timestamp second and the entire semantic suffix must match
- only extra trailing zeros in the fractional timestamp are eligible
- exactly one batch filename must match
- changed suffixes, ambiguity, duplicates, provider envelopes, and unrelated invalid decisions still fail closed into `NEEDS_REVIEW`
- no fuzzy or edit-distance matching is introduced

## Evals and hill climb

RED evidence before implementation:

- `npm test -- tests/orchestratorSafety.test.js` failed because the canonical keep file was not moved; the batch was marked `INVALID_DECISIONS`

GREEN evidence:

- `npm run evals:filename-recovery` — 7/7
- `npm run evals:batch-aggregation` — 20/20
- `npm run evals:stop-rule` — 28/28
- `npm test` — 22 files, 147/147 tests
- `git diff --check` — clean

The hill-climb cases prove same-invocation recovery, canonical minutes, preserved raw-response provenance, rejection of semantic-suffix changes, and rejection of ambiguous expansions.

## Contract report

- change set: 183 inserted lines, below the 300-line warning threshold
- prompt/cache structure: unchanged; no cache-key bump required
- JSON top-level schema: unchanged
- `json_validity_rate`: no regression observed; all 147 repository tests pass
- `retry_recovery_rate`: not applicable; recovery is deterministic and adds no API retry
- `todos_addressed/total_todos`: 0/0 in touched files
- live API spend: none for this post-response repair

## Published state

- commit: `687fc3d` (`Recover unique semantic filename expansions`)
- base: `feature/repair-large-context`
- head: `agent/automatic-semantic-filename-recovery`
- GitHub merge state after publication: clean
- PR remains a draft for review and the repository mindfulness window
