### PR TITLE
Add optional target level size

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ through to the script unchanged.
 | `--verbosity` | `high` | Verbosity for GPT-5 models (`low`, `medium`, `high`) |
 | `--reasoning-effort` | `high` | Reasoning effort for GPT-5 models (`minimal`, `low`, `medium`, `high`, `auto`) |
 | `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |
+| `--target-level-size` | *(unset)* | Continue recursive refinement until a completed `_level-*` contains at most this many source photos |
 | `--parallel` | *(deprecated)* | Maps to `--workers` and prints a warning |
 | `--field-notes` | `false` | Enable notebook updates via field-notes workflow |
 | `--verbose` | `false` | Print extra logs |
@@ -207,6 +208,21 @@ or the `--stage-concurrency` flag when staging needs to be throttled.
 Recursive runs settle every photo in the current level before deciding what happens
 next. If the completed level is unanimous—every photo is in `_keep`, or every photo
 is in `_aside`—the run stops. A mixed level descends into `_keep` and continues.
+
+That unanimous-level rule remains the default. To request a smaller terminal level,
+set a positive target:
+
+```bash
+/path/to/photo-select/photo-select-here.sh --target-level-size 10
+```
+
+With `--target-level-size 10`, the tool completes and archives each level until a
+completed `_level-*` contains 10 or fewer source photos. Unanimous `_keep` above the
+target continues into `_keep`; unanimous `_aside` remains terminal because no photos
+remain to refine. The target is an upper bound, so a mixed level may reduce the next
+level from above 10 to below 10. Omitting the option preserves unanimous stopping
+exactly as before. The option changes recursive stopping only; it does not alter the
+curatorial prompt or decision schema.
 
 ### Concurrency: `--workers` (recommended)
 
@@ -490,7 +506,9 @@ through that API, so no extra flags are needed.
 4. Parse that JSON to determine which files were explicitly labeled `keep` or `aside` and capture any notes about each image.
 5. Move those files to the corresponding sub‑folders and write a text file containing the notes next to each image. Files omitted from the decision block remain in place for the next batch so the model can review them again. Meeting minutes are saved as `minutes-<uuid>.json` (and `minutes-<uuid>.txt` when `PHOTO_SELECT_TRANSCRIPT_TXT=1`).
 6. Re‑run the algorithm on the newly created `_keep` folder (unless `--no-recurse`).
-   If every photo at a level is kept or every photo is set aside, recursion stops early.
+   By default, if every photo at a level is kept or every photo is set aside, recursion
+   stops early. With `--target-level-size N`, unanimous keep above `N` continues until
+   a completed level contains at most `N` source photos; unanimous aside still stops.
 7. On the first pass of each level a `_level-XXX` folder is created next to `_keep` and `_aside` containing a snapshot of the images originally present. If any files fail to copy after three retries (common on network drives), their paths are recorded in `failed-archives.txt` inside that folder.
 8. Stop when a directory has zero unclassified images.
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "evals:batch-aggregation": "vitest run tests/batchAggregation.test.js tests/openaiBatchProvider.test.js tests/orchestratorBatchAggregation.test.js",
     "evals:batch-prompt-cache": "node scripts/eval-batch-prompt-cache.mjs",
     "evals:filename-recovery": "vitest run tests/orchestratorSafety.test.js",
-    "evals:stop-rule": "vitest run tests/evaluateLevelOutcome.test.js tests/orchestrator.test.js",
+    "evals:stop-rule": "vitest run tests/evaluateLevelOutcome.test.js tests/orchestrator.test.js tests/cliTargetLevelSize.test.js",
     "undici:smoke": "node scripts/undici-smoke.mjs",
     "debug:batch": "node scripts/debug-batch.mjs"
   },

--- a/src/core/evaluateLevelOutcome.js
+++ b/src/core/evaluateLevelOutcome.js
@@ -9,9 +9,23 @@ export function evaluateLevelOutcome({
   complete,
   hasKeep,
   hasAside,
+  levelSize,
+  targetLevelSize,
 }) {
   if (!complete) {
     return { state: "incomplete", shouldStop: false };
+  }
+
+  const hasTarget =
+    Number.isInteger(targetLevelSize) && targetLevelSize > 0;
+  const hasKnownLevelSize = Number.isInteger(levelSize) && levelSize >= 0;
+
+  if (
+    hasTarget &&
+    hasKnownLevelSize &&
+    levelSize <= targetLevelSize
+  ) {
+    return { state: "target_reached", shouldStop: true };
   }
 
   if (hasKeep && hasAside) {
@@ -19,7 +33,12 @@ export function evaluateLevelOutcome({
   }
 
   if (hasKeep) {
-    return { state: "unanimous_keep", shouldStop: true };
+    const shouldContinueTowardTarget =
+      hasTarget && hasKnownLevelSize && levelSize > targetLevelSize;
+    return {
+      state: "unanimous_keep",
+      shouldStop: !shouldContinueTowardTarget,
+    };
   }
 
   if (hasAside) {

--- a/src/core/parsePositiveInteger.js
+++ b/src/core/parsePositiveInteger.js
@@ -1,0 +1,11 @@
+import { InvalidArgumentError } from "commander";
+
+export function parsePositiveInteger(value) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new InvalidArgumentError("must be a positive integer");
+  }
+  return parsed;
+}
+
+export default parsePositiveInteger;

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import path from "node:path";
 import { DEFAULT_PROMPT_PATH } from "./templates.js";
 import { configureHttpFromEnv, closeDispatcher } from "./net.js";
 import { scheduler } from "./scheduler.js";
+import { parsePositiveInteger } from "./core/parsePositiveInteger.js";
 
 function parseEnvFlag(value, fallback = false) {
   if (value == null || value === "") return fallback;
@@ -69,6 +70,11 @@ program
     process.env.PHOTO_SELECT_REASONING_EFFORT
   )
   .option("--no-recurse", "Process a single directory only")
+  .option(
+    "--target-level-size <n>",
+    "Continue until a completed level contains at most N photos",
+    parsePositiveInteger
+  )
   .option(
     "--retry-needs-review",
     "Re-include files listed in NEEDS_REVIEW for an explicit retry",
@@ -137,6 +143,7 @@ let {
   concurrency: concurrencyFlag,
   disablePhotoFilter,
   retryNeedsReview,
+  targetLevelSize,
 } = program.opts();
 
 if (program.getOptionValueSource && program.getOptionValueSource('parallel')) {
@@ -263,6 +270,7 @@ process.env.PHOTO_SELECT_USER_EFFORT = finalReasoningEffort;
       verbosity,
       reasoningEffort: finalReasoningEffort,
       retryNeedsReview,
+      targetLevelSize,
     });
     console.log("🎉  Finished triaging.");
   } catch (err) {

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -287,13 +287,35 @@ export async function findShallowestLevelWithEligibleImages(rootDir, options = {
       dirExists(path.join(current, "_keep")),
       dirExists(path.join(current, "_aside")),
     ]);
+    let levelSize;
+    if (Number.isInteger(options.targetLevelSize)) {
+      try {
+        levelSize = (
+          await listImages(
+            path.join(current, `_level-${String(level).padStart(3, "0")}`)
+          )
+        ).length;
+      } catch (err) {
+        if (err?.code !== "ENOENT") throw err;
+      }
+    }
     const outcome = evaluateLevelOutcome({
       complete: state.needsReviewImages.length === 0,
       hasKeep,
       hasAside,
+      levelSize,
+      targetLevelSize: options.targetLevelSize,
     });
     if (outcome.shouldStop) {
-      return { dir: current, depth, level, state, stopped: true, outcome };
+      return {
+        dir: current,
+        depth,
+        level,
+        levelSize,
+        state,
+        stopped: true,
+        outcome,
+      };
     }
     const next = path.join(current, "_keep");
     if (!(await dirExists(next))) return null;
@@ -307,6 +329,12 @@ export async function triageTree(options) {
   const rootDir = options.dir;
   let lastDepth = 0;
 
+  if (Number.isInteger(options.targetLevelSize)) {
+    console.log(
+      `🎯  target-level-size=${options.targetLevelSize}: complete levels until one contains at most this many photos.`
+    );
+  }
+
   while (true) {
     const work = await findShallowestLevelWithEligibleImages(rootDir, options);
     if (!work) {
@@ -314,6 +342,12 @@ export async function triageTree(options) {
       break;
     }
     if (work.stopped) {
+      if (work.outcome.state === "target_reached") {
+        console.log(
+          `${"  ".repeat(work.depth)}🎯  Completed level ${work.level} contains ${work.levelSize} photo(s), meeting target ≤ ${options.targetLevelSize}; stopping recursion.`
+        );
+        break;
+      }
       const bucket = work.outcome.state === "unanimous_keep" ? "kept" : "set aside";
       console.log(
         `${"  ".repeat(work.depth)}🎯  All images ${bucket} at completed level ${work.level}; stopping recursion.`
@@ -460,6 +494,7 @@ export async function resolveResumeLevel(startDir) {
  * @param {Object} options.provider     Chat provider instance
  * @param {string} options.model        Model id for the provider
  * @param {boolean} [options.recurse=true]  Whether to descend into _keep folders
+ * @param {number} [options.targetLevelSize] Continue until a completed level has at most this many photos
  * @param {string[]} [options.curators=[]]   Names inserted into the prompt
  * @param {string} [options.contextPath]     Optional additional context file
 * @param {boolean} [options.fieldNotes=false] Enable field notes workflow
@@ -487,6 +522,7 @@ export async function triageDirectory(options) {
     stageConcurrency,
     retryNeedsReview = envBool("PHOTO_SELECT_RETRY_NEEDS_REVIEW", false),
     allowDescendWithNeedsReview = envBool("PHOTO_SELECT_ALLOW_DESCEND_WITH_NEEDS_REVIEW", false),
+    targetLevelSize,
     _cascadeLevel = false,
   } = options;
   if (!provider) {
@@ -1039,12 +1075,20 @@ export async function triageDirectory(options) {
       complete: true,
       hasKeep,
       hasAside,
+      levelSize: await countImages(levelDir),
+      targetLevelSize,
     });
     const keepHasWork = keepCount > 0 || hasDeeperKeep;
     if (outcome.shouldStop) {
-      const bucket = outcome.state === "unanimous_keep" ? "kept" : "set aside";
-      console.log(`${indent}🎯  All images ${bucket} at this level; stopping recursion.`);
-    } else if (outcome.state === "mixed" && keepHasWork) {
+      if (outcome.state === "target_reached") {
+        console.log(
+          `${indent}🎯  Completed level ${depth + 1} meets target ≤ ${targetLevelSize}; stopping recursion.`
+        );
+      } else {
+        const bucket = outcome.state === "unanimous_keep" ? "kept" : "set aside";
+        console.log(`${indent}🎯  All images ${bucket} at this level; stopping recursion.`);
+      }
+    } else if (keepHasWork) {
       await triageDirectory({
         dir: keepDir,
         promptPath,
@@ -1064,6 +1108,7 @@ export async function triageDirectory(options) {
         update,
         forceRebuild,
         stageConcurrency,
+        targetLevelSize,
       });
     }
   }

--- a/tests/cliTargetLevelSize.test.js
+++ b/tests/cliTargetLevelSize.test.js
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const execFileAsync = promisify(execFile);
+
+describe("--target-level-size", () => {
+  it("is advertised as an optional completed-level stopping target", async () => {
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      ["src/index.js", "--help"],
+      { cwd: process.cwd() }
+    );
+
+    expect(stdout).toContain("--target-level-size <n>");
+    expect(stdout).toMatch(
+      /Continue until a completed level contains at most\s+N photos/
+    );
+  });
+
+  it("rejects zero instead of silently changing it to one", async () => {
+    await expect(
+      execFileAsync(
+        process.execPath,
+        ["src/index.js", "--target-level-size", "0"],
+        { cwd: process.cwd() }
+      )
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining("must be a positive integer"),
+    });
+  });
+
+  it("forwards a valid target into the recursive scheduler", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "ps-cli-target-"));
+    try {
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        [
+          "src/index.js",
+          "--provider",
+          "ollama",
+          "--dir",
+          dir,
+          "--target-level-size",
+          "10",
+        ],
+        {
+          cwd: process.cwd(),
+          env: { ...process.env, OPENAI_API_KEY: "test" },
+        }
+      );
+
+      expect(stdout).toContain("target-level-size=10");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/evaluateLevelOutcome.test.js
+++ b/tests/evaluateLevelOutcome.test.js
@@ -31,4 +31,49 @@ describe("evaluateLevelOutcome", () => {
   ])("$name", ({ input, expected }) => {
     expect(evaluateLevelOutcome(input)).toEqual(expected);
   });
+
+  it.each([
+    {
+      name: "at the requested size",
+      levelSize: 10,
+    },
+    {
+      name: "below the requested size",
+      levelSize: 9,
+    },
+  ])("stops a completed mixed level $name", ({ levelSize }) => {
+    expect(
+      evaluateLevelOutcome({
+        complete: true,
+        hasKeep: true,
+        hasAside: true,
+        levelSize,
+        targetLevelSize: 10,
+      })
+    ).toEqual({ state: "target_reached", shouldStop: true });
+  });
+
+  it("continues past unanimous keep while the completed level is above the target", () => {
+    expect(
+      evaluateLevelOutcome({
+        complete: true,
+        hasKeep: true,
+        hasAside: false,
+        levelSize: 11,
+        targetLevelSize: 10,
+      })
+    ).toEqual({ state: "unanimous_keep", shouldStop: false });
+  });
+
+  it("still stops after unanimous aside above the target because no photos remain", () => {
+    expect(
+      evaluateLevelOutcome({
+        complete: true,
+        hasKeep: false,
+        hasAside: true,
+        levelSize: 11,
+        targetLevelSize: 10,
+      })
+    ).toEqual({ state: "unanimous_aside", shouldStop: true });
+  });
 });

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -103,6 +103,45 @@ describe("triageDirectory", () => {
     await expect(fs.stat(path.join(tmpDir, "_aside", "2.jpg"))).resolves.toBeTruthy();
   });
 
+  it("completes a target-sized level after continuing past unanimous keep", async () => {
+    await fs.writeFile(path.join(tmpDir, "3.jpg"), "c");
+    let completedLevels = 0;
+    chatCompletion.mockImplementation(async ({ images }) => {
+      const names = images.map((file) => path.basename(file)).sort();
+      completedLevels += 1;
+      if (completedLevels === 1) {
+        return JSON.stringify({ keep: names, aside: [] });
+      }
+      if (completedLevels === 2) {
+        return JSON.stringify({ keep: names.slice(0, 2), aside: names.slice(2) });
+      }
+      return JSON.stringify({ keep: names, aside: [] });
+    });
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: true,
+      targetLevelSize: 2,
+    });
+
+    expect(chatCompletion).toHaveBeenCalledTimes(3);
+    const targetArchive = path.join(
+      tmpDir,
+      "_keep",
+      "_keep",
+      "_level-003"
+    );
+    const targetPhotos = (await fs.readdir(targetArchive)).filter((name) =>
+      name.endsWith(".jpg")
+    );
+    expect(targetPhotos).toHaveLength(2);
+    await expect(
+      fs.stat(path.join(tmpDir, "_keep", "_keep", "_level-004"))
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("evaluates unanimity after the entire level, not after each batch", async () => {
     for (let i = 3; i <= 11; i++) {
       await fs.writeFile(path.join(tmpDir, `${i}.jpg`), String(i));


### PR DESCRIPTION
## Summary

- preserve the existing unanimous completed-level stop rule when no target is supplied
- add `--target-level-size N` to continue recursive curation until a completed archived level contains at most N source photos
- continue through unanimous-keep levels above the target; keep unanimous-aside terminal because no photos survive to recurse
- validate positive integers and expose the active target in CLI logs
- expand stop-rule evals and user documentation

## User impact

There is no behavior change by default. Opt in with:

```bash
photo-select-here.sh ... --target-level-size 10
```

The target is checked only after the whole level is classified and archived. It is an upper bound, so a level may jump from above 10 to below 10. It does not modify the prompt, context brief, decision schema, caching, curator selection, or filename recovery.

For an all-keep level above the target, recursion continues into `_keep`. An all-aside level remains terminal because there are no surviving photos to process.

## Verification

- Node 20.19.6 full suite: **155/155 passed**
- Node 24.2.0 full suite: **155/155 passed**
- stop-rule eval: **36/36 passed**
- batch aggregation eval: **20/20 passed**
- filename recovery eval: **7/7 passed**
- retry recovery scenario: **1/1 passed**
- live prompt-cache read-after-write: **passed**, with 87,069 cached input tokens on the read
- live provider cache barrier: **passed**, with 3/4 cache-hit requests after one seed write
- `git diff --check` and changed-file `node --check`: **passed**

## Contract metrics

- `json_validity_rate`: **100%** of executed JSON/schema assertions; no JSON-validity failures in the 155-test full suite
- `retry_recovery_rate`: **100% (1/1)**
- `todos_addressed/total_todos`: **0/0** actionable TODOs in the changed scope
- change set: **260 lines** (253 additions, 7 deletions), below the 300-line warning threshold

## Hill-climb notes

The eval suite first failed on the new boundary behavior, recursive all-keep continuation, CLI help/validation, and CLI-to-scheduler propagation. The implementation was then tightened until those new cases and the existing default-behavior regressions all passed.