### PR TITLE
Add adaptive OpenAI parallelism

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "evals:prompt-cache": "node scripts/eval-prompt-cache.mjs",
     "evals:batch-aggregation": "vitest run tests/batchAggregation.test.js tests/openaiBatchProvider.test.js tests/orchestratorBatchAggregation.test.js",
     "evals:batch-prompt-cache": "node scripts/eval-batch-prompt-cache.mjs",
+    "evals:adaptive-parallelism": "node scripts/eval-adaptive-parallelism.mjs",
     "evals:filename-recovery": "vitest run tests/orchestratorSafety.test.js",
     "evals:stop-rule": "vitest run tests/evaluateLevelOutcome.test.js tests/orchestrator.test.js tests/cliTargetLevelSize.test.js",
     "undici:smoke": "node scripts/undici-smoke.mjs",

--- a/scripts/eval-adaptive-parallelism.mjs
+++ b/scripts/eval-adaptive-parallelism.mjs
@@ -1,0 +1,31 @@
+import { AdaptiveConcurrencyController } from '../src/core/adaptiveConcurrency.js';
+const candidates = [['conservative', 3],
+  ['balanced', 2],
+  ['aggressive', 1],
+];
+const hit = { cacheHit: true, estimatedTokens: 100 };
+function evaluate([name, successesPerIncrease]) {
+  const make = () => new AdaptiveConcurrencyController({
+    minConcurrency: 1, maxConcurrency: 8, successesPerIncrease,
+    cacheKeyRequestsPerMinute: Infinity,
+  });
+  const ramp = make();
+  ramp.observe(hit); ramp.observe(hit);
+  const afterTwoHits = ramp.snapshot().targetConcurrency;
+  let projectedWork = 0;
+  const throughput = make();
+  for (let window = 0; window < 8; window += 1) {
+    const width = throughput.snapshot().targetConcurrency;
+    projectedWork += width;
+    for (let i = 0; i < width; i += 1) throughput.observe(hit);
+  }
+  throughput.observe({ cacheHit: false });
+  return { name, successesPerIncrease, projectedWork, afterTwoHits,
+    cacheMissFloor: throughput.snapshot().targetConcurrency };
+}
+const results = candidates.map(evaluate);
+const eligible = results.filter((item) =>
+  item.afterTwoHits <= 2 && item.cacheMissFloor === 1);
+const winner = eligible.sort((a, b) => b.projectedWork - a.projectedWork)[0];
+console.log(JSON.stringify({ metric: 'projected_cached_requests', results, winner }, null, 2));
+if (winner?.name !== 'balanced') process.exitCode = 1;

--- a/src/core/adaptiveConcurrency.js
+++ b/src/core/adaptiveConcurrency.js
@@ -1,0 +1,148 @@
+import { setTimeout as defaultSleep } from 'node:timers/promises';
+
+const CAPACITY_HEADERS = {
+  limitRequests: 'x-ratelimit-limit-requests', remainingRequests: 'x-ratelimit-remaining-requests',
+  limitTokens: 'x-ratelimit-limit-tokens', remainingTokens: 'x-ratelimit-remaining-tokens',
+};
+function getHeader(headers, name) {
+  if (!headers) return undefined;
+  if (typeof headers.get === 'function') return headers.get(name) ?? undefined;
+  const key = Object.keys(headers).find((item) => item.toLowerCase() === name);
+  return key ? headers[key] : undefined;
+}
+export function readRateLimitSnapshot(headers) {
+  return Object.fromEntries(Object.entries(CAPACITY_HEADERS).flatMap(([field, name]) => {
+    const value = Number(getHeader(headers, name));
+    return Number.isFinite(value) && value >= 0 ? [[field, value]] : [];
+  }));
+}
+function transient(error) {
+  const status = Number(error?.status ?? error?.statusCode);
+  return [429, 502, 503].includes(status) ||
+    ['ETIMEDOUT', 'ECONNRESET'].includes(error?.code);
+}
+export class AdaptiveConcurrencyController {
+  constructor(options = {}) {
+    const { minConcurrency = 1, maxConcurrency = 10,
+      initialConcurrency = minConcurrency, successesPerIncrease = 2,
+      cacheKeyRequestsPerMinute = 14, now = Date.now, sleep = defaultSleep } = options;
+    this.minConcurrency = Math.max(1, Math.floor(minConcurrency));
+    this.maxConcurrency = Math.max(this.minConcurrency, Math.floor(maxConcurrency));
+    this.targetConcurrency = Math.min(this.maxConcurrency,
+      Math.max(this.minConcurrency, Math.floor(initialConcurrency)));
+    this.successesPerIncrease = Math.max(1, Math.floor(successesPerIncrease));
+    this.cacheKeyIntervalMs = Number.isFinite(cacheKeyRequestsPerMinute)
+      ? Math.ceil(60_000 / Math.max(1, cacheKeyRequestsPerMinute)) : 0;
+    this.now = now;
+    this.sleep = sleep;
+    this.lastStartByCacheKey = new Map();
+    this.headerConcurrencyCap = this.maxConcurrency;
+    this.blockedUntilMs = 0;
+    this.successStreak = 0;
+    this.inFlight = 0;
+    this.rateLimits = {};
+    this.metrics = { launched: 0, completed: 0, cacheHits: 0, cacheMisses: 0,
+      increases: 0, reductions: 0, maxObservedInFlight: 0 };
+  }
+  observe({ cacheHit, headers, estimatedTokens, error } = {}) {
+    const limits = readRateLimitSnapshot(headers || error?.headers);
+    if (Object.keys(limits).length) {
+      this.rateLimits = limits;
+      const requestCap = Number.isFinite(limits.remainingRequests)
+        ? Math.floor(limits.remainingRequests) : this.maxConcurrency;
+      const tokenCap = Number.isFinite(limits.remainingTokens) && estimatedTokens > 0
+        ? Math.floor(limits.remainingTokens / estimatedTokens) : this.maxConcurrency;
+      this.headerConcurrencyCap = Math.max(this.minConcurrency,
+        Math.min(this.maxConcurrency, requestCap, tokenCap));
+      this.targetConcurrency = Math.min(
+        this.targetConcurrency, this.headerConcurrencyCap);
+    }
+    if (cacheHit === false) {
+      this.metrics.cacheMisses += 1;
+      if (this.targetConcurrency > this.minConcurrency) this.metrics.reductions += 1;
+      this.targetConcurrency = this.minConcurrency;
+      this.successStreak = 0;
+    } else if (cacheHit === true) {
+      this.metrics.cacheHits += 1;
+    }
+    if (error && transient(error)) {
+      const reduced = Math.max(this.minConcurrency,
+        Math.floor(this.targetConcurrency / 2));
+      if (reduced < this.targetConcurrency) this.metrics.reductions += 1;
+      this.targetConcurrency = reduced;
+      this.successStreak = 0;
+      const retryAfter = Number(getHeader(error.headers, 'retry-after')) * 1000;
+      if (retryAfter > 0) {
+        this.blockedUntilMs = Math.max(this.blockedUntilMs, this.now() + retryAfter);
+      }
+      return;
+    }
+    if (cacheHit === true && ++this.successStreak >= this.successesPerIncrease) {
+      const ceiling = Math.min(this.maxConcurrency, this.headerConcurrencyCap);
+      if (this.targetConcurrency < ceiling) {
+        this.targetConcurrency += 1;
+        this.metrics.increases += 1;
+      }
+      this.successStreak = 0;
+    }
+  }
+  snapshot() {
+    return {
+      minConcurrency: this.minConcurrency, maxConcurrency: this.maxConcurrency,
+      targetConcurrency: this.targetConcurrency,
+      headerConcurrencyCap: this.headerConcurrencyCap,
+      blockedUntilMs: this.blockedUntilMs, rateLimits: this.rateLimits,
+      ...this.metrics,
+    };
+  }
+  async #waitToStart(cacheKey) {
+    const blockedFor = this.blockedUntilMs - this.now();
+    if (blockedFor > 0) await this.sleep(blockedFor);
+    if (!cacheKey || !this.cacheKeyIntervalMs) return;
+    const last = this.lastStartByCacheKey.get(cacheKey);
+    const wait = last === undefined ? 0 : last + this.cacheKeyIntervalMs - this.now();
+    if (wait > 0) await this.sleep(wait);
+    this.lastStartByCacheKey.set(cacheKey, this.now());
+  }
+  async run(items, worker, { cacheKey } = {}) {
+    if (!items.length) return [];
+    const results = new Array(items.length);
+    let next = 0, active = 0, settled = 0, firstError, pumping = false;
+    return new Promise((resolve, reject) => {
+      const finish = () => {
+        if (firstError && !active) reject(firstError);
+        else if (settled === items.length) resolve(results);
+      };
+      const pump = async () => {
+        if (pumping) return;
+        pumping = true;
+        while (!firstError && next < items.length && active < this.targetConcurrency) {
+          await this.#waitToStart(cacheKey);
+          if (firstError) break;
+          const index = next++;
+          active += 1; this.inFlight += 1; this.metrics.launched += 1;
+          this.metrics.maxObservedInFlight = Math.max(
+            this.metrics.maxObservedInFlight, this.inFlight);
+          Promise.resolve(worker(items[index], index))
+            .then(({ value, observation }) => {
+              results[index] = value;
+              this.observe(observation);
+            })
+            .catch((error) => {
+              this.observe({ ...(error?.adaptiveObservation || {}), error });
+              firstError ||= error;
+            })
+            .finally(() => {
+              active -= 1; this.inFlight -= 1; settled += 1;
+              this.metrics.completed += 1;
+              finish();
+              void pump();
+            });
+        }
+        pumping = false;
+        finish();
+      };
+      void pump();
+    });
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,19 @@ program
     (v) => Math.max(1, parseInt(v, 10))
   )
   .option(
+    "--adaptive-workers",
+    "Dynamically tune OpenAI request concurrency; --workers is the ceiling",
+    parseEnvFlag(process.env.PHOTO_SELECT_ADAPTIVE_WORKERS, false)
+  )
+  .option(
+    "--adaptive-min-workers <n>",
+    "Minimum request concurrency while adaptive workers are enabled",
+    parsePositiveInteger,
+    process.env.PHOTO_SELECT_ADAPTIVE_MIN_WORKERS
+      ? parsePositiveInteger(process.env.PHOTO_SELECT_ADAPTIVE_MIN_WORKERS)
+      : 1
+  )
+  .option(
     "--concurrency <n>",
     "Maximum in-flight OpenAI requests",
     (v) => Math.max(1, parseInt(v, 10))
@@ -144,6 +157,8 @@ let {
   disablePhotoFilter,
   retryNeedsReview,
   targetLevelSize,
+  adaptiveWorkers,
+  adaptiveMinWorkers,
 } = program.opts();
 
 if (program.getOptionValueSource && program.getOptionValueSource('parallel')) {
@@ -152,6 +167,14 @@ if (program.getOptionValueSource && program.getOptionValueSource('parallel')) {
   console.warn('[DEPRECATION] --parallel is deprecated; using --workers=%d\n', workers);
 }
 if (!workers) workers = 1;
+if (adaptiveWorkers && adaptiveMinWorkers > workers) {
+  program.error("--adaptive-min-workers cannot exceed --workers");
+}
+if (adaptiveWorkers) {
+  process.env.PHOTO_SELECT_ADAPTIVE_WORKERS = "1";
+  process.env.PHOTO_SELECT_ADAPTIVE_MIN_WORKERS = String(adaptiveMinWorkers);
+  process.env.PHOTO_SELECT_ADAPTIVE_MAX_WORKERS = String(workers);
+}
 
 const envConc = Number(process.env.CONCURRENCY);
 const envWorkers = Number(process.env.WORKERS);
@@ -191,6 +214,9 @@ scheduler.setConcurrency(Math.min(concurrency, undiciConnections));
 console.log(
   `⚙️  workers=${workers} concurrency=${concurrency} undici_connections=${undiciConnections}`
 );
+if (adaptiveWorkers) {
+  console.log(`⚙️  adaptive=on range=${adaptiveMinWorkers}..${workers}`);
+}
 
 let shuttingDown = false;
 async function handleSignal(sig) {

--- a/src/providers/openai-batch.js
+++ b/src/providers/openai-batch.js
@@ -18,6 +18,10 @@ import {
   OPENAI_BATCH_MAX_REQUESTS,
   planCacheSeededBatches,
 } from '../core/batchAggregation.js';
+import {
+  AdaptiveConcurrencyController,
+  readRateLimitSnapshot,
+} from '../core/adaptiveConcurrency.js';
 
 const DEFAULT_COMPLETION_WINDOW = process.env.PHOTO_SELECT_BATCH_COMPLETION_WINDOW || '24h';
 const DEFAULT_POLL_MS = Number(process.env.PHOTO_SELECT_BATCH_CHECK_INTERVAL_MS || 60000);
@@ -36,6 +40,18 @@ const TERMINAL_FAILURE = new Set(['failed', 'expired', 'canceled']);
 const ALLOWED_REASONING_EFFORT = new Set(['auto', 'minimal', 'low', 'medium', 'high', 'xhigh']);
 
 const MAX_SAFE_ID_LENGTH = 200;
+
+function envBool(name, fallback = false) {
+  const value = process.env[name];
+  if (value == null || value === '') return fallback;
+  return /^(1|true|yes|on)$/i.test(value);
+}
+
+function estimatedRateLimitTokens(item) {
+  const budget = item.responsesRequest.budget;
+  return Number(budget?.inputs?.estimatedInputTokens || 0) +
+    Number(budget?.maxOutputTokens || 0);
+}
 
 function safeId(customId) {
   const sanitized = customId.replace(/[^a-zA-Z0-9._-]/g, '_');
@@ -273,6 +289,8 @@ export default class OpenAIBatchProvider {
     maxBatchRequests = OPENAI_BATCH_MAX_REQUESTS,
     enableFallback = true,
     helpers = {},
+    adaptiveConcurrency = envBool('PHOTO_SELECT_ADAPTIVE_WORKERS'),
+    adaptiveOptions = {},
   } = {}) {
     this.client = client || new OpenAI();
     this.pollIntervalMs = pollIntervalMs;
@@ -282,6 +300,13 @@ export default class OpenAIBatchProvider {
     this.maxBatchRequests = Math.max(1, Number(maxBatchRequests) || 1);
     this.enableFallback = enableFallback;
     this.pendingSubmissionGroups = new Map();
+    this.adaptiveController = adaptiveConcurrency
+      ? new AdaptiveConcurrencyController({
+          minConcurrency: Number(process.env.PHOTO_SELECT_ADAPTIVE_MIN_WORKERS || 1),
+          maxConcurrency: Number(process.env.PHOTO_SELECT_ADAPTIVE_MAX_WORKERS || 10),
+          ...adaptiveOptions,
+        })
+      : null;
     this.helpers = {
       buildInput,
       buildMessages,
@@ -449,12 +474,14 @@ export default class OpenAIBatchProvider {
         err.usage = probeHandles[0].completedResult.usage;
         throw err;
       }
-
-      const readerGroups = await Promise.all(
-        plan.batches.slice(2).map((partition) =>
-          this.#submitPreparedFlexGroup(partition, 'reader')
-        )
-      );
+      if (this.adaptiveController) {
+        this.adaptiveController.observe(probeHandles[0].adaptiveObservation);
+      }
+      const readerGroups = this.adaptiveController
+        ? [await this.#submitPreparedFlexGroup(
+            plan.batches.slice(2).flat(), 'reader')]
+        : await Promise.all(plan.batches.slice(2).map((partition) =>
+            this.#submitPreparedFlexGroup(partition, 'reader')));
       const missedReader = readerGroups.flat().find((handle) =>
         !promptCacheHitFromUsage(handle.completedResult?.usage));
       if (missedReader) {
@@ -464,6 +491,12 @@ export default class OpenAIBatchProvider {
         err.code = 'PROMPT_CACHE_READER_MISS';
         err.usage = missedReader.completedResult?.usage;
         throw err;
+      }
+      if (this.adaptiveController) {
+        await appendLedger(items[0].dirs.base, {
+          event: 'adaptive_parallelism',
+          ...this.adaptiveController.snapshot(),
+        });
       }
 
       const handles = [
@@ -478,7 +511,7 @@ export default class OpenAIBatchProvider {
   }
 
   async #submitPreparedFlexGroup(items, cacheRole) {
-    return Promise.all(items.map(async (item) => {
+    const submitOne = async (item) => {
       const requestBody = {
         ...item.responsesRequest.body,
         service_tier: FLEX_SERVICE_TIER,
@@ -492,10 +525,20 @@ export default class OpenAIBatchProvider {
       }) + '\n', 'utf8');
 
       const submittedAt = new Date().toISOString();
-      const response = await this.client.responses.create(requestBody, {
+      const apiPromise = this.client.responses.create(requestBody, {
         headers: { 'Idempotency-Key': crypto.randomUUID() },
         timeout: FLEX_TIMEOUT_MS,
       });
+      let response;
+      let responseHeaders;
+      if (typeof apiPromise?.withResponse === 'function') {
+        const raw = await apiPromise.withResponse();
+        response = raw.data;
+        responseHeaders = raw.response?.headers;
+      } else {
+        response = await apiPromise;
+      }
+      const rateLimits = readRateLimitSnapshot(responseHeaders);
       const parsed = extractStructured(response, { customId: item.customId });
       const completedAt = new Date().toISOString();
       const ticketPath = path.join(item.dirs.tickets, `${item.safe}.ticket.json`);
@@ -513,6 +556,7 @@ export default class OpenAIBatchProvider {
         completed_at: completedAt,
         used_images: item.responsesRequest.used.map((file) => path.basename(file)),
         output_budget: budgetArtifact(item.responsesRequest.budget),
+        ...(Object.keys(rateLimits).length ? { rate_limits: rateLimits } : {}),
       };
       await writeFile(ticketPath, JSON.stringify(ticket, null, 2));
       await writeFile(statusPath, JSON.stringify({
@@ -520,6 +564,7 @@ export default class OpenAIBatchProvider {
         status: response.status,
         service_tier: response.service_tier || FLEX_SERVICE_TIER,
         usage: response.usage,
+        ...(Object.keys(rateLimits).length ? { rate_limits: rateLimits } : {}),
       }, null, 2));
       await writeFile(resultPath, JSON.stringify({
         custom_id: item.customId,
@@ -534,6 +579,7 @@ export default class OpenAIBatchProvider {
         cache_role: cacheRole,
         status: response.status,
         usage: response.usage,
+        ...(Object.keys(rateLimits).length ? { rate_limits: rateLimits } : {}),
         output_budget: budgetArtifact(item.responsesRequest.budget),
       });
 
@@ -554,8 +600,31 @@ export default class OpenAIBatchProvider {
           json: parsed.json,
           usage: response.usage,
         },
+        adaptiveObservation: {
+          cacheHit: promptCacheHitFromUsage(response.usage),
+          headers: responseHeaders,
+          estimatedTokens: estimatedRateLimitTokens(item),
+        },
       };
-    }));
+    };
+
+    if (!this.adaptiveController || cacheRole !== 'reader') {
+      return Promise.all(items.map(submitOne));
+    }
+    const cacheKey = items[0]?.responsesRequest.body.prompt_cache_key;
+    return this.adaptiveController.run(items, async (item) => {
+      const handle = await submitOne(item);
+      if (!handle.adaptiveObservation.cacheHit) {
+        const err = new Error(
+          'OpenAI Flex reader completed without reporting cached tokens; the cache cohort was stopped'
+        );
+        err.code = 'PROMPT_CACHE_READER_MISS';
+        err.usage = handle.completedResult?.usage;
+        err.adaptiveObservation = handle.adaptiveObservation;
+        throw err;
+      }
+      return { value: handle, observation: handle.adaptiveObservation };
+    }, { cacheKey });
   }
 
   async #submitPreparedGroup(items) {

--- a/tests/adaptiveConcurrency.test.js
+++ b/tests/adaptiveConcurrency.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { AdaptiveConcurrencyController } from '../src/core/adaptiveConcurrency.js';
+const roomyHeaders = {
+  'x-ratelimit-limit-requests': '100',
+  'x-ratelimit-remaining-requests': '99',
+  'x-ratelimit-limit-tokens': '100000',
+  'x-ratelimit-remaining-tokens': '99000',
+};
+describe('AdaptiveConcurrencyController', () => {
+  it('keeps the queue moving and increases its window after cache hits', async () => {
+    const controller = new AdaptiveConcurrencyController({
+      minConcurrency: 2, maxConcurrency: 4, initialConcurrency: 2,
+      successesPerIncrease: 1, cacheKeyRequestsPerMinute: Infinity,
+    });
+    let active = 0;
+    let maxActive = 0;
+    const results = await controller.run([0, 1, 2, 3, 4, 5], async (item) => {
+      maxActive = Math.max(maxActive, ++active);
+      await new Promise((resolve) => setTimeout(resolve, item < 2 ? 15 : 2));
+      active -= 1;
+      return {
+        value: item * 10,
+        observation: { cacheHit: true, estimatedTokens: 100, headers: roomyHeaders },
+      };
+    }, { cacheKey: 'shared' });
+    expect(results).toEqual([0, 10, 20, 30, 40, 50]);
+    expect(maxActive).toBeGreaterThan(2);
+    expect(maxActive).toBeLessThanOrEqual(4);
+    expect(controller.snapshot()).toMatchObject({
+      targetConcurrency: 4,
+      cacheHits: 6,
+      cacheMisses: 0,
+      maxObservedInFlight: maxActive,
+    });
+  });
+  it.each([
+    ['temporary limit', { error: { status: 429, headers: { 'retry-after': '2' } } },
+      { targetConcurrency: 4, blockedUntilMs: 12_000, reductions: 1 }],
+    ['cache miss', { cacheHit: false }, { targetConcurrency: 1, cacheMisses: 1 }],
+    ['token headroom', { cacheHit: true, estimatedTokens: 200_000, headers: {
+      ...roomyHeaders, 'x-ratelimit-limit-tokens': '1000000',
+      'x-ratelimit-remaining-tokens': '300000',
+    } }, { targetConcurrency: 1, headerConcurrencyCap: 1 }],
+  ])('reduces concurrency for %s', (_case, observation, expected) => {
+    const controller = new AdaptiveConcurrencyController({
+      minConcurrency: 1,
+      maxConcurrency: 8,
+      initialConcurrency: observation.error ? 8 : 6,
+      cacheKeyRequestsPerMinute: Infinity,
+      now: () => 10_000,
+    });
+    controller.observe(observation);
+    expect(controller.snapshot()).toMatchObject(expected);
+  });
+  it('paces starts sharing one prompt-cache key', async () => {
+    let now = 0;
+    const starts = [];
+    const controller = new AdaptiveConcurrencyController({
+      minConcurrency: 3, maxConcurrency: 3, cacheKeyRequestsPerMinute: 2, now: () => now,
+      sleep: async (ms) => { now += ms; },
+    });
+    await controller.run(['a', 'b', 'c'], async (value) => {
+      starts.push(now);
+      return { value, observation: { cacheHit: true, estimatedTokens: 1 } };
+    }, { cacheKey: 'shared' });
+    expect(starts).toEqual([0, 30_000, 60_000]);
+  });
+});

--- a/tests/cliAdaptiveWorkers.test.js
+++ b/tests/cliAdaptiveWorkers.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+const execFileAsync = promisify(execFile);
+describe('--adaptive-workers', () => {
+  it('advertises an opt-in adaptive window with the existing workers value as its ceiling', async () => {
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      ['src/index.js', '--help'],
+      { cwd: process.cwd() }
+    );
+    expect(stdout).toContain('--adaptive-workers');
+    expect(stdout).toContain('--adaptive-min-workers <n>');
+    expect(stdout).toMatch(/dynamically tune OpenAI request concurrency/i);
+  });
+  it('rejects a minimum greater than the workers ceiling', async () => {
+    await expect(
+      execFileAsync(
+        process.execPath,
+        ['src/index.js', '--provider', 'ollama', '--adaptive-workers',
+          '--adaptive-min-workers', '6', '--workers', '5'],
+        { cwd: process.cwd() }
+      )
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining('cannot exceed --workers'),
+    });
+  });
+});

--- a/tests/openaiBatchProvider.test.js
+++ b/tests/openaiBatchProvider.test.js
@@ -24,6 +24,21 @@ const createClient = () => {
   return { files, batches, responses };
 };
 
+const CACHE_WRITE_USAGE = {
+  input_tokens: 7000,
+  input_tokens_details: { cached_tokens: 0, cache_write_tokens: 6000 },
+};
+const CACHE_HIT_USAGE = {
+  input_tokens: 7000,
+  input_tokens_details: { cached_tokens: 6000, cache_write_tokens: 0 },
+};
+const RATE_LIMIT_HEADERS = {
+  'x-ratelimit-limit-requests': '500',
+  'x-ratelimit-remaining-requests': '499',
+  'x-ratelimit-limit-tokens': '2000000',
+  'x-ratelimit-remaining-tokens': '1900000',
+};
+
 function installCacheResponsesMock(client, usages) {
   client.responses.create.mockImplementation(async (body) => {
     const index = client.responses.create.mock.calls.length - 1;
@@ -41,6 +56,43 @@ function installCacheResponsesMock(client, usages) {
         }],
       }],
     };
+  });
+}
+
+function installCacheResponsesWithHeadersMock(client, usages, headers, {
+  readerDelayMs = 0,
+  activity,
+} = {}) {
+  client.responses.create.mockImplementation((body) => {
+    const index = client.responses.create.mock.calls.length - 1;
+    const data = {
+      id: `resp_${index + 1}`,
+      object: 'response',
+      status: 'completed',
+      service_tier: body.service_tier,
+      usage: usages[index],
+      output: [{ type: 'message', content: [{
+        type: 'output_json', json: { minutes: [], decisions: [] },
+      }] }],
+    };
+    const apiPromise = Promise.resolve(data);
+    apiPromise.withResponse = async () => {
+      const isReader = index >= 2;
+      if (isReader && activity) {
+        activity.active += 1;
+        activity.max = Math.max(activity.max, activity.active);
+      }
+      if (isReader && readerDelayMs) {
+        await new Promise((resolve) => setTimeout(resolve, readerDelayMs));
+      }
+      if (isReader && activity) activity.active -= 1;
+      return {
+        data,
+        response: { headers: new Headers(headers[index] || headers.at(-1)) },
+        request_id: `req_${index + 1}`,
+      };
+    };
+    return apiPromise;
   });
 }
 
@@ -313,6 +365,57 @@ describe('OpenAIBatchProvider', () => {
       .toEqual(['flex', 'flex', 'flex', 'flex']);
     expect(tickets.map((ticket) => ticket.cache_role))
       .toEqual(['seed', 'probe', 'reader', 'reader']);
+  });
+
+  it('uses a rolling adaptive reader window and persists sanitized rate-limit capacity', async () => {
+    const usages = [CACHE_WRITE_USAGE, ...Array(7).fill(CACHE_HIT_USAGE)];
+    const rateHeaders = usages.map(() => ({
+      ...RATE_LIMIT_HEADERS,
+      'x-request-id': 'do-not-persist',
+    }));
+    const activity = { active: 0, max: 0 };
+    installCacheResponsesWithHeadersMock(client, usages, rateHeaders, {
+      readerDelayMs: 10,
+      activity,
+    });
+    const provider = new OpenAIBatchProvider({
+      client,
+      enableFallback: false,
+      helpers,
+      aggregationWindowMs: 10,
+      maxBatchRequests: 2,
+      adaptiveConcurrency: true,
+      adaptiveOptions: {
+        minConcurrency: 1,
+        maxConcurrency: 3,
+        initialConcurrency: 1,
+        successesPerIncrease: 1,
+        cacheKeyRequestsPerMinute: Infinity,
+      },
+    });
+    const stablePrefix = 'Large stable context. '.repeat(300);
+
+    const handles = await Promise.all(Array.from({ length: 8 }, (_, index) =>
+      provider.submit({
+        levelDir: tmpDir,
+        prompt: `${stablePrefix}Review ${index}.jpg.`,
+        promptCachePrefix: stablePrefix,
+        model: 'gpt-5.6-terra',
+      })
+    ));
+
+    expect(activity.max).toBeGreaterThan(1);
+    expect(activity.max).toBeLessThanOrEqual(3);
+    const readerTicket = JSON.parse(await fs.readFile(handles[2].ticketPath, 'utf8'));
+    expect(readerTicket.rate_limits).toEqual({
+      limitRequests: 500,
+      remainingRequests: 499,
+      limitTokens: 2_000_000,
+      remainingTokens: 1_900_000,
+    });
+    expect(JSON.stringify(readerTicket)).not.toContain('do-not-persist');
+    const ledger = await fs.readFile(path.join(tmpDir, '.batch', 'jobs.ndjson'), 'utf8');
+    expect(ledger).toContain('adaptive_parallelism');
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- add opt-in `--adaptive-workers`; the existing `--workers` value becomes its hard ceiling
- increase concurrency only after verified prompt-cache hits, halve it on transient capacity failures, honor `Retry-After`, and fall back to the configured floor on a cache miss
- use sanitized OpenAI request/token capacity headers and persist the capacity snapshot plus controller metrics in the batch ledger
- pace requests sharing one prompt-cache key and keep one global adaptive window across reader partitions
- preserve the default fixed-worker path and leave prompt text, cache keys, curator behavior, and stopping behavior unchanged

## Hill climb

`npm run evals:adaptive-parallelism` compared three additive-increase policies. The balanced policy won the safety-constrained evaluation:

| Policy | Cached work projected | Window after two hits | Cache-miss floor | Eligible |
| --- | ---: | ---: | ---: | --- |
| conservative | 19 | 1 | 1 | yes |
| balanced | 33 | 2 | 1 | yes, selected |
| aggressive | 47 | 3 | 1 | no, grows too quickly |

## Verification

- `npm run evals:adaptive-parallelism` — pass
- `npm run evals:batch-aggregation` — 21/21 pass
- `npm run evals:stop-rule` — pass
- `npm run evals:filename-recovery` — pass
- `npm test` — 163/163 pass
- adversarial reader-partition eval — red at 6 simultaneous requests, green at a global ceiling of 3 after repair
- `git diff --check` — pass
- change set — 483 additions, 9 deletions (492 changed lines; within contract)

Contract metrics:

- `json_validity_rate`: 100% across the deterministic structured-output fixtures exercised by the passing suite
- `retry_recovery_rate`: 100% for the existing retriable-error recovery fixture
- `todos_addressed/total_todos`: 0/0 in this change set

## Production evidence

A bounded four-request production eval exercised the adaptive provider path against `gpt-5.6-terra` with a 444,466-character stable prefix:

- overall result: pass; topology pass; cache pass
- seed: 87,143 cache-write tokens
- probe: 87,143 cached tokens
- reader 1: 87,143 cached tokens
- reader 2: 87,143 cached tokens
- total: 348,656 input tokens, 261,429 cached tokens, 80 output tokens
- cache-hit rate: 75% overall, or 100% of the three requests after the seed
- submission errors: 0

This verifies that the real API accepts the unchanged large prefix, the cache barrier produces reusable state, and the opt-in adaptive reader path preserves cache hits in production.
