### PR TITLE
Automatically retry NEEDS_REVIEW levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ through to the script unchanged.
 | `--reasoning-effort` | `high` | Reasoning effort for GPT-5 models (`minimal`, `low`, `medium`, `high`, `auto`) |
 | `--no-recurse` | `false` | Process only the given directory without descending into `_keep` |
 | `--target-level-size` | *(unset)* | Continue recursive refinement until a completed `_level-*` contains at most this many source photos |
+| `--retry-needs-review` | `false` | Automatically retry held `NEEDS_REVIEW` files without restarting the CLI |
+| `--needs-review-retries` | `2` | Maximum automatic repair passes per `_level-*` when retries are enabled |
 | `--refresh-people-index` | `false` | Force one atomic rebuild of Photo Filter's people index before the level prefetch |
 | `--parallel` | *(deprecated)* | Maps to `--workers` and prints a warning |
 | `--field-notes` | `false` | Enable notebook updates via field-notes workflow |
@@ -224,6 +226,15 @@ remain to refine. The target is an upper bound, so a mixed level may reduce the 
 level from above 10 to below 10. Omitting the option preserves unanimous stopping
 exactly as before. The option changes recursive stopping only; it does not alter the
 curatorial prompt or decision schema.
+
+With `--retry-needs-review`, a safe batch failure remains marked and unmoved, then
+only the held files are submitted again automatically. The default allowance is two
+repair passes after the ordinary pass, independently for each `_level-*`. The used
+allowance is recorded under that level's `.batch` directory before submission, so a
+process restart cannot silently replenish it. Override the limit with
+`--needs-review-retries N` (or `PHOTO_SELECT_NEEDS_REVIEW_RETRIES`). If the allowance
+is exhausted, the level stays blocked for human review. Omitting
+`--retry-needs-review` preserves the existing fail-closed behavior.
 
 ### Concurrency: `--workers` (recommended)
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "evals:batch-prompt-cache": "node scripts/eval-batch-prompt-cache.mjs",
     "evals:adaptive-parallelism": "node scripts/eval-adaptive-parallelism.mjs",
     "evals:filename-recovery": "vitest run tests/orchestratorSafety.test.js",
+    "evals:needs-review-retries": "vitest run tests/planNeedsReviewRetry.test.js tests/orchestrator.test.js tests/cliNeedsReviewRetries.test.js",
     "evals:stop-rule": "vitest run tests/evaluateLevelOutcome.test.js tests/orchestrator.test.js tests/cliTargetLevelSize.test.js",
     "evals:people-index": "vitest run tests/peoplePrefetch.test.js tests/cliPeopleIndex.test.js tests/integration/prompt-curators.int.test.js tests/orchestrator.test.js",
     "undici:smoke": "node scripts/undici-smoke.mjs",

--- a/src/core/planNeedsReviewRetry.js
+++ b/src/core/planNeedsReviewRetry.js
@@ -1,0 +1,23 @@
+/**
+ * Decide whether a level may begin another automatic NEEDS_REVIEW repair pass.
+ * The caller persists the returned retry count before submitting any work.
+ */
+export function planNeedsReviewRetry({
+  enabled,
+  retriesUsed,
+  maxRetries,
+  heldCount,
+}) {
+  if (!enabled || heldCount === 0) {
+    return { shouldRetry: false, retriesUsed, reason: "not_requested" };
+  }
+  if (retriesUsed >= maxRetries) {
+    return { shouldRetry: false, retriesUsed, reason: "exhausted" };
+  }
+  return {
+    shouldRetry: true,
+    retriesUsed: retriesUsed + 1,
+    attempt: retriesUsed + 1,
+    reason: "available",
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -77,8 +77,16 @@ program
   )
   .option(
     "--retry-needs-review",
-    "Re-include files listed in NEEDS_REVIEW for an explicit retry",
+    "Automatically retry files listed in NEEDS_REVIEW",
     parseEnvFlag(process.env.PHOTO_SELECT_RETRY_NEEDS_REVIEW, false)
+  )
+  .option(
+    "--needs-review-retries <n>",
+    "Maximum automatic repair passes per level",
+    parsePositiveInteger,
+    process.env.PHOTO_SELECT_NEEDS_REVIEW_RETRIES
+      ? parsePositiveInteger(process.env.PHOTO_SELECT_NEEDS_REVIEW_RETRIES)
+      : 2
   )
   .option(
     "-P, --parallel <n>",
@@ -161,6 +169,7 @@ let {
   concurrency: concurrencyFlag,
   disablePhotoFilter,
   retryNeedsReview,
+  needsReviewRetries,
   targetLevelSize,
   adaptiveWorkers,
   adaptiveMinWorkers,
@@ -302,6 +311,7 @@ process.env.PHOTO_SELECT_USER_EFFORT = finalReasoningEffort;
       verbosity,
       reasoningEffort: finalReasoningEffort,
       retryNeedsReview,
+      needsReviewRetries,
       targetLevelSize,
       refreshPeopleIndex,
     });

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { readFile, writeFile, mkdir, stat } from "node:fs/promises";
+import { readFile, writeFile, mkdir, stat, rename, rm } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { batchStore } from "./batchContext.js";
@@ -14,6 +14,7 @@ import { sanitizePeople } from "./lib/people.js";
 import { finalizeCurators } from "./core/finalizeCurators.js";
 import { evaluateLevelOutcome } from "./core/evaluateLevelOutcome.js";
 import { reconcileDecisionFilenames } from "./core/reconcileDecisionFilenames.js";
+import { planNeedsReviewRetry } from "./core/planNeedsReviewRetry.js";
 
 const exec = promisify(execFile);
 
@@ -240,6 +241,50 @@ async function clearNeedsReviewEntries(dir, files) {
   await writeFile(marker, kept.length ? `${kept.join("\n")}\n` : "", "utf8");
 }
 
+const NEEDS_REVIEW_RETRY_SCHEMA = 1;
+
+async function readNeedsReviewRetryState(statePath) {
+  try {
+    const parsed = JSON.parse(await readFile(statePath, "utf8"));
+    if (
+      parsed?.schemaVersion !== NEEDS_REVIEW_RETRY_SCHEMA ||
+      !Number.isInteger(parsed?.retriesUsed) ||
+      parsed.retriesUsed < 0
+    ) {
+      throw new Error("invalid retry-state shape");
+    }
+    return parsed.retriesUsed;
+  } catch (err) {
+    if (err?.code === "ENOENT") return 0;
+    const wrapped = new Error(
+      `Cannot read NEEDS_REVIEW retry state at ${statePath}: ${err.message}`
+    );
+    wrapped.code = "INVALID_NEEDS_REVIEW_RETRY_STATE";
+    wrapped.cause = err;
+    throw wrapped;
+  }
+}
+
+async function writeNeedsReviewRetryState(statePath, { retriesUsed, maxRetries }) {
+  await mkdir(path.dirname(statePath), { recursive: true });
+  const temporaryPath = `${statePath}.${process.pid}.tmp`;
+  await writeFile(
+    temporaryPath,
+    JSON.stringify(
+      {
+        schemaVersion: NEEDS_REVIEW_RETRY_SCHEMA,
+        retriesUsed,
+        maxRetries,
+        updatedAt: new Date().toISOString(),
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+  await rename(temporaryPath, statePath);
+}
+
 export async function listLevelState(dir, { retryNeedsReview = envBool("PHOTO_SELECT_RETRY_NEEDS_REVIEW", false) } = {}) {
   const allImages = await listImages(dir);
   const needsReviewNames = await readNeedsReviewNames(dir);
@@ -332,6 +377,11 @@ export async function triageTree(options) {
   if (Number.isInteger(options.targetLevelSize)) {
     console.log(
       `🎯  target-level-size=${options.targetLevelSize}: complete levels until one contains at most this many photos.`
+    );
+  }
+  if (options.retryNeedsReview) {
+    console.log(
+      `🔁  needs-review-retries=${options.needsReviewRetries}: automatic repair passes per level.`
     );
   }
 
@@ -495,6 +545,8 @@ export async function resolveResumeLevel(startDir) {
  * @param {string} options.model        Model id for the provider
  * @param {boolean} [options.recurse=true]  Whether to descend into _keep folders
  * @param {number} [options.targetLevelSize] Continue until a completed level has at most this many photos
+ * @param {boolean} [options.retryNeedsReview=false] Automatically repair held files
+ * @param {number} [options.needsReviewRetries=2] Maximum repair passes per level
  * @param {string[]} [options.curators=[]]   Names inserted into the prompt
  * @param {string} [options.contextPath]     Optional additional context file
  * @param {boolean} [options.refreshPeopleIndex=false] Force one derived people-index refresh
@@ -522,11 +574,15 @@ export async function triageDirectory(options) {
     forceRebuild = false,
     stageConcurrency,
     retryNeedsReview = envBool("PHOTO_SELECT_RETRY_NEEDS_REVIEW", false),
+    needsReviewRetries = Number(process.env.PHOTO_SELECT_NEEDS_REVIEW_RETRIES || 2),
     allowDescendWithNeedsReview = envBool("PHOTO_SELECT_ALLOW_DESCEND_WITH_NEEDS_REVIEW", false),
     targetLevelSize,
     refreshPeopleIndex = false,
     _cascadeLevel = false,
   } = options;
+  if (!Number.isInteger(needsReviewRetries) || needsReviewRetries < 1) {
+    throw new Error("needsReviewRetries must be a positive integer");
+  }
   if (!provider) {
     const m = await import('./providers/openai.js');
     provider = new m.default();
@@ -536,6 +592,7 @@ export async function triageDirectory(options) {
       ...options,
       provider,
       retryNeedsReview,
+      needsReviewRetries,
       allowDescendWithNeedsReview,
     });
   }
@@ -653,17 +710,67 @@ export async function triageDirectory(options) {
 
   let completedBatches = 0;
   const retrySuppressedNames = new Set();
+  const needsReviewRetryStatePath = path.join(
+    levelDir,
+    ".batch",
+    "needs-review-retries.json"
+  );
+  let needsReviewRetriesUsed = retryNeedsReview
+    ? await readNeedsReviewRetryState(needsReviewRetryStatePath)
+    : 0;
 
   while (true) {
-    const state = await listLevelState(dir, { retryNeedsReview });
-    const images = state.eligibleImages.filter(
+    const state = await listLevelState(dir, { retryNeedsReview: false });
+    const activeImages = state.eligibleImages.filter(
       (file) => !retrySuppressedNames.has(path.basename(file))
     );
+    const retryableHeldImages = state.needsReviewImages.filter(
+      (file) => !retrySuppressedNames.has(path.basename(file))
+    );
+    const retryPlan = planNeedsReviewRetry({
+      enabled: retryNeedsReview,
+      retriesUsed: needsReviewRetriesUsed,
+      maxRetries: needsReviewRetries,
+      heldCount: retryableHeldImages.length,
+    });
+    let images = activeImages;
+    if (retryPlan.shouldRetry) {
+      needsReviewRetriesUsed = retryPlan.retriesUsed;
+      await writeNeedsReviewRetryState(needsReviewRetryStatePath, {
+        retriesUsed: needsReviewRetriesUsed,
+        maxRetries: needsReviewRetries,
+      });
+      images = [...activeImages, ...retryableHeldImages];
+      console.log(
+        `${indent}🔁  NEEDS_REVIEW repair pass ${retryPlan.attempt}/${needsReviewRetries}: ${retryableHeldImages.length} held image(s).`
+      );
+    }
     console.log(`${indent}📊  level ${depth + 1}: ${state.allImages.length} source image(s): ${images.length} eligible, ${state.needsReviewImages.length} NEEDS_REVIEW`);
     if (images.length === 0) {
       if (state.needsReviewImages.length > 0) {
+        const pendingRetry = planNeedsReviewRetry({
+          enabled: retryNeedsReview,
+          retriesUsed: needsReviewRetriesUsed,
+          maxRetries: needsReviewRetries,
+          heldCount: state.needsReviewImages.length,
+        });
+        if (pendingRetry.shouldRetry && retrySuppressedNames.size > 0) {
+          retrySuppressedNames.clear();
+          console.log(
+            `${indent}🔁  Preparing automatic NEEDS_REVIEW repair pass ${pendingRetry.attempt}/${needsReviewRetries}.`
+          );
+          continue;
+        }
+        if (retryNeedsReview && pendingRetry.reason === "exhausted") {
+          console.warn(
+            `${indent}⚠️  NEEDS_REVIEW automatic repair budget exhausted (${needsReviewRetriesUsed}/${needsReviewRetries}) for level ${depth + 1}.`
+          );
+        }
         console.warn(`${indent}⚠️  Level blocked: ${dir} has ${state.needsReviewImages.length} image file(s) needing review. Not descending.`);
         return { blocked: true, blockedCount: state.needsReviewImages.length };
+      }
+      if (retryNeedsReview) {
+        await rm(needsReviewRetryStatePath, { force: true });
       }
       console.log(`${indent}✅  Level settled: ${dir} has 0 active image files.`);
       break;
@@ -983,7 +1090,7 @@ export async function triageDirectory(options) {
                 if (keep.length + aside.length > 0) {
                   completedBatches++;
                   const elapsedSec = (Date.now() - levelStart) / 1000;
-                  const remainingNow = (await listLevelState(dir, { retryNeedsReview })).eligibleImages.length;
+                  const remainingNow = (await listLevelState(dir, { retryNeedsReview: false })).eligibleImages.length;
                   const remainingBatchesNow = Math.ceil(remainingNow / BATCH_SIZE);
                   const tps = completedBatches / elapsedSec;
                   const etaSec = tps > 0 ? Math.ceil(remainingBatchesNow / tps) : Infinity;
@@ -1049,7 +1156,7 @@ export async function triageDirectory(options) {
       } finally {
         multibar.stop();
       }
-      const nextState = await listLevelState(dir, { retryNeedsReview });
+      const nextState = await listLevelState(dir, { retryNeedsReview: false });
       const remaining = nextState.eligibleImages.filter(
         (file) => !retrySuppressedNames.has(path.basename(file))
       ).length;
@@ -1124,6 +1231,8 @@ export async function triageDirectory(options) {
         update,
         forceRebuild,
         stageConcurrency,
+        retryNeedsReview,
+        needsReviewRetries,
         targetLevelSize,
       });
     }

--- a/tests/cliNeedsReviewRetries.test.js
+++ b/tests/cliNeedsReviewRetries.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const execFileAsync = promisify(execFile);
+
+describe("--needs-review-retries", () => {
+  it("advertises a per-level automatic repair limit", async () => {
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      ["src/index.js", "--help"],
+      { cwd: process.cwd() }
+    );
+
+    expect(stdout).toContain("--needs-review-retries <n>");
+    expect(stdout).toMatch(/automatic repair passes per level/i);
+  });
+
+  it("rejects zero instead of silently changing it to one", async () => {
+    await expect(
+      execFileAsync(
+        process.execPath,
+        ["src/index.js", "--needs-review-retries", "0"],
+        { cwd: process.cwd() }
+      )
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining("must be a positive integer"),
+    });
+  });
+
+  it("forwards the configured limit to the recursive scheduler", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "ps-cli-review-retries-"));
+    try {
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        [
+          "src/index.js",
+          "--provider",
+          "ollama",
+          "--dir",
+          dir,
+          "--retry-needs-review",
+          "--needs-review-retries",
+          "2",
+        ],
+        {
+          cwd: process.cwd(),
+          env: { ...process.env, OPENAI_API_KEY: "test" },
+        }
+      );
+
+      expect(stdout).toContain("needs-review-retries=2");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -639,4 +639,106 @@ describe("cascade scheduler invariants", () => {
     const marker = await fs.readFile(path.join(tmpDir, "NEEDS_REVIEW"), "utf8");
     expect(marker.trim()).toBe("");
   });
+
+  it("automatically retries a failed level up to twice without a manual restart", async () => {
+    const incomplete = JSON.stringify({
+      object: "response",
+      status: "incomplete",
+      incomplete_details: { reason: "max_output_tokens" },
+      output: [],
+    });
+    chatCompletion
+      .mockResolvedValueOnce(incomplete)
+      .mockResolvedValueOnce(incomplete)
+      .mockResolvedValueOnce(
+        JSON.stringify({ keep: ["1.jpg"], aside: ["2.jpg"] })
+      );
+
+    const result = await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: false,
+      retryNeedsReview: true,
+      needsReviewRetries: 2,
+    });
+
+    expect(result).toEqual({ blocked: false, blockedCount: 0 });
+    expect(chatCompletion).toHaveBeenCalledTimes(3);
+    await expect(fs.stat(path.join(tmpDir, "_keep", "1.jpg"))).resolves.toBeTruthy();
+    await expect(fs.stat(path.join(tmpDir, "_aside", "2.jpg"))).resolves.toBeTruthy();
+    const marker = await fs.readFile(path.join(tmpDir, "NEEDS_REVIEW"), "utf8");
+    expect(marker.trim()).toBe("");
+  });
+
+  it("retries only the failed batch and never resubmits classified files", async () => {
+    for (let i = 3; i <= 11; i++) {
+      await fs.writeFile(path.join(tmpDir, `${i}.jpg`), String(i));
+    }
+    let failedNames;
+    let singletonCalls = 0;
+    const seen = [];
+    chatCompletion.mockImplementation(async ({ images }) => {
+      const names = images.map((file) => path.basename(file)).sort();
+      seen.push(names);
+      if (names.length === 1) {
+        singletonCalls += 1;
+        failedNames = names;
+        if (singletonCalls === 1) {
+          return JSON.stringify({
+            object: "response",
+            status: "incomplete",
+            incomplete_details: { reason: "max_output_tokens" },
+            output: [],
+          });
+        }
+      }
+      return JSON.stringify({ keep: [], aside: names });
+    });
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: false,
+      workers: 1,
+      retryNeedsReview: true,
+      needsReviewRetries: 2,
+    });
+
+    expect(seen).toHaveLength(3);
+    expect(seen[2]).toEqual(failedNames);
+    expect(seen[2]).toHaveLength(1);
+    expect(seen[0].some((name) => seen[2].includes(name))).toBe(false);
+  });
+
+  it("persists the two-retry allowance so a restart cannot reset it", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    chatCompletion.mockResolvedValue(
+      JSON.stringify({
+        object: "response",
+        status: "incomplete",
+        incomplete_details: { reason: "max_output_tokens" },
+        output: [],
+      })
+    );
+
+    const options = {
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: false,
+      retryNeedsReview: true,
+      needsReviewRetries: 2,
+    };
+    const first = await triageDirectory(options);
+    const second = await triageDirectory(options);
+
+    expect(first).toEqual({ blocked: true, blockedCount: 2 });
+    expect(second).toEqual({ blocked: true, blockedCount: 2 });
+    expect(chatCompletion).toHaveBeenCalledTimes(3);
+    expect(
+      warnSpy.mock.calls.some(([message]) => message.includes("exhausted (2/2)"))
+    ).toBe(true);
+  });
 });

--- a/tests/planNeedsReviewRetry.test.js
+++ b/tests/planNeedsReviewRetry.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { planNeedsReviewRetry } from "../src/core/planNeedsReviewRetry.js";
+
+describe("planNeedsReviewRetry", () => {
+  it("offers the next repair pass while the per-level budget remains", () => {
+    expect(
+      planNeedsReviewRetry({
+        enabled: true,
+        retriesUsed: 1,
+        maxRetries: 2,
+        heldCount: 10,
+      })
+    ).toEqual({
+      shouldRetry: true,
+      retriesUsed: 2,
+      attempt: 2,
+      reason: "available",
+    });
+  });
+
+  it("fails closed after the configured repair budget is exhausted", () => {
+    expect(
+      planNeedsReviewRetry({
+        enabled: true,
+        retriesUsed: 2,
+        maxRetries: 2,
+        heldCount: 10,
+      })
+    ).toEqual({
+      shouldRetry: false,
+      retriesUsed: 2,
+      reason: "exhausted",
+    });
+  });
+
+  it("does not alter the default hold behavior when repair is disabled", () => {
+    expect(
+      planNeedsReviewRetry({
+        enabled: false,
+        retriesUsed: 0,
+        maxRetries: 2,
+        heldCount: 10,
+      }).shouldRetry
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- make `--retry-needs-review` continue the current `_level-*` automatically instead of requiring a manual CLI restart
- allow two repair passes after the ordinary pass by default, configurable with `--needs-review-retries N`
- persist the consumed per-level allowance before submission so relaunching the process cannot reset it
- resubmit only files still held by `NEEDS_REVIEW`; already classified files are never included again
- preserve the existing fail-closed behavior when `--retry-needs-review` is omitted

This changes orchestration only. It does not alter prompts, context, curator enrichment, decision validation, stop rules, or model settings.

## Failure boundary

The strict filename and response checks remain unchanged. A safe batch failure is still marked and left unmoved. The scheduler may now perform the bounded repair passes itself. After the configured allowance is exhausted, the level remains blocked for human review and reports the exhausted count.

Retry state lives at `_level-NNN/.batch/needs-review-retries.json`, is written atomically before a repair submission, and is removed after the level settles.

## Evals

- `npm run evals:needs-review-retries`
- `npm run evals:filename-recovery`
- `npm run evals:stop-rule`
- `npm test -- --reporter=dot` — 29 files, 181 tests passed

The new evals cover CLI validation and forwarding, the two-pass ceiling, automatic recovery without restart, no resubmission of classified files, fail-closed exhaustion, and persistence across a process restart.

## Contract review

- change size: 368 insertions and 6 deletions; this triggers the >=300-line warning but remains below the >500-line mechanical-change threshold
- no prompt template or reply-schema changes
- no cache structure mutation
- no new or unaddressed TODOs
