### PR TITLE
Pause safely when OpenAI credits are exhausted

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,15 @@ through that API, so no extra flags are needed.
 7. On the first pass of each level a `_level-XXX` folder is created next to `_keep` and `_aside` containing a snapshot of the images originally present. If any files fail to copy after three retries (common on network drives), their paths are recorded in `failed-archives.txt` inside that folder.
 8. Stop when a directory has zero unclassified images.
 
+### Billing interruptions
+
+If OpenAI reports exhausted credits or a billing limit, Photo Select stops
+submitting new work, drains already-completed in-flight batches, and exits with
+status 75. Completed classifications remain in place; the current level records
+`.batch/billing-pause.json` plus a `billing_paused` ledger event. Add credits and
+rerun the same command to resume. Billing failures do not create `NEEDS_REVIEW`
+entries, and the pause marker is cleared after the next successful batch.
+
 ### Structured outputs (OpenAI)
 
 OpenAI requests now include a JSON schema so the API returns typed responses.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "evals:adaptive-parallelism": "node scripts/eval-adaptive-parallelism.mjs",
     "evals:filename-recovery": "vitest run tests/orchestratorSafety.test.js",
     "evals:needs-review-retries": "vitest run tests/planNeedsReviewRetry.test.js tests/orchestrator.test.js tests/cliNeedsReviewRetries.test.js",
+    "evals:billing-pause": "vitest run tests/orchestrator.test.js tests/openaiBatchProvider.test.js",
     "evals:stop-rule": "vitest run tests/evaluateLevelOutcome.test.js tests/orchestrator.test.js tests/cliTargetLevelSize.test.js",
     "evals:people-index": "vitest run tests/peoplePrefetch.test.js tests/cliPeopleIndex.test.js tests/integration/prompt-curators.int.test.js tests/orchestrator.test.js",
     "undici:smoke": "node scripts/undici-smoke.mjs",

--- a/src/core/providerErrors.js
+++ b/src/core/providerErrors.js
@@ -1,0 +1,59 @@
+const BILLING_ERROR_CODES = new Set([
+  "billing_hard_limit_reached",
+  "billing_limit",
+  "insufficient_quota",
+]);
+
+function text(value) {
+  return value == null ? "" : String(value);
+}
+
+export function providerErrorSummary(err) {
+  const nested = err?.error || err?.response?.data?.error || err?.body?.error || {};
+  return {
+    code: text(nested?.code || err?.code) || undefined,
+    type: text(nested?.type || err?.type) || undefined,
+    status: Number(err?.status || err?.statusCode || err?.response?.status) || undefined,
+    message: text(nested?.message || err?.message) || "Unknown provider error",
+  };
+}
+
+export function isBillingLimitError(err) {
+  if (!err) return false;
+  const summary = providerErrorSummary(err);
+  if (
+    BILLING_ERROR_CODES.has(summary.code?.toLowerCase()) ||
+    BILLING_ERROR_CODES.has(summary.type?.toLowerCase())
+  ) {
+    return true;
+  }
+  return [
+    summary.message,
+    err?.error?.message,
+    err?.cause?.message,
+    err?.response?.data?.error?.message,
+    err?.response?.data?.message,
+    err?.response?.error?.message,
+    err?.response?.message,
+    err?.body?.error?.message,
+    err?.body?.message,
+  ]
+    .flat()
+    .filter(Boolean)
+    .some((message) =>
+      /billing (hard )?limit|not have enough credits|add more credits|exceeded (?:your )?(?:current )?quota/i.test(
+        String(message)
+      )
+    );
+}
+
+export function createBillingLimitError(err, pause = {}) {
+  const wrapped = new Error(
+    "OpenAI API credits exhausted; run paused with completed work preserved."
+  );
+  wrapped.code = "BILLING_LIMIT";
+  wrapped.exitCode = 75;
+  wrapped.cause = err;
+  Object.assign(wrapped, pause);
+  return wrapped;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -319,12 +319,18 @@ process.env.PHOTO_SELECT_USER_EFFORT = finalReasoningEffort;
   } catch (err) {
     if (err?.code === "BILLING_LIMIT") {
       console.error(
-        "🛑  Billing limit reached. Please review your provider usage before retrying."
+        `⏸️  OpenAI API credits exhausted. Run paused${
+          Number.isInteger(err?.remainingImages)
+            ? ` with ${err.remainingImages} image(s) remaining`
+            : ""
+        }; completed work was preserved.`
       );
+      console.error("   Add credits, then rerun the same command to resume.");
       if (process.env.PHOTO_SELECT_VERBOSE === "1" && err?.cause) {
         console.error("  ↳ cause:", err.cause);
       }
-      process.exit(1);
+      process.exitCode = err?.exitCode || 75;
+      return;
     }
     console.error("❌  Error:", err);
     process.exit(1);

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { readFile, writeFile, mkdir, stat, rename, rm } from "node:fs/promises";
+import { appendFile, readFile, writeFile, mkdir, stat, rename, rm } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { batchStore } from "./batchContext.js";
@@ -15,6 +15,11 @@ import { finalizeCurators } from "./core/finalizeCurators.js";
 import { evaluateLevelOutcome } from "./core/evaluateLevelOutcome.js";
 import { reconcileDecisionFilenames } from "./core/reconcileDecisionFilenames.js";
 import { planNeedsReviewRetry } from "./core/planNeedsReviewRetry.js";
+import {
+  createBillingLimitError,
+  isBillingLimitError,
+  providerErrorSummary,
+} from "./core/providerErrors.js";
 
 const exec = promisify(execFile);
 
@@ -599,32 +604,6 @@ export async function triageDirectory(options) {
   const indent = "  ".repeat(depth);
   let notesWriter;
 
-  function isBillingLimitError(err) {
-    if (!err) return false;
-    const candidates = [
-      err?.message,
-      err?.error?.message,
-      err?.cause?.message,
-      err?.response?.data?.error?.message,
-      err?.response?.data?.message,
-      err?.response?.error?.message,
-      err?.response?.message,
-      err?.body?.error?.message,
-      err?.body?.message,
-    ]
-      .flat()
-      .filter(Boolean)
-      .map((msg) => String(msg));
-    return candidates.some((message) => /billing (hard )?limit/i.test(message));
-  }
-
-  function createBillingLimitError(err) {
-    const wrapped = new Error("Billing hard limit reached; aborting remaining batches.");
-    wrapped.code = "BILLING_LIMIT";
-    wrapped.cause = err;
-    return wrapped;
-  }
-
   function isPromptCacheSafetyError(err) {
     return err?.code === "PROMPT_CACHE_PROBE_MISS";
   }
@@ -685,6 +664,60 @@ export async function triageDirectory(options) {
 
   // Archive original images at this level
   const levelDir = path.join(dir, `_level-${String(depth + 1).padStart(3, '0')}`);
+  const billingPausePath = path.join(levelDir, ".batch", "billing-pause.json");
+  const billingLedgerPath = path.join(levelDir, ".batch", "jobs.ndjson");
+  const appendBillingLedger = async (entry) => {
+    await mkdir(path.dirname(billingLedgerPath), { recursive: true });
+    await appendFile(
+      billingLedgerPath,
+      `${JSON.stringify({ ts: new Date().toISOString(), ...entry })}\n`,
+      "utf8"
+    );
+  };
+  const writeBillingPause = async (err) => {
+    const remainingState = await listLevelState(dir, { retryNeedsReview: false });
+    const remainingImages = remainingState.eligibleImages.length;
+    const pause = {
+      schemaVersion: 1,
+      state: "paused",
+      reason: "billing_exhausted",
+      code: "BILLING_LIMIT",
+      pausedAt: new Date().toISOString(),
+      level: depth + 1,
+      source: dir,
+      remainingImages,
+      remainingBatches: Math.ceil(remainingImages / BATCH_SIZE),
+      cause: providerErrorSummary(err),
+    };
+    await mkdir(path.dirname(billingPausePath), { recursive: true });
+    const temporaryPath = `${billingPausePath}.${process.pid}.tmp`;
+    await writeFile(temporaryPath, JSON.stringify(pause, null, 2), "utf8");
+    await rename(temporaryPath, billingPausePath);
+    await appendBillingLedger({
+      event: "billing_paused",
+      code: pause.cause.code,
+      type: pause.cause.type,
+      status: pause.cause.status,
+      level: pause.level,
+      remaining_images: pause.remainingImages,
+      remaining_batches: pause.remainingBatches,
+    });
+    return pause;
+  };
+  const clearBillingPause = async () => {
+    try {
+      await stat(billingPausePath);
+    } catch (err) {
+      if (err?.code === "ENOENT") return false;
+      throw err;
+    }
+    await rm(billingPausePath, { force: true });
+    await appendBillingLedger({
+      event: "billing_resumed",
+      level: depth + 1,
+    });
+    return true;
+  };
   const runSession = async (payload) => {
     const handle = await provider.submit({
       levelDir,
@@ -1080,6 +1113,9 @@ export async function triageDirectory(options) {
                   moveFiles(aside, asideDir, notes),
                 ]);
                 await clearNeedsReviewEntries(dir, [...keep, ...aside]);
+                if (await clearBillingPause()) {
+                  log(`${indent}▶️  Billing pause cleared after successful progress.`);
+                }
                   if (unclassified.length && keep.length + aside.length > 0) {
                     queue.push(...unclassified);
                   }
@@ -1137,11 +1173,12 @@ export async function triageDirectory(options) {
                   }
                   throw err;
                 }
-                if (isBillingLimitError(err) && !abortProcessing) {
-                  abortProcessing = true;
-                  queue.length = 0;
-                  log(`${indent}🛑  Billing limit reached; stopping remaining batches.`);
-                  throw createBillingLimitError(err);
+                if (isBillingLimitError(err)) {
+                  if (!abortProcessing) {
+                    abortProcessing = true;
+                    queue.length = 0;
+                  }
+                  throw err;
                 }
               }
             });
@@ -1152,7 +1189,21 @@ export async function triageDirectory(options) {
           { length: Math.min(dynamicWorkers, Math.max(queue.length, 1)) },
           () => workerFn()
         );
-        await Promise.all(pool);
+        const outcomes = await Promise.allSettled(pool);
+        const failure = outcomes.find((outcome) => outcome.status === "rejected");
+        if (failure) {
+          if (!isBillingLimitError(failure.reason)) throw failure.reason;
+          const pause = await writeBillingPause(failure.reason);
+          log(
+            `${indent}⏸️  OpenAI API credits exhausted; paused level ${pause.level} with ${pause.remainingImages} image(s) remaining.`
+          );
+          log(`${indent}   Add credits, then rerun the same command to resume.`);
+          throw createBillingLimitError(failure.reason, {
+            pausePath: billingPausePath,
+            remainingImages: pause.remainingImages,
+            remainingBatches: pause.remainingBatches,
+          });
+        }
       } finally {
         multibar.stop();
       }

--- a/src/providers/openai-batch.js
+++ b/src/providers/openai-batch.js
@@ -22,6 +22,10 @@ import {
   AdaptiveConcurrencyController,
   readRateLimitSnapshot,
 } from '../core/adaptiveConcurrency.js';
+import {
+  isBillingLimitError,
+  providerErrorSummary,
+} from '../core/providerErrors.js';
 
 const DEFAULT_COMPLETION_WINDOW = process.env.PHOTO_SELECT_BATCH_COMPLETION_WINDOW || '24h';
 const DEFAULT_POLL_MS = Number(process.env.PHOTO_SELECT_BATCH_CHECK_INTERVAL_MS || 60000);
@@ -424,6 +428,19 @@ export default class OpenAIBatchProvider {
     if (!group) return;
     this.pendingSubmissionGroups.delete(groupKey);
     let items = [];
+    const completedHandles = new Map();
+    const resolved = new Set();
+    const recordHandle = (handle) => {
+      completedHandles.set(handle.customId, handle);
+      return handle;
+    };
+    const resolveHandle = (handle) => {
+      const item = items.find((candidate) => candidate.customId === handle.customId);
+      if (!item || resolved.has(item.customId)) return handle;
+      resolved.add(item.customId);
+      item.resolve(handle);
+      return handle;
+    };
     try {
       items = (await Promise.all(group.items.map(async (queued) => {
         try {
@@ -458,14 +475,18 @@ export default class OpenAIBatchProvider {
       if (!plan.seeded) {
         const handles = [];
         for (const partition of plan.batches) {
-          handles.push(...await this.#submitPreparedGroup(partition));
+          const submitted = await this.#submitPreparedGroup(partition);
+          submitted.forEach(recordHandle);
+          handles.push(...submitted);
         }
-        items.forEach((item, index) => item.resolve(handles[index]));
+        handles.forEach(resolveHandle);
         return;
       }
 
-      const seedHandles = await this.#submitPreparedFlexGroup(plan.batches[0], 'seed');
-      const probeHandles = await this.#submitPreparedFlexGroup(plan.batches[1], 'probe');
+      const seedHandles = await this.#submitPreparedFlexGroup(
+        plan.batches[0], 'seed', recordHandle);
+      const probeHandles = await this.#submitPreparedFlexGroup(
+        plan.batches[1], 'probe', recordHandle);
       if (!promptCacheHitFromUsage(probeHandles[0].completedResult.usage)) {
         const err = new Error(
           'OpenAI prompt-cache probe completed without reporting cached tokens; reader fanout was stopped'
@@ -479,9 +500,9 @@ export default class OpenAIBatchProvider {
       }
       const readerGroups = this.adaptiveController
         ? [await this.#submitPreparedFlexGroup(
-            plan.batches.slice(2).flat(), 'reader')]
+            plan.batches.slice(2).flat(), 'reader', recordHandle)]
         : await Promise.all(plan.batches.slice(2).map((partition) =>
-            this.#submitPreparedFlexGroup(partition, 'reader')));
+            this.#submitPreparedFlexGroup(partition, 'reader', recordHandle)));
       const missedReader = readerGroups.flat().find((handle) =>
         !promptCacheHitFromUsage(handle.completedResult?.usage));
       if (missedReader) {
@@ -504,13 +525,18 @@ export default class OpenAIBatchProvider {
         ...probeHandles,
         ...readerGroups.flat(),
       ];
-      items.forEach((item, index) => item.resolve(handles[index]));
+      handles.forEach(resolveHandle);
     } catch (err) {
-      items.forEach((item) => item.reject(err));
+      if (isBillingLimitError(err)) {
+        for (const handle of completedHandles.values()) resolveHandle(handle);
+      }
+      for (const item of items) {
+        if (!resolved.has(item.customId)) item.reject(err);
+      }
     }
   }
 
-  async #submitPreparedFlexGroup(items, cacheRole) {
+  async #submitPreparedFlexGroup(items, cacheRole, onCompleted) {
     const submitOne = async (item) => {
       const requestBody = {
         ...item.responsesRequest.body,
@@ -524,19 +550,32 @@ export default class OpenAIBatchProvider {
         body: requestBody,
       }) + '\n', 'utf8');
 
-      const submittedAt = new Date().toISOString();
-      const apiPromise = this.client.responses.create(requestBody, {
-        headers: { 'Idempotency-Key': crypto.randomUUID() },
-        timeout: FLEX_TIMEOUT_MS,
-      });
       let response;
       let responseHeaders;
-      if (typeof apiPromise?.withResponse === 'function') {
-        const raw = await apiPromise.withResponse();
-        response = raw.data;
-        responseHeaders = raw.response?.headers;
-      } else {
-        response = await apiPromise;
+      const submittedAt = new Date().toISOString();
+      try {
+        const apiPromise = this.client.responses.create(requestBody, {
+          headers: { 'Idempotency-Key': crypto.randomUUID() },
+          timeout: FLEX_TIMEOUT_MS,
+        });
+        if (typeof apiPromise?.withResponse === 'function') {
+          const raw = await apiPromise.withResponse();
+          response = raw.data;
+          responseHeaders = raw.response?.headers;
+        } else {
+          response = await apiPromise;
+        }
+      } catch (err) {
+        const summary = providerErrorSummary(err);
+        await appendLedger(item.dirs.base, {
+          custom_id: item.customId,
+          event: 'submit_error',
+          endpoint: DEFAULT_ENDPOINT,
+          service_tier: FLEX_SERVICE_TIER,
+          cache_role: cacheRole,
+          ...summary,
+        });
+        throw err;
       }
       const rateLimits = readRateLimitSnapshot(responseHeaders);
       const parsed = extractStructured(response, { customId: item.customId });
@@ -608,13 +647,11 @@ export default class OpenAIBatchProvider {
       };
     };
 
-    if (!this.adaptiveController || cacheRole !== 'reader') {
-      return Promise.all(items.map(submitOne));
-    }
-    const cacheKey = items[0]?.responsesRequest.body.prompt_cache_key;
-    return this.adaptiveController.run(items, async (item) => {
-      const handle = await submitOne(item);
-      if (!handle.adaptiveObservation.cacheHit) {
+    const accept = (handle) => {
+      if (
+        cacheRole === 'reader' &&
+        !handle.adaptiveObservation.cacheHit
+      ) {
         const err = new Error(
           'OpenAI Flex reader completed without reporting cached tokens; the cache cohort was stopped'
         );
@@ -623,7 +660,20 @@ export default class OpenAIBatchProvider {
         err.adaptiveObservation = handle.adaptiveObservation;
         throw err;
       }
-      return { value: handle, observation: handle.adaptiveObservation };
+      onCompleted?.(handle);
+      return handle;
+    };
+
+    if (!this.adaptiveController || cacheRole !== 'reader') {
+      return Promise.all(items.map(async (item) => accept(await submitOne(item))));
+    }
+    const cacheKey = items[0]?.responsesRequest.body.prompt_cache_key;
+    return this.adaptiveController.run(items, async (item) => {
+      const handle = await submitOne(item);
+      return {
+        value: accept(handle),
+        observation: handle.adaptiveObservation,
+      };
     }, { cacheKey });
   }
 
@@ -691,12 +741,14 @@ export default class OpenAIBatchProvider {
         break;
       } catch (err) {
         lastErr = err;
+        const summary = providerErrorSummary(err);
         await Promise.all(items.map((item) => appendLedger(item.dirs.base, {
           custom_id: item.customId,
           event: 'submit_error',
           endpoint,
-          message: err?.message,
+          ...summary,
         })));
+        if (isBillingLimitError(err)) throw err;
         if (!this.enableFallback || endpoint === FALLBACK_ENDPOINT) throw err;
       }
     }

--- a/tests/openaiBatchProvider.test.js
+++ b/tests/openaiBatchProvider.test.js
@@ -367,6 +367,72 @@ describe('OpenAIBatchProvider', () => {
       .toEqual(['seed', 'probe', 'reader', 'reader']);
   });
 
+  it('preserves completed cache-barrier work when a later reader exhausts credits', async () => {
+    client.responses.create.mockImplementation(async (body) => {
+      const index = client.responses.create.mock.calls.length - 1;
+      if (index === 2) {
+        const exhausted = new Error(
+          'Your account does not have enough credits to perform the requested operation.'
+        );
+        exhausted.status = 429;
+        exhausted.error = {
+          message: exhausted.message,
+          type: 'insufficient_quota',
+          code: 'insufficient_quota',
+        };
+        throw exhausted;
+      }
+      return {
+        id: `resp_${index + 1}`,
+        object: 'response',
+        status: 'completed',
+        service_tier: body.service_tier,
+        usage: index === 0 ? CACHE_WRITE_USAGE : CACHE_HIT_USAGE,
+        output: [{
+          type: 'message',
+          content: [{
+            type: 'output_json',
+            json: { minutes: [], decisions: [] },
+          }],
+        }],
+      };
+    });
+    const provider = new OpenAIBatchProvider({
+      client,
+      enableFallback: false,
+      helpers,
+      aggregationWindowMs: 10,
+    });
+    const stablePrefix = 'Large stable context. '.repeat(300);
+    const outcomes = await Promise.allSettled(['seed', 'probe', 'reader'].map((name) =>
+      provider.submit({
+        levelDir: tmpDir,
+        prompt: `${stablePrefix}Review ${name}.jpg.`,
+        promptCachePrefix: stablePrefix,
+        model: 'gpt-5.6-terra',
+      })
+    ));
+    expect(outcomes.map((outcome) => outcome.status)).toEqual([
+      'fulfilled',
+      'fulfilled',
+      'rejected',
+    ]);
+    expect(outcomes[2].reason).toMatchObject({
+      status: 429,
+      error: { code: 'insufficient_quota' },
+    });
+    const tickets = await fs.readdir(path.join(tmpDir, '.batch', 'tickets'));
+    expect(tickets).toHaveLength(2);
+    const ledger = await fs.readFile(path.join(tmpDir, '.batch', 'jobs.ndjson'), 'utf8');
+    const events = ledger.trim().split('\n').map((line) => JSON.parse(line));
+    expect(events.filter((event) => event.event === 'completed')).toHaveLength(2);
+    expect(events).toContainEqual(expect.objectContaining({
+      event: 'submit_error',
+      code: 'insufficient_quota',
+      status: 429,
+    }));
+  });
+
   it('uses a rolling adaptive reader window and persists sanitized rate-limit capacity', async () => {
     const usages = [CACHE_WRITE_USAGE, ...Array(7).fill(CACHE_HIT_USAGE)];
     const rateHeaders = usages.map(() => ({

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -477,13 +477,139 @@ describe("triageDirectory", () => {
           recurse: false,
           provider,
         })
-      ).rejects.toMatchObject({ code: "BILLING_LIMIT" });
+      ).rejects.toMatchObject({ code: "BILLING_LIMIT", exitCode: 75 });
     } finally {
       logSpy.mockRestore();
     }
     expect(provider.submit).toHaveBeenCalledTimes(1);
     await expect(fs.stat(path.join(tmpDir, "1.jpg"))).resolves.toBeTruthy();
     await expect(fs.stat(path.join(tmpDir, "2.jpg"))).resolves.toBeTruthy();
+  });
+
+  it("pauses modern exhausted-credit errors without repeating or marking photos for review", async () => {
+    const exhausted = new Error(
+      "Your account does not have enough credits to perform the requested operation. Please add more credits to your account and try again."
+    );
+    exhausted.status = 429;
+    exhausted.error = {
+      message: exhausted.message,
+      type: "insufficient_quota",
+      code: "insufficient_quota",
+    };
+    const unexpectedSecondAttempt = new Error(
+      "A second submission must never start after credit exhaustion"
+    );
+    unexpectedSecondAttempt.code = "PROMPT_CACHE_PROBE_MISS";
+    const provider = {
+      submit: vi.fn(async () => ({})),
+      collect: vi
+        .fn()
+        .mockRejectedValueOnce(exhausted)
+        .mockRejectedValueOnce(unexpectedSecondAttempt),
+    };
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await expect(
+        triageDirectory({
+          dir: tmpDir,
+          promptPath: promptFile,
+          model: "gpt-5.6-terra",
+          recurse: false,
+          provider,
+        })
+      ).rejects.toMatchObject({ code: "BILLING_LIMIT" });
+    } finally {
+      logSpy.mockRestore();
+    }
+
+    expect(provider.submit).toHaveBeenCalledTimes(1);
+    await expect(fs.stat(path.join(tmpDir, "NEEDS_REVIEW"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    const levelDir = path.join(tmpDir, "_level-001");
+    const pause = JSON.parse(
+      await fs.readFile(path.join(levelDir, ".batch", "billing-pause.json"), "utf8")
+    );
+    expect(pause).toMatchObject({
+      schemaVersion: 1,
+      state: "paused",
+      reason: "billing_exhausted",
+      code: "BILLING_LIMIT",
+      level: 1,
+      remainingImages: 2,
+      remainingBatches: 1,
+      cause: {
+        code: "insufficient_quota",
+        type: "insufficient_quota",
+        status: 429,
+      },
+    });
+    const ledger = await fs.readFile(
+      path.join(levelDir, ".batch", "jobs.ndjson"),
+      "utf8"
+    );
+    expect(ledger).toContain('"event":"billing_paused"');
+  });
+
+  it("drains successful in-flight batches before reporting a billing pause", async () => {
+    for (let i = 3; i <= 11; i++) await fs.writeFile(path.join(tmpDir, `${i}.jpg`), String(i));
+    const provider = {
+      submit: vi.fn(async ({ images }) => ({ images })),
+      collect: vi.fn(async ({ images }) => {
+        if (images.length === 1) {
+          const err = new Error("Your account does not have enough credits");
+          err.code = "insufficient_quota";
+          throw err;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        return {
+          raw: JSON.stringify({
+            keep: images.map((file) => path.basename(file)),
+            aside: [],
+          }),
+        };
+      }),
+    };
+    await expect(
+      triageDirectory({
+        dir: tmpDir,
+        promptPath: promptFile,
+        model: "gpt-5.6-terra",
+        recurse: false,
+        workers: 2,
+        provider,
+      })
+    ).rejects.toMatchObject({ code: "BILLING_LIMIT" });
+    expect(await fs.readdir(path.join(tmpDir, "_keep"))).toHaveLength(10);
+    const pause = JSON.parse(await fs.readFile(
+      path.join(tmpDir, "_level-001", ".batch", "billing-pause.json")));
+    expect(pause.remainingImages).toBe(1);
+  });
+
+  it("clears a billing-pause checkpoint after the next successful batch", async () => {
+    const levelDir = path.join(tmpDir, "_level-001");
+    const pausePath = path.join(levelDir, ".batch", "billing-pause.json");
+    await fs.mkdir(path.dirname(pausePath), { recursive: true });
+    await fs.writeFile(
+      pausePath,
+      JSON.stringify({
+        schemaVersion: 1,
+        state: "paused",
+        reason: "billing_exhausted",
+      })
+    );
+    chatCompletion.mockResolvedValueOnce(
+      JSON.stringify({ keep: ["1.jpg"], aside: ["2.jpg"] })
+    );
+
+    await triageDirectory({
+      dir: tmpDir,
+      promptPath: promptFile,
+      model: "test-model",
+      recurse: false,
+    });
+
+    await expect(fs.stat(pausePath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("stops processing when a prompt-cache probe misses", async () => {


### PR DESCRIPTION
## Summary

- recognize current OpenAI exhausted-credit responses (`insufficient_quota`, billing-limit codes, and their messages)
- stop new submissions immediately while draining already-completed in-flight work
- persist an atomic `_level-XXX/.batch/billing-pause.json` checkpoint and `billing_paused` ledger event
- preserve completed classifications, avoid false `NEEDS_REVIEW` holds, and clear the checkpoint after successful resumed progress
- exit cleanly with status 75 and tell the operator to add credits and rerun the same command

## Root cause

The orchestrator only recognized the older `Billing hard limit` message. Current structured exhausted-credit errors fell through the generic worker catch, so the level loop could submit again. In cache-barrier cohorts, a later reader failure also rejected already-completed seed and probe work, and the worker pool surfaced failures before successful siblings finished materializing results.

## Hill climb

The first regression cases failed against the prior behavior. The implementation was then tightened in two rounds:

1. partial cache-cohort settlement is allowed only for billing exhaustion; prompt-cache probe/reader safety failures still reject the entire cohort
2. the worker pool drains all in-flight workers before writing the final pause checkpoint, so its remaining-photo count reflects materialized successes

No OpenAI request was submitted during verification; production-shaped SDK error fixtures and cache-barrier sequences make the tests deterministic and spend-free.

## Verification

- `npm test -- --silent` — 29 files, 185 tests passed
- `npm run evals:billing-pause -- --silent` — 49 passed
- `npm run evals:batch-aggregation -- --silent` — 22 passed
- `npm run evals:adaptive-parallelism` — passed; balanced policy remains the winner
- `npm run evals:needs-review-retries -- --silent` — 37 passed
- `npm run evals:stop-rule -- --silent` — 43 passed
- `npm run evals:filename-recovery -- --silent` — 7 passed
- `npm run evals:people-index -- --silent` — 41 passed
- `git diff --check` and `node --check` for all changed runtime modules — passed

Contract metrics: billing fixtures preserve 100% JSON validity for completed responses; retry-recovery behavior is unchanged; TODOs introduced/addressed: 0/0. The change set is exactly 500 modified lines, within the contract boundary.

## Pull request state

- remote diff: 8 files, 435 additions, 65 deletions
- mergeability: `MERGEABLE`
- GitHub checks: none are configured/reported for this branch; local verification above is the available automated evidence
