### PR TITLE
Prefetch content-addressed people metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ through to the script unchanged.
 | `--reasoning-effort` | `high` | Reasoning effort for GPT-5 models (`minimal`, `low`, `medium`, `high`, `auto`) |
 | `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |
 | `--target-level-size` | *(unset)* | Continue recursive refinement until a completed `_level-*` contains at most this many source photos |
+| `--refresh-people-index` | `false` | Force one atomic rebuild of Photo Filter's people index before the level prefetch |
 | `--parallel` | *(deprecated)* | Maps to `--workers` and prints a warning |
 | `--field-notes` | `false` | Enable notebook updates via field-notes workflow |
 | `--verbose` | `false` | Print extra logs |
@@ -354,7 +355,9 @@ on startup.
 
 ### People metadata (optional)
 
-Set `PHOTO_FILTER_API_BASE` to the base URL of your [photo‑filter](https://github.com/openhouse/photo-filter) service to include face‑tag data in the prompt. The CLI assumes the service is available at `http://localhost:3000` when the variable is unset and logs a warning if requests fail. For each image it fetches `/api/photos/by-filename/<filename>/persons` and sends a JSON blob like `{ "filename": "DSCF1234.jpg", "people": ["Alice", "Bob"] }` before the image itself. Results are cached per filename for the duration of the run. Pass `--disable-photo-filter` (or set `PHOTO_SELECT_DISABLE_PEOPLE=1`) to skip these lookups for a single job.
+Set `PHOTO_FILTER_API_BASE` to the base URL of your [photo‑filter](https://github.com/openhouse/photo-filter) service to include face‑tag data in the prompt. The CLI assumes the service is available at `http://localhost:3000` when the variable is unset and logs a warning if requests fail. Before each level, supported servers bulk-resolve the filenames from one content-addressed `photos.json` snapshot and prime the existing per-filename cache. Older servers fall back to `/api/photos/by-filename/<filename>/persons`. In either case the prompt receives the same JSON blob, such as `{ "filename": "DSCF1234.jpg", "people": ["Alice", "Bob"] }` before the image itself. If duplicate album exports for one semantic photograph disagree, the bulk index keeps the deterministic union of their known people labels rather than whichever album happened to be scanned first.
+
+Pass `--refresh-people-index` (or set `PHOTO_SELECT_REFRESH_PEOPLE_INDEX=1`) when the derived index may be stale. This forces one atomic rebuild from the active `photos.json` files. The returned corpus hash proves the index matches those files; it cannot prove the files match the current Apple Photos library, so upstream source freshness remains reported separately as `unknown`. Pass `--disable-photo-filter` (or set `PHOTO_SELECT_DISABLE_PEOPLE=1`) to skip people lookups for a single job.
 
 Example:
 

--- a/docs/rfcs/0010-content-addressed-people-prefetch.md
+++ b/docs/rfcs/0010-content-addressed-people-prefetch.md
@@ -6,7 +6,7 @@
 | **Audience** | Photo Select and Photo Filter contributors |
 | **Author** | Jamie Burkart with collaborators |
 | **Created** | 2026-08-11 |
-| **Companion** | `openhouse/photo-filter` RFC 0008 |
+| **Companion** | [`openhouse/photo-filter` RFC 0008](https://github.com/openhouse/photo-filter/pull/68) |
 
 ---
 
@@ -17,10 +17,12 @@ people metadata through Photo Filter's content-addressed bulk API. Populate the
 existing in-process people cache from one verified corpus snapshot, then let
 the established prompt path proceed unchanged.
 
-This is a performance repair, not a curatorial-policy change. The CLI,
-filenames, prompt wording, context brief, person ordering, repeated-person
-curator additions, decisions, resume behavior, and output artifacts remain the
-same.
+This is primarily a performance repair, not a curatorial-policy change. The
+CLI, filenames, prompt wording, context brief, repeated-person curator rule,
+decisions, resume behavior, and output artifacts remain the same. The companion
+index also repairs one metadata inconsistency: duplicate album memberships
+union their known people labels instead of allowing the first membership to
+erase labels present on another.
 
 ## 2 — Motivation
 
@@ -87,8 +89,9 @@ the Apple Photos library.
 
 ## 6 — Prompt and cache invariants
 
-The bulk path returns the same ordered people arrays as the legacy endpoint.
-Therefore it does not:
+For consistent metadata, the bulk path returns the same ordered people arrays
+as the legacy endpoint. For conflicting duplicate album exports, it returns a
+deterministic union. The transport change itself does not:
 
 - truncate or rewrite `--context`;
 - change prompt templates or message ordering;
@@ -130,7 +133,8 @@ Code-based evals must establish:
 3. A hash mismatch or malformed response commits no partial cache entries.
 4. A bulk `404` preserves the current legacy request path.
 5. Bulk and legacy paths serialize byte-identical people metadata into prompt
-   inputs for exact, semantic-alias, missing, and ambiguous fixtures.
+   inputs for consistent exact, semantic-alias, missing, and ambiguous fixtures;
+   conflicting duplicate memberships follow the documented union rule.
 6. Two photographs containing the same person still add that person to the
    curators under the existing rule.
 7. Context bytes and prompt-template bytes are identical before and after the

--- a/docs/rfcs/0010-content-addressed-people-prefetch.md
+++ b/docs/rfcs/0010-content-addressed-people-prefetch.md
@@ -1,0 +1,166 @@
+# RFC 0010 — Content-Addressed People Prefetch
+
+| Field | Value |
+| --- | --- |
+| **Status** | **Draft** |
+| **Audience** | Photo Select and Photo Filter contributors |
+| **Author** | Jamie Burkart with collaborators |
+| **Created** | 2026-08-11 |
+| **Companion** | `openhouse/photo-filter` RFC 0008 |
+
+---
+
+## 1 — Summary
+
+Before Photo Select prepares model prompts for a level, resolve that level's
+people metadata through Photo Filter's content-addressed bulk API. Populate the
+existing in-process people cache from one verified corpus snapshot, then let
+the established prompt path proceed unchanged.
+
+This is a performance repair, not a curatorial-policy change. The CLI,
+filenames, prompt wording, context brief, person ordering, repeated-person
+curator additions, decisions, resume behavior, and output artifacts remain the
+same.
+
+## 2 — Motivation
+
+The current client asks Photo Filter for people one filename at a time. Photo
+Filter cold-scans an album's `photos.json` for each request and serializes those
+scans. Large levels can therefore spend tens of minutes collecting people tags
+before the first model request is submitted.
+
+People enrichment is part of the work's relational intelligence: if the same
+person appears in multiple photographs, that person's lens joins the
+curatorial comparison. Removing or sampling enrichment would make the tool
+faster by changing what it means. This RFC instead removes repeated work.
+
+## 3 — Companion contract
+
+Photo Filter RFC 0008 defines a derived people index identified by the SHA-256
+of every active canonical `photos.json` source. Its API keeps two freshness
+claims separate:
+
+1. **Index freshness:** the index exactly represents that `photos.json`
+   corpus.
+2. **Source freshness:** that corpus reflects the current Apple Photos
+   library.
+
+Photo Select may rely on the first claim when the corpus hash is verified. It
+must display `sourceFreshness: "unknown"` when no upstream export revision can
+prove the second claim. A verified cache must not imply more than it proves.
+
+## 4 — Level prefetch
+
+For every recursively selected level:
+
+1. collect its eligible filenames in deterministic order;
+2. partition them into requests of at most 500 filenames;
+3. send the first chunk with `refresh: "verify"` (or `"force"` when explicitly
+   requested);
+4. send every later chunk with the first response's
+   `expectedCorpusSha256` and `refresh: "snapshot"`;
+5. reject a hash mismatch rather than mix people metadata from two corpus
+   revisions;
+6. populate the existing `peopleCache` only after all chunks validate;
+7. run the existing prompt preparation and provider workflow.
+
+The prefetch is once per level, not once per batch. Duplicate filenames are
+deduplicated for transport but retain their original level behavior.
+
+## 5 — Compatibility and fallback
+
+Capability detection is intentionally conservative:
+
+- A successful bulk response primes the existing cache.
+- `404` or `405` means the connected Photo Filter predates RFC 0008. Photo
+  Select records that fact and falls back to the existing lazy, per-filename
+  endpoint.
+- A malformed response, corpus mismatch, or server error is surfaced. It does
+  not become a cache of empty people arrays.
+- Legacy fallback is lazy; Photo Select does not launch an unbounded fan-out of
+  old single-filename calls merely because bulk support is absent.
+
+Omitting the new refresh option preserves current CLI behavior. An explicit
+`--refresh-people-index` option (and corresponding environment variable) asks
+the first level request to force a rebuild. It does not mutate photographs or
+the Apple Photos library.
+
+## 6 — Prompt and cache invariants
+
+The bulk path returns the same ordered people arrays as the legacy endpoint.
+Therefore it does not:
+
+- truncate or rewrite `--context`;
+- change prompt templates or message ordering;
+- change filename whitelists;
+- change how a person appearing in more than one photo is added to the
+  curators;
+- change model, reasoning effort, batching, recursion, or stopping rules.
+
+The provider prompt-cache key is not bumped merely because people metadata was
+transported in bulk. If a verified refresh reveals genuinely changed people
+metadata, the resulting prompt content and request identity change naturally.
+
+## 7 — Observability
+
+Verbose output reports one compact line per level:
+
+```text
+people-index: status=verified corpus=<12-char-prefix> sources=42 names=13167 elapsed=1.8s source_freshness=unknown
+```
+
+Track:
+
+- `people_prefetch_ms`
+- `people_prefetch_names`
+- `people_prefetch_chunks`
+- `people_prefetch_cache_hits`
+- `people_prefetch_fallbacks`
+- `people_corpus_sha256`
+- `people_source_freshness`
+
+Private filenames and person names are not logged by default.
+
+## 8 — Evaluation plan
+
+Code-based evals must establish:
+
+1. 1,001 filenames produce chunk sizes `500`, `500`, and `1`.
+2. Every chunk after the first is pinned to the same corpus hash.
+3. A hash mismatch or malformed response commits no partial cache entries.
+4. A bulk `404` preserves the current legacy request path.
+5. Bulk and legacy paths serialize byte-identical people metadata into prompt
+   inputs for exact, semantic-alias, missing, and ambiguous fixtures.
+6. Two photographs containing the same person still add that person to the
+   curators under the existing rule.
+7. Context bytes and prompt-template bytes are identical before and after the
+   transport change.
+8. An end-to-end fixture replaces hundreds of source scans with one verified
+   index build while preserving decisions.
+
+## 9 — Rollout
+
+1. Land the companion Photo Filter bulk endpoint and parity evals.
+2. Land level prefetch with legacy fallback disabled only in its focused eval.
+3. Run both paths against the same representative local corpus and compare
+   normalized prompt inputs.
+4. Measure cold and warm latency, scan count, and corpus identity.
+5. Keep the legacy endpoint until deployed clients demonstrate parity.
+
+## 10 — Alternatives rejected
+
+- **Increase workers only:** the server's per-album lock still serializes cold
+  scans and risks resource pressure.
+- **Sample or cap people tags:** faster, but changes the curatorial team.
+- **Cache forever by filename:** cannot prove which export revision supplied a
+  result.
+- **Hash only requested filenames:** misses additions, deletions, and changes
+  elsewhere in active metadata sources.
+- **Assume index freshness proves Apple Photos freshness:** confuses two
+  different provenance boundaries.
+
+## 11 — Open question
+
+When the export layer can expose a durable Apple Photos revision, should Photo
+Select offer a strict mode that refuses to begin a paid model run unless both
+index freshness and source freshness are proven?

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "evals:adaptive-parallelism": "node scripts/eval-adaptive-parallelism.mjs",
     "evals:filename-recovery": "vitest run tests/orchestratorSafety.test.js",
     "evals:stop-rule": "vitest run tests/evaluateLevelOutcome.test.js tests/orchestrator.test.js tests/cliTargetLevelSize.test.js",
+    "evals:people-index": "vitest run tests/peoplePrefetch.test.js tests/cliPeopleIndex.test.js tests/integration/prompt-curators.int.test.js tests/orchestrator.test.js",
     "undici:smoke": "node scripts/undici-smoke.mjs",
     "debug:batch": "node scripts/debug-batch.mjs"
   },

--- a/src/chatClient.js
+++ b/src/chatClient.js
@@ -19,6 +19,7 @@ import { getSurrogateImage } from "./imagePreprocessor.js";
 import { drain } from "./net.js";
 import { SimpleSemaphore } from "./lib/semaphore.js";
 import { buildCacheableResponsesPrompt } from "./core/promptCaching.js";
+import { createPeoplePrefetcher } from "./peoplePrefetch.js";
 
 function numEnv(name, fallback) {
   const v = process.env[name];
@@ -96,6 +97,15 @@ if (!USE_UNDICI && !isPeopleLookupDisabled()) {
 }
 const peopleSem = new SimpleSemaphore(PEOPLE_CONCURRENCY);
 const peopleCache = new Map();
+const peoplePrefetcher = createPeoplePrefetcher({
+  apiBase: PEOPLE_API_BASE,
+  isDisabled: isPeopleLookupDisabled,
+  commitEntries(entries) {
+    for (const [filename, people] of entries) {
+      peopleCache.set(filename, people);
+    }
+  },
+});
 
 const BUMP_TOKENS = numEnv("PHOTO_SELECT_BUMP_TOKENS", 4000);
 
@@ -233,6 +243,10 @@ export async function getPeople(filename) {
     peopleCache.set(filename, []);
     return [];
   }
+}
+
+export async function prefetchPeople(files, { force = false } = {}) {
+  return peoplePrefetcher.prefetch(files, { force });
 }
 
 /** Return any people who appear in more than one file */

--- a/src/index.js
+++ b/src/index.js
@@ -131,6 +131,11 @@ program
     "Disable photo-filter API lookups for this job",
     disablePhotoFilterDefault
   )
+  .option(
+    "--refresh-people-index",
+    "Force one verified rebuild of Photo Filter's people index",
+    parseEnvFlag(process.env.PHOTO_SELECT_REFRESH_PEOPLE_INDEX, false)
+  )
   .parse(process.argv);
 
 let {
@@ -159,6 +164,7 @@ let {
   targetLevelSize,
   adaptiveWorkers,
   adaptiveMinWorkers,
+  refreshPeopleIndex,
 } = program.opts();
 
 if (program.getOptionValueSource && program.getOptionValueSource('parallel')) {
@@ -297,6 +303,7 @@ process.env.PHOTO_SELECT_USER_EFFORT = finalReasoningEffort;
       reasoningEffort: finalReasoningEffort,
       retryNeedsReview,
       targetLevelSize,
+      refreshPeopleIndex,
     });
     console.log("🎉  Finished triaging.");
   } catch (err) {

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -6,7 +6,7 @@ import { batchStore } from "./batchContext.js";
 import crypto from "node:crypto";
 import { ensureArchiveLevel } from "./archive/ensureArchiveLevel.js";
 import { listImages, pickRandom, moveFiles } from "./imageSelector.js";
-import { parseReply, getPeople } from "./chatClient.js";
+import { parseReply, getPeople, prefetchPeople } from "./chatClient.js";
 import { buildPrompt } from "./templates.js";
 import FieldNotesWriter from "./fieldNotesWriter.js";
 import { MultiBar, Presets } from "cli-progress";
@@ -497,6 +497,7 @@ export async function resolveResumeLevel(startDir) {
  * @param {number} [options.targetLevelSize] Continue until a completed level has at most this many photos
  * @param {string[]} [options.curators=[]]   Names inserted into the prompt
  * @param {string} [options.contextPath]     Optional additional context file
+ * @param {boolean} [options.refreshPeopleIndex=false] Force one derived people-index refresh
 * @param {boolean} [options.fieldNotes=false] Enable field notes workflow
 * @param {number} [options.depth=0]         Internal recursion depth (for logging)
 */
@@ -523,6 +524,7 @@ export async function triageDirectory(options) {
     retryNeedsReview = envBool("PHOTO_SELECT_RETRY_NEEDS_REVIEW", false),
     allowDescendWithNeedsReview = envBool("PHOTO_SELECT_ALLOW_DESCEND_WITH_NEEDS_REVIEW", false),
     targetLevelSize,
+    refreshPeopleIndex = false,
     _cascadeLevel = false,
   } = options;
   if (!provider) {
@@ -680,6 +682,20 @@ export async function triageDirectory(options) {
       await writeFile(listPath, archiveResult.failed.join("\n"), "utf8");
       console.warn(
         `${indent}⚠️  ${archiveResult.failed.length} file(s) failed to archive; see ${listPath}`
+      );
+    }
+
+    const peopleStart = Date.now();
+    const peopleResult = await prefetchPeople(images, {
+      force: refreshPeopleIndex,
+    });
+    if (verbose && peopleResult.mode === "bulk") {
+      console.log(
+        `${indent}people-index: status=${peopleResult.indexStatus} corpus=${peopleResult.corpusSha256.slice(0, 12)} sources=${peopleResult.sourceCount} names=${peopleResult.names} elapsed=${((Date.now() - peopleStart) / 1000).toFixed(1)}s source_freshness=${peopleResult.sourceFreshness}`,
+      );
+    } else if (verbose && peopleResult.mode === "legacy-fallback") {
+      console.warn(
+        `${indent}people-index: mode=legacy-fallback reason=${peopleResult.reason ?? "unsupported"}`,
       );
     }
 

--- a/src/peoplePrefetch.js
+++ b/src/peoplePrefetch.js
@@ -1,0 +1,194 @@
+import path from "node:path";
+import { sanitizePeople } from "./lib/people.js";
+
+const MAX_FILENAMES = 500;
+const HASH_PATTERN = /^[a-f0-9]{64}$/;
+
+function peopleError(code, message, status) {
+  const error = new Error(message);
+  error.code = code;
+  if (status) error.status = status;
+  return error;
+}
+
+function chunksOf(items, size = MAX_FILENAMES) {
+  const chunks = [];
+  for (let offset = 0; offset < items.length; offset += size) {
+    chunks.push(items.slice(offset, offset + size));
+  }
+  return chunks;
+}
+
+function validatePayload(payload, requested, expectedCorpusSha256) {
+  const corpusSha256 = payload?.meta?.corpusSha256;
+  if (!HASH_PATTERN.test(corpusSha256 ?? "")) {
+    throw peopleError(
+      "PEOPLE_INDEX_INVALID_RESPONSE",
+      "Photo Filter returned no valid people-index corpus identity",
+    );
+  }
+  if (expectedCorpusSha256 && corpusSha256 !== expectedCorpusSha256) {
+    throw peopleError(
+      "PEOPLE_CORPUS_MISMATCH",
+      "Photo Filter returned people metadata from a different corpus",
+    );
+  }
+  if (!Array.isArray(payload?.data) || payload.data.length !== requested.length) {
+    throw peopleError(
+      "PEOPLE_INDEX_INVALID_RESPONSE",
+      "Photo Filter returned an incomplete bulk people response",
+    );
+  }
+  const byName = new Map();
+  for (const item of payload.data) {
+    if (!item || typeof item.filename !== "string" || byName.has(item.filename)) {
+      throw peopleError(
+        "PEOPLE_INDEX_INVALID_RESPONSE",
+        "Photo Filter returned duplicate or invalid bulk people entries",
+      );
+    }
+    byName.set(item.filename, sanitizePeople(item.people ?? []));
+  }
+  if (requested.some((filename) => !byName.has(filename))) {
+    throw peopleError(
+      "PEOPLE_INDEX_INVALID_RESPONSE",
+      "Photo Filter omitted a requested filename from the bulk people response",
+    );
+  }
+  return { corpusSha256, byName, meta: payload.meta };
+}
+
+export function createPeoplePrefetcher({
+  fetchImpl = (...args) => globalThis.fetch(...args),
+  apiBase,
+  commitEntries,
+  isDisabled = () => false,
+} = {}) {
+  let corpusSha256 = null;
+  let bulkUnavailable = false;
+  let forceConsumed = false;
+
+  async function requestChunk(filenames, body) {
+    let response;
+    try {
+      response = await fetchImpl(
+        `${apiBase}/api/photos/by-filenames/persons`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ ...body, filenames }),
+        },
+      );
+    } catch (error) {
+      return {
+        fallback: true,
+        permanent: false,
+        reason: error?.code ?? "network",
+      };
+    }
+    let payload = null;
+    try {
+      payload = await response.json();
+    } catch {
+      /* validated below */
+    }
+    if (response.status === 404 || response.status === 405) {
+      return {
+        fallback: true,
+        permanent: true,
+        reason: `http-${response.status}`,
+      };
+    }
+    if (!response.ok) {
+      const code = payload?.errors?.[0]?.code ?? "PEOPLE_INDEX_HTTP_ERROR";
+      throw peopleError(
+        code,
+        payload?.errors?.[0]?.detail ?? `Photo Filter HTTP ${response.status}`,
+        response.status,
+      );
+    }
+    return { payload };
+  }
+
+  async function run(filenames, { force = false } = {}) {
+    const mode =
+      force && !forceConsumed
+        ? "force"
+        : corpusSha256
+          ? "snapshot"
+          : "verify";
+    let expected = mode === "snapshot" ? corpusSha256 : null;
+    const staged = new Map();
+    let lastMeta = null;
+    const chunks = chunksOf(filenames);
+
+    for (let index = 0; index < chunks.length; index += 1) {
+      const refresh = index === 0 ? mode : "snapshot";
+      const request = await requestChunk(chunks[index], {
+        refresh,
+        ...(expected ? { expectedCorpusSha256: expected } : {}),
+      });
+      if (request.fallback) return request;
+      const validated = validatePayload(
+        request.payload,
+        chunks[index],
+        expected,
+      );
+      expected = validated.corpusSha256;
+      lastMeta = validated.meta;
+      for (const entry of validated.byName) staged.set(...entry);
+    }
+
+    commitEntries(staged);
+    corpusSha256 = expected;
+    if (mode === "force") forceConsumed = true;
+    return {
+      mode: "bulk",
+      names: filenames.length,
+      chunks: chunks.length,
+      corpusSha256,
+      sourceCount: lastMeta?.sourceCount ?? 0,
+      sourceFreshness: lastMeta?.sourceFreshness ?? "unknown",
+      indexStatus: lastMeta?.indexStatus ?? "unknown",
+    };
+  }
+
+  return {
+    async prefetch(files, options = {}) {
+      if (isDisabled()) return { mode: "disabled", names: 0, chunks: 0 };
+      const filenames = [
+        ...new Set(files.map((file) => path.basename(file))),
+      ];
+      if (filenames.length === 0) {
+        return { mode: "empty", names: 0, chunks: 0 };
+      }
+      if (bulkUnavailable) {
+        return { mode: "legacy-fallback", names: filenames.length, chunks: 0 };
+      }
+      try {
+        const result = await run(filenames, options);
+        if (result.fallback) {
+          bulkUnavailable = result.permanent;
+          return {
+            mode: "legacy-fallback",
+            names: filenames.length,
+            chunks: 0,
+            reason: result.reason,
+          };
+        }
+        return result;
+      } catch (error) {
+        if (
+          error?.status === 409 &&
+          ["PEOPLE_INDEX_UNAVAILABLE", "PEOPLE_CORPUS_MISMATCH"].includes(
+            error?.code,
+          )
+        ) {
+          corpusSha256 = null;
+          return run(filenames, options);
+        }
+        throw error;
+      }
+    },
+  };
+}

--- a/tests/cliPeopleIndex.test.js
+++ b/tests/cliPeopleIndex.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+describe("--refresh-people-index", () => {
+  it("advertises an explicit derived-metadata refresh without changing defaults", async () => {
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      ["src/index.js", "--help"],
+      { cwd: process.cwd() },
+    );
+
+    expect(stdout).toContain("--refresh-people-index");
+    expect(stdout).toMatch(/force one verified rebuild[\s\S]*people index/i);
+  });
+});

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -13,10 +13,11 @@ vi.mock("../src/chatClient.js", async () => {
     ...actual,
     chatCompletion: vi.fn(),
     getPeople: vi.fn().mockResolvedValue([]),
+    prefetchPeople: vi.fn().mockResolvedValue({ mode: "bulk", names: 0 }),
   };
 });
 
-import { chatCompletion, getPeople } from "../src/chatClient.js";
+import { chatCompletion, getPeople, prefetchPeople } from "../src/chatClient.js";
 import { triageDirectory } from "../src/orchestrator.js";
 
 let tmpDir;
@@ -36,6 +37,23 @@ afterEach(async () => {
 });
 
 describe("triageDirectory", () => {
+  it("prefetches level metadata before the first paid request", async () => {
+    chatCompletion.mockResolvedValueOnce(
+      JSON.stringify({ keep: ["1.jpg"], aside: ["2.jpg"] })
+    );
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: false,
+    });
+
+    expect(prefetchPeople).toHaveBeenCalledTimes(1);
+    expect(prefetchPeople.mock.invocationCallOrder[0]).toBeLessThan(
+      chatCompletion.mock.invocationCallOrder[0]
+    );
+  });
+
   it("moves files into keep and aside", async () => {
     chatCompletion.mockResolvedValueOnce(
       JSON.stringify({ keep: ["1.jpg"], aside: ["2.jpg"] })

--- a/tests/peoplePrefetch.test.js
+++ b/tests/peoplePrefetch.test.js
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi } from "vitest";
+import { finalizeCurators } from "../src/core/finalizeCurators.js";
+import { createPeoplePrefetcher } from "../src/peoplePrefetch.js";
+
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
+
+function jsonResponse(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return body;
+    },
+  };
+}
+
+function successFor(body, corpusSha256 = HASH_A) {
+  return jsonResponse({
+    data: body.filenames.map((filename) => ({
+      filename,
+      resolvedFilename: filename,
+      status: "exact",
+      people: filename.startsWith("shared-") ? ["Alice"] : [filename],
+    })),
+    meta: {
+      schemaVersion: 1,
+      corpusSha256,
+      sourceCount: 2,
+      indexStatus: body.refresh === "snapshot" ? "snapshot" : "rebuilt",
+      sourceFreshness: "unknown",
+    },
+  });
+}
+
+describe("people metadata bulk prefetch", () => {
+  it("chunks 1,001 names and pins every later chunk to one corpus", async () => {
+    const requests = [];
+    const cache = new Map();
+    const fetchImpl = vi.fn(async (_url, options) => {
+      const body = JSON.parse(options.body);
+      requests.push(body);
+      return successFor(body);
+    });
+    const prefetcher = createPeoplePrefetcher({
+      fetchImpl,
+      apiBase: "http://photo-filter.test",
+      commitEntries(entries) {
+        for (const [filename, people] of entries) cache.set(filename, people);
+      },
+    });
+    const filenames = Array.from({ length: 1001 }, (_, i) => `P${i}.jpg`);
+
+    const result = await prefetcher.prefetch(filenames);
+
+    expect(requests.map((body) => body.filenames.length)).toEqual([500, 500, 1]);
+    expect(requests[0]).toMatchObject({ refresh: "verify" });
+    expect(requests.slice(1)).toEqual(
+      requests.slice(1).map((body) => ({
+        ...body,
+        refresh: "snapshot",
+        expectedCorpusSha256: HASH_A,
+      })),
+    );
+    expect(cache).toHaveLength(1001);
+    expect(result).toMatchObject({
+      mode: "bulk",
+      names: 1001,
+      chunks: 3,
+      corpusSha256: HASH_A,
+      sourceFreshness: "unknown",
+    });
+
+    await prefetcher.prefetch(["P0.jpg"]);
+    expect(requests[3]).toMatchObject({
+      refresh: "snapshot",
+      expectedCorpusSha256: HASH_A,
+    });
+  });
+
+  it("commits no partial cache when chunk corpus identities differ", async () => {
+    const commitEntries = vi.fn();
+    let request = 0;
+    const prefetcher = createPeoplePrefetcher({
+      fetchImpl: vi.fn(async (_url, options) => {
+        const body = JSON.parse(options.body);
+        request += 1;
+        return successFor(body, request === 1 ? HASH_A : HASH_B);
+      }),
+      apiBase: "http://photo-filter.test",
+      commitEntries,
+    });
+    const filenames = Array.from({ length: 501 }, (_, i) => `P${i}.jpg`);
+
+    await expect(prefetcher.prefetch(filenames)).rejects.toMatchObject({
+      code: "PEOPLE_CORPUS_MISMATCH",
+    });
+    expect(commitEntries).not.toHaveBeenCalled();
+  });
+
+  it("falls back lazily and remembers when the bulk capability is absent", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ errors: [{ detail: "Not Found" }] }, 404),
+    );
+    const commitEntries = vi.fn();
+    const prefetcher = createPeoplePrefetcher({
+      fetchImpl,
+      apiBase: "http://photo-filter.test",
+      commitEntries,
+    });
+
+    expect(await prefetcher.prefetch(["A.jpg"])).toMatchObject({
+      mode: "legacy-fallback",
+    });
+    expect(await prefetcher.prefetch(["B.jpg"])).toMatchObject({
+      mode: "legacy-fallback",
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(commitEntries).not.toHaveBeenCalled();
+  });
+
+  it("preserves the repeated-person curator rule with bulk results", async () => {
+    const cache = new Map();
+    const prefetcher = createPeoplePrefetcher({
+      fetchImpl: vi.fn(async (_url, options) =>
+        successFor(JSON.parse(options.body)),
+      ),
+      apiBase: "http://photo-filter.test",
+      commitEntries(entries) {
+        for (const [filename, people] of entries) cache.set(filename, people);
+      },
+    });
+
+    await prefetcher.prefetch(["shared-a.jpg", "shared-b.jpg", "solo.jpg"]);
+    const finalized = finalizeCurators(
+      ["Base Curator"],
+      [...cache].map(([file, people]) => ({ file, people })),
+    );
+
+    expect(finalized.finalCurators).toEqual(["Base Curator", "Alice"]);
+    expect(finalized.added).toEqual(["Alice"]);
+  });
+
+  it("recovers from a restarted server by verifying the full level again", async () => {
+    const requests = [];
+    const commitEntries = vi.fn();
+    let call = 0;
+    const prefetcher = createPeoplePrefetcher({
+      fetchImpl: vi.fn(async (_url, options) => {
+        const body = JSON.parse(options.body);
+        requests.push(body);
+        call += 1;
+        if (call === 2) {
+          return jsonResponse(
+            { errors: [{ code: "PEOPLE_INDEX_UNAVAILABLE", detail: "restart" }] },
+            409,
+          );
+        }
+        return successFor(body, call === 1 ? HASH_A : HASH_B);
+      }),
+      apiBase: "http://photo-filter.test",
+      commitEntries,
+    });
+
+    await prefetcher.prefetch(["A.jpg"]);
+    const recovered = await prefetcher.prefetch(["B.jpg"]);
+
+    expect(requests.map(({ refresh }) => refresh)).toEqual([
+      "verify",
+      "snapshot",
+      "verify",
+    ]);
+    expect(recovered.corpusSha256).toBe(HASH_B);
+    expect(commitEntries).toHaveBeenCalledTimes(2);
+  });
+
+  it("forces one refresh, then reuses the pinned snapshot", async () => {
+    const requests = [];
+    const prefetcher = createPeoplePrefetcher({
+      fetchImpl: vi.fn(async (_url, options) => {
+        const body = JSON.parse(options.body);
+        requests.push(body);
+        return successFor(body);
+      }),
+      apiBase: "http://photo-filter.test",
+      commitEntries() {},
+    });
+
+    await prefetcher.prefetch(["A.jpg"], { force: true });
+    await prefetcher.prefetch(["B.jpg"], { force: true });
+    expect(requests.map(({ refresh }) => refresh)).toEqual(["force", "snapshot"]);
+  });
+
+  it("retries bulk discovery after a transient network fallback", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("reset"), { code: "ECONNRESET" }))
+      .mockImplementationOnce(async (_url, options) =>
+        successFor(JSON.parse(options.body)),
+      );
+    const prefetcher = createPeoplePrefetcher({
+      fetchImpl,
+      apiBase: "http://photo-filter.test",
+      commitEntries() {},
+    });
+
+    expect(await prefetcher.prefetch(["A.jpg"])).toMatchObject({
+      mode: "legacy-fallback",
+    });
+    expect(await prefetcher.prefetch(["B.jpg"])).toMatchObject({ mode: "bulk" });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Status

Implemented and fully verified. This remains a draft for contract-required
large-change review and coordination with the companion server PR.

## What changed

- add RFC 0010 and prefetch a complete recursive level before any paid provider
  request
- request at most 500 filenames per chunk, then pin every later chunk and level
  to one corpus SHA-256
- stage results and commit to the existing people cache only after every chunk
  validates
- recover atomically from a server restart or corpus mismatch; never commit a
  partial cache
- lazily retain the legacy per-filename path for servers returning 404/405
- add `--refresh-people-index` and `PHOTO_SELECT_REFRESH_PEOPLE_INDEX=1` for one
  explicit force rebuild
- report compact corpus, timing, source-count, freshness, and fallback status in
  verbose mode

## Preserved behavior

This does not alter prompt templates, context bytes, filename whitelists, model
or reasoning settings, batching, recursion, stop rules, resume behavior, output
schemas, or the rule that people appearing in multiple photos join the
curatorial team. The companion server deliberately corrects one metadata edge:
duplicate album memberships union known labels instead of allowing an
unlabeled first membership to erase them.

## Freshness boundary

The pinned hash proves that all chunks use one exact `photos.json` corpus. It
does not claim those exports match the current Apple Photos library; that source
freshness remains `unknown` until an upstream export revision exists.

## Verification

- `npm run evals:people-index`: **35/35 pass**
- `npm test -- --silent`: **27 files, 172/172 tests pass**
- production-shaped companion benchmark: 500 filenames resolve in **45.069 s**
  cold and **16 ms** pinned-warm across 12 sources / 82,555 entries
- no OpenAI request was made by the benchmark

## Companion

Photo Filter PR: https://github.com/openhouse/photo-filter/pull/68

## Change-set contract

This PR is 657 insertions / 3 deletions including the RFC and evals. It exceeds
the 500-line large-change threshold and therefore remains draft for explicit
review. No `--mechanical` assertion is made: this change is not mechanical.
